### PR TITLE
fix: Update notification timestamps to use local time instead of UTC

### DIFF
--- a/Modules/Notification/Notification/Data/Seed/NotificationDataSeed.cs
+++ b/Modules/Notification/Notification/Data/Seed/NotificationDataSeed.cs
@@ -31,7 +31,7 @@ public class NotificationDataSeed : IDataSeeder<NotificationDbContext>
                 Title = "Welcome to Notification System",
                 Message = "Real-time notifications are now active for your collateral appraisal workflow.",
                 Type = NotificationType.SystemNotification,
-                CreatedAt = DateTime.UtcNow.AddHours(-1),
+                CreatedAt = DateTime.Now.AddHours(-1),
                 IsRead = false,
                 ActionUrl = "/dashboard",
                 Metadata = new Dictionary<string, object>
@@ -47,7 +47,7 @@ public class NotificationDataSeed : IDataSeeder<NotificationDbContext>
                 Title = "New Task Assigned: Admin Review",
                 Message = "You have been assigned a new task for Request #1 in the Admin stage.",
                 Type = NotificationType.TaskAssigned,
-                CreatedAt = DateTime.UtcNow.AddMinutes(-30),
+                CreatedAt = DateTime.Now.AddMinutes(-30),
                 IsRead = false,
                 ActionUrl = "/requests/1/tasks",
                 Metadata = new Dictionary<string, object>
@@ -64,9 +64,10 @@ public class NotificationDataSeed : IDataSeeder<NotificationDbContext>
                 Id = Guid.NewGuid(),
                 UserId = "testuser",
                 Title = "Task Completed: Appraisal Review",
-                Message = "Task AppraisalStaff has been approved by appraiser1. Request #2 moved from AppraisalStaff to AppraisalChecker.",
+                Message =
+                    "Task AppraisalStaff has been approved by appraiser1. Request #2 moved from AppraisalStaff to AppraisalChecker.",
                 Type = NotificationType.TaskCompleted,
-                CreatedAt = DateTime.UtcNow.AddMinutes(-15),
+                CreatedAt = DateTime.Now.AddMinutes(-15),
                 IsRead = true,
                 ActionUrl = "/requests/2",
                 Metadata = new Dictionary<string, object>

--- a/Modules/Notification/Notification/Notification/CommandHandlers/NotifyAssignmentHandler.cs
+++ b/Modules/Notification/Notification/Notification/CommandHandlers/NotifyAssignmentHandler.cs
@@ -16,7 +16,7 @@ public class NotifyAssignmentCommandHandler(INotificationService notificationSer
             context.Message.AssignedType,
             GetRequestIdFromContext(context),
             context.Message.TaskName.ToString(),
-            DateTime.UtcNow,
+            DateTime.Now,
             context.Message.NotifiedTo
         );
         await notificationService.SendTaskAssignedToOtherNotificationAsync(notification);
