### PR TITLE
Refactor migration assembly configuration to use assembly names dynamically for Assignment, Saga, OpenIddict, and Request modules

### DIFF
--- a/Modules/Assignment/Assignment/AssignmentModule.cs
+++ b/Modules/Assignment/Assignment/AssignmentModule.cs
@@ -25,7 +25,8 @@ public static class AssignmentModule
             options.AddInterceptors(sp.GetServices<ISaveChangesInterceptor>());
             options.UseSqlServer(configuration.GetConnectionString("Database"), sqlOptions =>
             {
-                sqlOptions.MigrationsAssembly("Assignment"); // Assignment assembly
+                sqlOptions.MigrationsAssembly(typeof(AssignmentDbContext).Assembly.GetName()
+                    .Name); // Assignment assembly
                 sqlOptions.MigrationsHistoryTable("__EFMigrationsHistory", "assignment");
             });
         });
@@ -35,7 +36,8 @@ public static class AssignmentModule
         {
             options.UseSqlServer(configuration.GetConnectionString("Database"), sqlOptions =>
             {
-                sqlOptions.MigrationsAssembly("Assignment"); // Separate saga assembly
+                sqlOptions.MigrationsAssembly(typeof(AppraisalSagaDbContext).Assembly.GetName()
+                    .Name); // Separate saga assembly
                 sqlOptions.MigrationsHistoryTable("__EFMigrationsHistory", "saga");
             });
         });

--- a/Modules/Auth/OAuth2OpenId/OpenIddictModule.cs
+++ b/Modules/Auth/OAuth2OpenId/OpenIddictModule.cs
@@ -29,7 +29,7 @@ public static class OpenIddictModule
         {
             options.UseSqlServer(configuration.GetConnectionString("Database"), sqlOptions =>
             {
-                sqlOptions.MigrationsAssembly("OAuth2OpenId");
+                sqlOptions.MigrationsAssembly(typeof(OpenIddictDbContext).Assembly.GetName().Name);
                 sqlOptions.MigrationsHistoryTable("__EFMigrationsHistory", "auth");
             });
             options.UseOpenIddict();

--- a/Modules/Request/Request/RequestModule.cs
+++ b/Modules/Request/Request/RequestModule.cs
@@ -2,9 +2,6 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Request.Configurations;
-using Request.Data.Repository;
-using Request.Requests.Services;
-using Shared.Data.Extensions;
 using Shared.Data.Interceptors;
 
 namespace Request;
@@ -30,7 +27,7 @@ public static class RequestModule
             options.AddInterceptors(sp.GetServices<ISaveChangesInterceptor>());
             options.UseSqlServer(configuration.GetConnectionString("Database"), sqlOptions =>
             {
-                sqlOptions.MigrationsAssembly("Request");
+                sqlOptions.MigrationsAssembly(typeof(RequestDbContext).Assembly.GetName().Name);
                 sqlOptions.MigrationsHistoryTable("__EFMigrationsHistory", "request");
             });
         });


### PR DESCRIPTION
This pull request refactors the configuration of Entity Framework Core (EF Core) migrations across multiple modules to dynamically determine the migration assembly using the `DbContext` type. Additionally, it removes unused imports in the `RequestModule` to clean up the codebase.

### EF Core Migrations Refactoring:
* [`Modules/Assignment/Assignment/AssignmentModule.cs`](diffhunk://#diff-cc4244f47402f23d646fa0575c78806e7a95186c4685e03e9b88ff6b71a9b12fL28-R29): Updated the migration assembly configuration for `AssignmentDbContext` and `AppraisalSagaDbContext` to dynamically use the assembly name of the respective `DbContext` type. [[1]](diffhunk://#diff-cc4244f47402f23d646fa0575c78806e7a95186c4685e03e9b88ff6b71a9b12fL28-R29) [[2]](diffhunk://#diff-cc4244f47402f23d646fa0575c78806e7a95186c4685e03e9b88ff6b71a9b12fL38-R40)
* [`Modules/Auth/OAuth2OpenId/OpenIddictModule.cs`](diffhunk://#diff-d9c39e521d62ff771fce2f4ae6416d00bdb3c7c8f8d140ee075c6243dbded6ddL32-R32): Updated the migration assembly configuration for `OpenIddictDbContext` to dynamically use the assembly name of the `DbContext` type.
* [`Modules/Request/Request/RequestModule.cs`](diffhunk://#diff-83552065de59a75005cafcdb0b3ba168a22cd0e9fb60b42744ecee09a2ae5d12L33-R30): Updated the migration assembly configuration for `RequestDbContext` to dynamically use the assembly name of the `DbContext` type.

### Code Cleanup:
* [`Modules/Request/Request/RequestModule.cs`](diffhunk://#diff-83552065de59a75005cafcdb0b3ba168a22cd0e9fb60b42744ecee09a2ae5d12L5-L7): Removed unused imports (`Request.Data.Repository`, `Request.Requests.Services`, `Shared.Data.Extensions`) to simplify and clean up the code.