@@ -24,7 +24,7 @@ public class NotifyAssignmentCommandHandler(INotificationService notificationSer
 
     private static long GetRequestIdFromContext(ConsumeContext<NotifyAssignment> context)
     {
-        if (context.Headers.TryGetHeader("RequestId", out var requestIdObj) && 
+        if (context.Headers.TryGetHeader("RequestId", out var requestIdObj) &&
             long.TryParse(requestIdObj?.ToString(), out var requestId))
         {
             return requestId;

--- a/Modules/Notification/Notification/Notification/EventHandlers/TaskAssignedNotificationEventHandler.cs
+++ b/Modules/Notification/Notification/Notification/EventHandlers/TaskAssignedNotificationEventHandler.cs
@@ -21,7 +21,7 @@ public class TaskAssignedNotificationEventHandler : IConsumer<TaskAssigned>
     {
         var taskAssigned = context.Message;
 
-        _logger.LogInformation("Processing TaskAssigned notification for user {AssignedTo} and task {TaskName}", 
+        _logger.LogInformation("Processing TaskAssigned notification for user {AssignedTo} and task {TaskName}",
             taskAssigned.AssignedTo, taskAssigned.TaskName);
 
         try
@@ -34,7 +34,7 @@ public class TaskAssignedNotificationEventHandler : IConsumer<TaskAssigned>
                 // We need to get request ID from saga state or context
                 GetRequestIdFromContext(context),
                 taskAssigned.TaskName.ToString(), // Using TaskName as current state for now
-                DateTime.UtcNow
+                DateTime.Now
             );
 
             await _notificationService.SendTaskAssignedNotificationAsync(notification);
@@ -53,7 +53,7 @@ public class TaskAssignedNotificationEventHandler : IConsumer<TaskAssigned>
     private static long GetRequestIdFromContext(ConsumeContext<TaskAssigned> context)
     {
         // Try to get request ID from message headers or correlation ID
-        if (context.Headers.TryGetHeader("RequestId", out var requestIdObj) && 
+        if (context.Headers.TryGetHeader("RequestId", out var requestIdObj) &&
             long.TryParse(requestIdObj?.ToString(), out var requestId))
         {
             return requestId;

--- a/Modules/Notification/Notification/Notification/EventHandlers/TaskCompletedNotificationEventHandler.cs
+++ b/Modules/Notification/Notification/Notification/EventHandlers/TaskCompletedNotificationEventHandler.cs
@@ -21,7 +21,7 @@ public class TaskCompletedNotificationEventHandler : IConsumer<TaskCompleted>
     {
         var taskCompleted = context.Message;
 
-        _logger.LogInformation("Processing TaskCompleted notification for task {TaskName} with action {ActionTaken}", 
+        _logger.LogInformation("Processing TaskCompleted notification for task {TaskName} with action {ActionTaken}",
             taskCompleted.TaskName, taskCompleted.ActionTaken);
 
         try
@@ -34,17 +34,17 @@ public class TaskCompletedNotificationEventHandler : IConsumer<TaskCompleted>
                 GetRequestIdFromContext(context),
                 GetPreviousState(taskCompleted.TaskName.ToString()),
                 GetNextState(taskCompleted.TaskName.ToString(), taskCompleted.ActionTaken),
-                DateTime.UtcNow
+                DateTime.Now
             );
 
             await _notificationService.SendTaskCompletedNotificationAsync(notification);
-            
-            _logger.LogInformation("Successfully sent TaskCompleted notification for task {TaskName}", 
+
+            _logger.LogInformation("Successfully sent TaskCompleted notification for task {TaskName}",
                 taskCompleted.TaskName);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error processing TaskCompleted notification for task {TaskName}", 
+            _logger.LogError(ex, "Error processing TaskCompleted notification for task {TaskName}",
                 taskCompleted.TaskName);
             throw;
         }
@@ -52,7 +52,7 @@ public class TaskCompletedNotificationEventHandler : IConsumer<TaskCompleted>
 
     private static long GetRequestIdFromContext(ConsumeContext<TaskCompleted> context)
     {
-        if (context.Headers.TryGetHeader("RequestId", out var requestIdObj) && 
+        if (context.Headers.TryGetHeader("RequestId", out var requestIdObj) &&
             long.TryParse(requestIdObj?.ToString(), out var requestId))
         {
             return requestId;

--- a/Modules/Notification/Notification/Notification/EventHandlers/TransitionCompletedNotificationEventHandler.cs
+++ b/Modules/Notification/Notification/Notification/EventHandlers/TransitionCompletedNotificationEventHandler.cs
@@ -21,7 +21,8 @@ public class TransitionCompletedNotificationEventHandler : IConsumer<TransitionC
     {
         var transitionCompleted = context.Message;
 
-        _logger.LogInformation("Processing TransitionCompleted notification for request {RequestId} to state {CurrentState}", 
+        _logger.LogInformation(
+            "Processing TransitionCompleted notification for request {RequestId} to state {CurrentState}",
             transitionCompleted.RequestId, transitionCompleted.CurrentState);
 
         try
@@ -35,17 +36,17 @@ public class TransitionCompletedNotificationEventHandler : IConsumer<TransitionC
                 transitionCompleted.AssignedTo,
                 transitionCompleted.AssignedType,
                 workflowSteps,
-                DateTime.UtcNow
+                DateTime.Now
             );
 
             await _notificationService.SendWorkflowProgressNotificationAsync(notification);
-            
-            _logger.LogInformation("Successfully sent TransitionCompleted notification for request {RequestId}", 
+
+            _logger.LogInformation("Successfully sent TransitionCompleted notification for request {RequestId}",
                 transitionCompleted.RequestId);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error processing TransitionCompleted notification for request {RequestId}", 
+            _logger.LogError(ex, "Error processing TransitionCompleted notification for request {RequestId}",
                 transitionCompleted.RequestId);
             throw;
         }
@@ -57,19 +58,19 @@ public class TransitionCompletedNotificationEventHandler : IConsumer<TransitionC
         {
             "AwaitingAssignment",
             "Admin",
-            "AppraisalStaff", 
+            "AppraisalStaff",
             "AppraisalChecker",
             "AppraisalVerifier"
         };
 
         var currentIndex = Array.IndexOf(allStates, currentState);
-        
+
         return allStates.Select((state, index) => new WorkflowStepDto(
             state,
             IsCompleted: index < currentIndex,
             IsCurrent: index == currentIndex,
             AssignedTo: index == currentIndex ? "Current User" : null,
-            CompletedAt: index < currentIndex ? DateTime.UtcNow.AddHours(-index) : null
+            CompletedAt: index < currentIndex ? DateTime.Now.AddHours(-index) : null
         )).ToList();
     }
 }

--- a/Shared/Shared/Exceptions/Handler/CustomExceptionHandler.cs
+++ b/Shared/Shared/Exceptions/Handler/CustomExceptionHandler.cs
@@ -11,7 +11,7 @@ public class CustomExceptionHandler(ILogger<CustomExceptionHandler> logger) : IE
     public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception,
         CancellationToken cancellationToken)
     {
-        logger.LogError("An error occurred: {Message} {Time}", exception.Message, DateTime.UtcNow);
+        logger.LogError("An error occurred: {Message} {Time}", exception.Message, DateTime.Now);
 
         var (detail, title, statusCode) = exception switch
         {


### PR DESCRIPTION
This pull request updates how timestamps are generated throughout the notification and exception handling modules. The main change is switching from `DateTime.UtcNow` to `DateTime.Now` for all date and time assignments and logging. This affects notification creation, event handling, workflow step tracking, and error logging, ensuring that all timestamps now use local time instead of UTC.

**Timestamp handling updates:**

* All notification seed data in `NotificationDataSeed.cs` now uses `DateTime.Now` for the `CreatedAt` property instead of `DateTime.UtcNow`. [[1]](diffhunk://#diff-372870267cbc408a9a6d11575b275062fd763b2b96af72b136bbd99a27f9e897L34-R34) [[2]](diffhunk://#diff-372870267cbc408a9a6d11575b275062fd763b2b96af72b136bbd99a27f9e897L50-R50) [[3]](diffhunk://#diff-372870267cbc408a9a6d11575b275062fd763b2b96af72b136bbd99a27f9e897L67-R70)
* All event handler and command handler classes (`NotifyAssignmentHandler.cs`, `TaskAssignedNotificationEventHandler.cs`, `TaskCompletedNotificationEventHandler.cs`, `TransitionCompletedNotificationEventHandler.cs`) now use `DateTime.Now` when creating notifications, replacing `DateTime.UtcNow`. [[1]](diffhunk://#diff-cb99cf3cc751e8de7e1b6fe6913ebce362e9d2d0f1d45e96e0205e0af2cc51b9L19-R19) [[2]](diffhunk://#diff-0cffa0b806aeb9b98444077c9883aea1028c72ad38b317d2765d21ad795e8750L37-R37) [[3]](diffhunk://#diff-1337ddcbc02e99454e11a55db5d9558c305195902602bef93ebb1c7d88becb61L37-R37) [[4]](diffhunk://#diff-f8a2eec6124c3ecc6c23d8373bbd2f6b9f7c1f622dc156d2c4b161ceed2682e7L38-R39)
* Workflow step completion timestamps in `TransitionCompletedNotificationEventHandler.cs` now use `DateTime.Now.AddHours(-index)` instead of UTC.

**Logging improvements:**

* Exception logging in `CustomExceptionHandler.cs` now records errors using local time (`DateTime.Now`) rather than UTC.
* Log formatting in `TransitionCompletedNotificationEventHandler.cs` was adjusted for better readability.