### PR TITLE
Claude/refine local plan 1sa od

### DIFF
--- a/Database/Scripts/Views/Workflow/vw_SlaComplianceSummary.sql
+++ b/Database/Scripts/Views/Workflow/vw_SlaComplianceSummary.sql
@@ -18,7 +18,7 @@ SELECT
     -- User dimension
     ct.AssignedTo
 FROM workflow.CompletedTasks ct
-         LEFT JOIN appraisal.Appraisals a ON a.Id = ct.CorrelationId
+         LEFT JOIN appraisal.Appraisals a ON a.RequestId = ct.CorrelationId
          LEFT JOIN (
     SELECT
         AppraisalId,

--- a/Database/Scripts/Views/Workflow/vw_SlaTaskList.sql
+++ b/Database/Scripts/Views/Workflow/vw_SlaTaskList.sql
@@ -30,7 +30,7 @@ SELECT
     -- Loan type from workflow variables (stored as JSON)
     NULL AS LoanType -- Can be derived from workflow variables if needed
 FROM workflow.PendingTasks pt
-         LEFT JOIN appraisal.Appraisals a ON a.Id = pt.CorrelationId
+         LEFT JOIN appraisal.Appraisals a ON a.RequestId = pt.CorrelationId
          LEFT JOIN request.Requests r ON a.RequestId = r.Id
          LEFT JOIN workflow.WorkflowInstances wi
                    ON wi.CorrelationId = CAST(pt.CorrelationId AS nvarchar(450))

--- a/Database/Scripts/Views/Workflow/vw_SlaTaskList.sql
+++ b/Database/Scripts/Views/Workflow/vw_SlaTaskList.sql
@@ -31,7 +31,7 @@ SELECT
     NULL AS LoanType -- Can be derived from workflow variables if needed
 FROM workflow.PendingTasks pt
          LEFT JOIN appraisal.Appraisals a ON a.RequestId = pt.CorrelationId
-         LEFT JOIN request.Requests r ON a.RequestId = r.Id
+         LEFT JOIN request.Requests r ON r.Id = pt.CorrelationId
          LEFT JOIN workflow.WorkflowInstances wi
                    ON wi.CorrelationId = CAST(pt.CorrelationId AS nvarchar(450))
                        AND wi.Status = 0 -- Running

--- a/Database/Scripts/Views/Workflow/vw_TaskList.sql
+++ b/Database/Scripts/Views/Workflow/vw_TaskList.sql
@@ -31,7 +31,7 @@ SELECT a.Id,
        DATEDIFF(HOUR, pt.AssignedAt, GETUTCDATE())                                     AS ElapsedHours,
        CASE WHEN pt.DueAt IS NOT NULL THEN DATEDIFF(HOUR, GETUTCDATE(), pt.DueAt) END  AS RemainingHours
 FROM workflow.PendingTasks pt
-         JOIN appraisal.Appraisals a ON a.Id = pt.CorrelationId
+         JOIN appraisal.Appraisals a ON a.RequestId = pt.CorrelationId
          JOIN request.Requests r ON a.RequestId = r.Id
     CROSS APPLY (SELECT TOP 1 Name
                       FROM request.RequestCustomers

--- a/Database/Scripts/Views/Workflow/vw_TaskList.sql
+++ b/Database/Scripts/Views/Workflow/vw_TaskList.sql
@@ -31,12 +31,12 @@ SELECT a.Id,
        DATEDIFF(HOUR, pt.AssignedAt, GETUTCDATE())                                     AS ElapsedHours,
        CASE WHEN pt.DueAt IS NOT NULL THEN DATEDIFF(HOUR, GETUTCDATE(), pt.DueAt) END  AS RemainingHours
 FROM workflow.PendingTasks pt
-         JOIN appraisal.Appraisals a ON a.RequestId = pt.CorrelationId
-         JOIN request.Requests r ON a.RequestId = r.Id
-    CROSS APPLY (SELECT TOP 1 Name
+         LEFT JOIN appraisal.Appraisals a ON a.RequestId = pt.CorrelationId
+         LEFT JOIN request.Requests r ON r.Id = pt.CorrelationId
+         OUTER APPLY (SELECT TOP 1 Name
                       FROM request.RequestCustomers
                       WHERE RequestId = r.Id) C
-         CROSS APPLY (SELECT STRING_AGG(PropertyType, ',') AS PropertyType
+         OUTER APPLY (SELECT STRING_AGG(PropertyType, ',') AS PropertyType
                       FROM request.RequestProperties
                       WHERE RequestId = r.Id
                       GROUP BY RequestId) P

--- a/Modules/Appraisal/Appraisal/Application/EventHandlers/AppraisalCreationRequestedIntegrationEventHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/EventHandlers/AppraisalCreationRequestedIntegrationEventHandler.cs
@@ -6,20 +6,21 @@ using Shared.Messaging.Events;
 namespace Appraisal.Application.EventHandlers;
 
 /// <summary>
-/// Handles RequestSubmittedIntegrationEvent by creating an appraisal from the submitted request.
+/// Handles AppraisalCreationRequestedIntegrationEvent by creating an appraisal from the request payload.
+/// This event is published by the Workflow module when the table-driven condition matches.
 /// </summary>
-public class RequestSubmittedIntegrationEventHandler(
-    ILogger<RequestSubmittedIntegrationEventHandler> logger,
+public class AppraisalCreationRequestedIntegrationEventHandler(
+    ILogger<AppraisalCreationRequestedIntegrationEventHandler> logger,
     IAppraisalCreationService appraisalCreationService)
-    : IConsumer<RequestSubmittedIntegrationEvent>
+    : IConsumer<AppraisalCreationRequestedIntegrationEvent>
 {
-    public async Task Consume(ConsumeContext<RequestSubmittedIntegrationEvent> context)
+    public async Task Consume(ConsumeContext<AppraisalCreationRequestedIntegrationEvent> context)
     {
         var message = context.Message;
 
         logger.LogInformation(
             "Integration Event received: {IntegrationEvent} for RequestId: {RequestId} with {TitleCount} titles",
-            nameof(RequestSubmittedIntegrationEvent),
+            nameof(AppraisalCreationRequestedIntegrationEvent),
             message.RequestId,
             message.RequestTitles.Count);
 
@@ -44,17 +45,16 @@ public class RequestSubmittedIntegrationEventHandler(
                 context.CancellationToken);
 
             logger.LogInformation(
-                "Successfully processed RequestSubmittedIntegrationEvent. Created/Retrieved AppraisalId: {AppraisalId} for RequestId: {RequestId}",
+                "Successfully processed AppraisalCreationRequestedIntegrationEvent. Created/Retrieved AppraisalId: {AppraisalId} for RequestId: {RequestId}",
                 appraisalId,
                 message.RequestId);
         }
         catch (Exception ex)
         {
             logger.LogError(ex,
-                "Error processing RequestSubmittedIntegrationEvent for RequestId: {RequestId}",
+                "Error processing AppraisalCreationRequestedIntegrationEvent for RequestId: {RequestId}",
                 message.RequestId);
 
-            // Let exception propagate for MassTransit retry/error handling
             throw;
         }
     }

--- a/Modules/Workflow/Workflow/Data/Seed/ActivityProcessConfigurationSeeder.cs
+++ b/Modules/Workflow/Workflow/Data/Seed/ActivityProcessConfigurationSeeder.cs
@@ -60,6 +60,24 @@ public class ActivityProcessConfigurationSeeder(
                 1,
                 "system",
                 """{"targetStatus": "InProgress"}"""),
+
+            // __on_workflow_start__: trigger immediate appraisal creation for non-manual channels
+            ActivityProcessConfiguration.Create(
+                "__on_workflow_start__",
+                "Emit appraisal creation (non-manual)",
+                "EmitAppraisalCreationRequested",
+                1,
+                "system",
+                """{"condition": "channel != 'MANUAL'"}"""),
+
+            // appraisal-initiation-check: trigger deferred appraisal creation for manual channels
+            ActivityProcessConfiguration.Create(
+                "appraisal-initiation-check",
+                "Emit appraisal creation (manual)",
+                "EmitAppraisalCreationRequested",
+                1,
+                "system",
+                """{"condition": "channel == 'MANUAL'", "requireDecision": "P"}"""),
         };
 
         await context.ActivityProcessConfigurations.AddRangeAsync(configs);

--- a/Modules/Workflow/Workflow/DocumentFollowups/Application/Commands/RaiseDocumentFollowupCommandHandler.cs
+++ b/Modules/Workflow/Workflow/DocumentFollowups/Application/Commands/RaiseDocumentFollowupCommandHandler.cs
@@ -41,7 +41,7 @@ public class RaiseDocumentFollowupCommandHandler(
             ?? throw new InvalidOperationException(
                 $"Raising workflow instance {command.RaisingWorkflowInstanceId} not found");
 
-        // 2. Resolve the pending task to capture activityId + correlationId (= appraisalId)
+        // 2. Resolve the pending task to capture activityId + correlationId (= requestId)
         var pendingTask = await dbContext.PendingTasks
             .AsNoTracking()
             .FirstOrDefaultAsync(t => t.Id == command.RaisingPendingTaskId, cancellationToken)
@@ -58,8 +58,8 @@ public class RaiseDocumentFollowupCommandHandler(
             throw new InvalidOperationException(
                 "An open document followup already exists for this task. Resolve or cancel it first.");
 
-        var appraisalId = pendingTask.CorrelationId;
-        var requestId = ReadGuidFromVariables(parentInstance.Variables, "requestId");
+        var requestId = pendingTask.CorrelationId;
+        var appraisalId = ReadGuidFromVariables(parentInstance.Variables, "appraisalId");
 
         // 3. Resolve followup workflow definition up front so we fail fast before any writes
         var followupDefinition = await definitionRepository.GetLatestVersion(

--- a/Modules/Workflow/Workflow/DocumentFollowups/Application/Commands/RaiseDocumentFollowupCommandHandler.cs
+++ b/Modules/Workflow/Workflow/DocumentFollowups/Application/Commands/RaiseDocumentFollowupCommandHandler.cs
@@ -59,7 +59,10 @@ public class RaiseDocumentFollowupCommandHandler(
                 "An open document followup already exists for this task. Resolve or cancel it first.");
 
         var requestId = pendingTask.CorrelationId;
-        var appraisalId = ReadGuidFromVariables(parentInstance.Variables, "appraisalId");
+        var appraisalId = ReadGuidFromVariables(parentInstance.Variables, "appraisalId")
+            ?? throw new InvalidOperationException(
+                $"Cannot raise document followup for workflow {command.RaisingWorkflowInstanceId}: " +
+                "appraisalId is not set in workflow variables. Document followups require an existing appraisal.");
 
         // 3. Resolve followup workflow definition up front so we fail fast before any writes
         var followupDefinition = await definitionRepository.GetLatestVersion(

--- a/Modules/Workflow/Workflow/EventHandlers/AppraisalCreatedIntegrationEventConsumer.cs
+++ b/Modules/Workflow/Workflow/EventHandlers/AppraisalCreatedIntegrationEventConsumer.cs
@@ -40,6 +40,9 @@ public class AppraisalCreatedIntegrationEventConsumer(
                 logger.LogWarning(
                     "No workflow found for RequestId: {RequestId}. AppraisalId {AppraisalId} will not be linked.",
                     message.RequestId, message.AppraisalId);
+                // Mark processed so the inbox row doesn't remain 'Processing' forever.
+                // No workflow exists, so there's nothing to retry against.
+                await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, context.CancellationToken);
                 return;
             }
 

--- a/Modules/Workflow/Workflow/EventHandlers/AppraisalCreatedIntegrationEventConsumer.cs
+++ b/Modules/Workflow/Workflow/EventHandlers/AppraisalCreatedIntegrationEventConsumer.cs
@@ -2,19 +2,20 @@ using Shared.Messaging.Events;
 using Shared.Messaging.Filters;
 using Workflow.Data;
 using Workflow.Workflow.Repositories;
-using Workflow.Workflow.Services;
 
 namespace Workflow.EventHandlers;
 
+/// <summary>
+/// Handles AppraisalCreatedIntegrationEvent by recording the appraisalId
+/// in the workflow instance's Variables. The workflow was already started
+/// by RequestSubmittedIntegrationEventConsumer with correlationId = requestId.
+/// </summary>
 public class AppraisalCreatedIntegrationEventConsumer(
     ILogger<AppraisalCreatedIntegrationEventConsumer> logger,
-    IWorkflowDefinitionRepository workflowDefinitionRepository,
     IWorkflowInstanceRepository workflowInstanceRepository,
-    IWorkflowService workflowService,
+    IWorkflowUnitOfWork unitOfWork,
     InboxGuard<WorkflowDbContext> inboxGuard) : IConsumer<AppraisalCreatedIntegrationEvent>
 {
-    private const string WorkflowName = "Collateral Appraisal Workflow";
-
     public async Task Consume(ConsumeContext<AppraisalCreatedIntegrationEvent> context)
     {
         if (await inboxGuard.TryClaimAsync(context.MessageId, GetType().Name, context.CancellationToken))
@@ -30,65 +31,39 @@ public class AppraisalCreatedIntegrationEventConsumer(
 
         try
         {
-            // Idempotency guard: skip if workflow already exists for this appraisal
-            var existing = await workflowInstanceRepository.GetByCorrelationId(
-                message.AppraisalId.ToString(), context.CancellationToken);
-            if (existing is not null)
+            // Find workflow by correlationId = requestId
+            var instance = await workflowInstanceRepository.GetByCorrelationId(
+                message.RequestId.ToString(), context.CancellationToken);
+
+            if (instance is null)
             {
-                logger.LogInformation(
-                    "Workflow already exists for AppraisalId: {AppraisalId} (InstanceId: {InstanceId}), skipping",
-                    message.AppraisalId, existing.Id);
+                logger.LogWarning(
+                    "No workflow found for RequestId: {RequestId}. AppraisalId {AppraisalId} will not be linked.",
+                    message.RequestId, message.AppraisalId);
                 return;
             }
 
-            var definition = await workflowDefinitionRepository.GetLatestVersion(
-                WorkflowName, context.CancellationToken);
-
-            if (definition is null)
+            // Record appraisal details in workflow variables
+            instance.UpdateVariables(new Dictionary<string, object>
             {
-                logger.LogError(
-                    "Workflow definition '{WorkflowName}' not found. Cannot start workflow for AppraisalId: {AppraisalId}",
-                    WorkflowName, message.AppraisalId);
-                throw new InvalidOperationException(
-                    $"Workflow definition '{WorkflowName}' not found.");
-            }
-
-            var instanceName = $"Appraisal-{message.AppraisalNumber ?? message.AppraisalId.ToString()}";
-
-            var initialVariables = new Dictionary<string, object>
-            {
-                ["requestId"] = message.RequestId,
                 ["appraisalId"] = message.AppraisalId,
                 ["appraisalNumber"] = message.AppraisalNumber ?? string.Empty,
-                ["appraisalType"] = message.AppraisalType ?? "Initial",
-                ["isPma"] = message.IsPma,
-                ["facilityLimit"] = message.FacilityLimit ?? 0m,
-                ["priority"] = message.Priority ?? "normal",
-                ["hasAppraisalBook"] = message.HasAppraisalBook,
-                ["channel"] = message.Channel ?? string.Empty
-            };
+                ["appraisalType"] = message.AppraisalType ?? "Initial"
+            });
 
-            var instance = await workflowService.StartWorkflowAsync(
-                workflowDefinitionId: definition.Id,
-                instanceName: instanceName,
-                startedBy: message.CreatedBy ?? "system",
-                initialVariables: initialVariables,
-                correlationId: message.AppraisalId.ToString(),
-                cancellationToken: context.CancellationToken);
+            await unitOfWork.SaveChangesAsync(context.CancellationToken);
 
             logger.LogInformation(
-                "Successfully started workflow instance {WorkflowInstanceId} for AppraisalId: {AppraisalId}",
-                instance.Id, message.AppraisalId);
+                "Linked AppraisalId {AppraisalId} to workflow {WorkflowInstanceId} for RequestId: {RequestId}",
+                message.AppraisalId, instance.Id, message.RequestId);
 
             await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, context.CancellationToken);
         }
         catch (Exception ex)
         {
             logger.LogError(ex,
-                "Error starting workflow for AppraisalId: {AppraisalId}",
-                message.AppraisalId);
-
-            // Let exception propagate for MassTransit retry/error handling
+                "Error linking AppraisalId {AppraisalId} to workflow for RequestId: {RequestId}",
+                message.AppraisalId, message.RequestId);
             throw;
         }
     }

--- a/Modules/Workflow/Workflow/EventHandlers/RequestSubmittedIntegrationEventConsumer.cs
+++ b/Modules/Workflow/Workflow/EventHandlers/RequestSubmittedIntegrationEventConsumer.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+using Shared.Messaging.Events;
+using Shared.Messaging.Filters;
+using Workflow.Data;
+using Workflow.Workflow.Pipeline;
+using Workflow.Workflow.Repositories;
+using Workflow.Workflow.Services;
+
+namespace Workflow.EventHandlers;
+
+/// <summary>
+/// Handles RequestSubmittedIntegrationEvent by immediately starting a workflow
+/// and conditionally triggering appraisal creation based on table-driven configuration.
+/// CorrelationId = requestId (not appraisalId).
+/// </summary>
+public class RequestSubmittedIntegrationEventConsumer(
+    ILogger<RequestSubmittedIntegrationEventConsumer> logger,
+    IWorkflowDefinitionRepository workflowDefinitionRepository,
+    IWorkflowInstanceRepository workflowInstanceRepository,
+    IWorkflowService workflowService,
+    AppraisalCreationTriggerEvaluator triggerEvaluator,
+    InboxGuard<WorkflowDbContext> inboxGuard) : IConsumer<RequestSubmittedIntegrationEvent>
+{
+    private const string WorkflowName = "Collateral Appraisal Workflow";
+
+    public async Task Consume(ConsumeContext<RequestSubmittedIntegrationEvent> context)
+    {
+        if (await inboxGuard.TryClaimAsync(context.MessageId, GetType().Name, context.CancellationToken))
+            return;
+
+        var message = context.Message;
+
+        logger.LogInformation(
+            "Integration Event received: {IntegrationEvent} for RequestId: {RequestId}",
+            nameof(RequestSubmittedIntegrationEvent), message.RequestId);
+
+        try
+        {
+            // Idempotency: skip if workflow already exists for this request
+            var existing = await workflowInstanceRepository.GetByCorrelationId(
+                message.RequestId.ToString(), context.CancellationToken);
+            if (existing is not null)
+            {
+                logger.LogInformation(
+                    "Workflow already exists for RequestId: {RequestId} (InstanceId: {InstanceId}), skipping",
+                    message.RequestId, existing.Id);
+                return;
+            }
+
+            // Resolve workflow definition
+            var definition = await workflowDefinitionRepository.GetLatestVersion(
+                WorkflowName, context.CancellationToken)
+                ?? throw new InvalidOperationException(
+                    $"Workflow definition '{WorkflowName}' not found.");
+
+            // Build initial variables
+            var initialVariables = new Dictionary<string, object>
+            {
+                ["requestId"] = message.RequestId,
+                ["channel"] = message.Channel ?? string.Empty,
+                ["priority"] = message.Priority ?? "normal",
+                ["isPma"] = message.IsPma,
+                ["facilityLimit"] = message.FacilityLimit ?? 0m,
+                ["hasAppraisalBook"] = message.HasAppraisalBook,
+                ["requestSubmissionPayload"] = JsonSerializer.Serialize(message)
+            };
+
+            var instanceName = $"Request-{message.RequestId}";
+
+            // Start workflow with correlationId = requestId
+            var instance = await workflowService.StartWorkflowAsync(
+                workflowDefinitionId: definition.Id,
+                instanceName: instanceName,
+                startedBy: message.CreatedBy ?? "system",
+                initialVariables: initialVariables,
+                correlationId: message.RequestId.ToString(),
+                cancellationToken: context.CancellationToken);
+
+            logger.LogInformation(
+                "Started workflow instance {WorkflowInstanceId} for RequestId: {RequestId}",
+                instance.Id, message.RequestId);
+
+            // Evaluate table-driven trigger for immediate appraisal creation
+            var shouldEmit = await triggerEvaluator.ShouldEmitAsync(
+                "__on_workflow_start__", initialVariables, ct: context.CancellationToken);
+
+            if (shouldEmit)
+            {
+                await context.Publish(new AppraisalCreationRequestedIntegrationEvent
+                {
+                    RequestId = message.RequestId,
+                    RequestTitles = message.RequestTitles,
+                    Appointment = message.Appointment,
+                    Fee = message.Fee,
+                    Contact = message.Contact,
+                    CreatedBy = message.CreatedBy,
+                    Priority = message.Priority,
+                    IsPma = message.IsPma,
+                    Purpose = message.Purpose,
+                    Channel = message.Channel,
+                    BankingSegment = message.BankingSegment,
+                    FacilityLimit = message.FacilityLimit,
+                    HasAppraisalBook = message.HasAppraisalBook,
+                    RequestedBy = message.RequestedBy,
+                    RequestedAt = message.RequestedAt
+                }, context.CancellationToken);
+
+                logger.LogInformation(
+                    "Published AppraisalCreationRequestedIntegrationEvent for RequestId: {RequestId} (immediate path)",
+                    message.RequestId);
+            }
+            else
+            {
+                logger.LogInformation(
+                    "Appraisal creation deferred for RequestId: {RequestId} (channel: {Channel})",
+                    message.RequestId, message.Channel);
+            }
+
+            await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, context.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Error processing RequestSubmittedIntegrationEvent for RequestId: {RequestId}",
+                message.RequestId);
+            throw;
+        }
+    }
+}

--- a/Modules/Workflow/Workflow/EventHandlers/RequestSubmittedIntegrationEventConsumer.cs
+++ b/Modules/Workflow/Workflow/EventHandlers/RequestSubmittedIntegrationEventConsumer.cs
@@ -1,7 +1,8 @@
-using System.Text.Json;
+using Shared.Data.Outbox;
 using Shared.Messaging.Events;
 using Shared.Messaging.Filters;
 using Workflow.Data;
+using Workflow.Workflow.Models;
 using Workflow.Workflow.Pipeline;
 using Workflow.Workflow.Repositories;
 using Workflow.Workflow.Services;
@@ -12,12 +13,19 @@ namespace Workflow.EventHandlers;
 /// Handles RequestSubmittedIntegrationEvent by immediately starting a workflow
 /// and conditionally triggering appraisal creation based on table-driven configuration.
 /// CorrelationId = requestId (not appraisalId).
+///
+/// Atomicity: uses IIntegrationEventOutbox so that workflow creation and the
+/// AppraisalCreationRequestedIntegrationEvent are committed in the same transaction.
+/// A crash between workflow creation and event publish cannot happen — either both
+/// persist or neither does.
 /// </summary>
 public class RequestSubmittedIntegrationEventConsumer(
     ILogger<RequestSubmittedIntegrationEventConsumer> logger,
     IWorkflowDefinitionRepository workflowDefinitionRepository,
     IWorkflowInstanceRepository workflowInstanceRepository,
     IWorkflowService workflowService,
+    IWorkflowUnitOfWork unitOfWork,
+    IIntegrationEventOutbox outbox,
     AppraisalCreationTriggerEvaluator triggerEvaluator,
     InboxGuard<WorkflowDbContext> inboxGuard) : IConsumer<RequestSubmittedIntegrationEvent>
 {
@@ -29,6 +37,7 @@ public class RequestSubmittedIntegrationEventConsumer(
             return;
 
         var message = context.Message;
+        var ct = context.CancellationToken;
 
         logger.LogInformation(
             "Integration Event received: {IntegrationEvent} for RequestId: {RequestId}",
@@ -36,87 +45,48 @@ public class RequestSubmittedIntegrationEventConsumer(
 
         try
         {
-            // Idempotency: skip if workflow already exists for this request
+            // Retry path: check if workflow already exists for this request
             var existing = await workflowInstanceRepository.GetByCorrelationId(
-                message.RequestId.ToString(), context.CancellationToken);
+                message.RequestId.ToString(), ct);
+
             if (existing is not null)
             {
-                logger.LogInformation(
-                    "Workflow already exists for RequestId: {RequestId} (InstanceId: {InstanceId}), skipping",
-                    message.RequestId, existing.Id);
+                await HandleExistingWorkflowAsync(existing, message, ct);
+                await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
                 return;
             }
 
-            // Resolve workflow definition
-            var definition = await workflowDefinitionRepository.GetLatestVersion(
-                WorkflowName, context.CancellationToken)
-                ?? throw new InvalidOperationException(
-                    $"Workflow definition '{WorkflowName}' not found.");
+            // First run: start a new workflow, atomically publishing the
+            // AppraisalCreationRequestedIntegrationEvent via the outbox if the
+            // table-driven condition matches.
+            var initialVariables = BuildInitialVariables(message);
 
-            // Build initial variables
-            var initialVariables = new Dictionary<string, object>
-            {
-                ["requestId"] = message.RequestId,
-                ["channel"] = message.Channel ?? string.Empty,
-                ["priority"] = message.Priority ?? "normal",
-                ["isPma"] = message.IsPma,
-                ["facilityLimit"] = message.FacilityLimit ?? 0m,
-                ["hasAppraisalBook"] = message.HasAppraisalBook,
-                ["requestSubmissionPayload"] = JsonSerializer.Serialize(message)
-            };
-
-            var instanceName = $"Request-{message.RequestId}";
-
-            // Start workflow with correlationId = requestId
-            var instance = await workflowService.StartWorkflowAsync(
-                workflowDefinitionId: definition.Id,
-                instanceName: instanceName,
-                startedBy: message.CreatedBy ?? "system",
-                initialVariables: initialVariables,
-                correlationId: message.RequestId.ToString(),
-                cancellationToken: context.CancellationToken);
-
-            logger.LogInformation(
-                "Started workflow instance {WorkflowInstanceId} for RequestId: {RequestId}",
-                instance.Id, message.RequestId);
-
-            // Evaluate table-driven trigger for immediate appraisal creation
             var shouldEmit = await triggerEvaluator.ShouldEmitAsync(
-                "__on_workflow_start__", initialVariables, ct: context.CancellationToken);
+                "__on_workflow_start__", initialVariables, ct: ct);
 
             if (shouldEmit)
             {
-                await context.Publish(new AppraisalCreationRequestedIntegrationEvent
-                {
-                    RequestId = message.RequestId,
-                    RequestTitles = message.RequestTitles,
-                    Appointment = message.Appointment,
-                    Fee = message.Fee,
-                    Contact = message.Contact,
-                    CreatedBy = message.CreatedBy,
-                    Priority = message.Priority,
-                    IsPma = message.IsPma,
-                    Purpose = message.Purpose,
-                    Channel = message.Channel,
-                    BankingSegment = message.BankingSegment,
-                    FacilityLimit = message.FacilityLimit,
-                    HasAppraisalBook = message.HasAppraisalBook,
-                    RequestedBy = message.RequestedBy,
-                    RequestedAt = message.RequestedAt
-                }, context.CancellationToken);
-
-                logger.LogInformation(
-                    "Published AppraisalCreationRequestedIntegrationEvent for RequestId: {RequestId} (immediate path)",
-                    message.RequestId);
-            }
-            else
-            {
-                logger.LogInformation(
-                    "Appraisal creation deferred for RequestId: {RequestId} (channel: {Channel})",
-                    message.RequestId, message.Channel);
+                outbox.Publish(BuildCreationRequestedEvent(message), message.RequestId.ToString());
+                initialVariables["appraisalCreationRequested"] = true;
             }
 
-            await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, context.CancellationToken);
+            var definition = await workflowDefinitionRepository.GetLatestVersion(WorkflowName, ct)
+                ?? throw new InvalidOperationException(
+                    $"Workflow definition '{WorkflowName}' not found.");
+
+            var instance = await workflowService.StartWorkflowAsync(
+                workflowDefinitionId: definition.Id,
+                instanceName: $"Request-{message.RequestId}",
+                startedBy: message.CreatedBy ?? "system",
+                initialVariables: initialVariables,
+                correlationId: message.RequestId.ToString(),
+                cancellationToken: ct);
+
+            logger.LogInformation(
+                "Started workflow instance {WorkflowInstanceId} for RequestId: {RequestId} (shouldEmit={ShouldEmit})",
+                instance.Id, message.RequestId, shouldEmit);
+
+            await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
         }
         catch (Exception ex)
         {
@@ -125,5 +95,90 @@ public class RequestSubmittedIntegrationEventConsumer(
                 message.RequestId);
             throw;
         }
+    }
+
+    private async Task HandleExistingWorkflowAsync(
+        WorkflowInstance existing, RequestSubmittedIntegrationEvent message, CancellationToken ct)
+    {
+        // If appraisal creation was already requested (flag set in Variables), skip.
+        if (IsAppraisalCreationRequested(existing.Variables))
+        {
+            logger.LogInformation(
+                "Workflow and appraisal creation already handled for RequestId: {RequestId}",
+                message.RequestId);
+            return;
+        }
+
+        // Stale-reclaim retry after a crash between workflow creation and flag set.
+        // Re-evaluate the trigger. For the immediate path we re-publish; for the deferred
+        // path the pipeline step handles publishing later, so we do nothing here.
+        var shouldEmit = await triggerEvaluator.ShouldEmitAsync(
+            "__on_workflow_start__", existing.Variables, ct: ct);
+
+        if (!shouldEmit)
+        {
+            logger.LogInformation(
+                "Existing workflow {WorkflowInstanceId} for RequestId {RequestId}: deferred path, nothing to re-publish",
+                existing.Id, message.RequestId);
+            return;
+        }
+
+        outbox.Publish(BuildCreationRequestedEvent(message), message.RequestId.ToString());
+        existing.UpdateVariables(new Dictionary<string, object>
+        {
+            ["appraisalCreationRequested"] = true
+        });
+        await unitOfWork.SaveChangesAsync(ct);
+
+        logger.LogInformation(
+            "Re-published AppraisalCreationRequestedIntegrationEvent for existing workflow {WorkflowInstanceId}, RequestId: {RequestId}",
+            existing.Id, message.RequestId);
+    }
+
+    private static Dictionary<string, object> BuildInitialVariables(RequestSubmittedIntegrationEvent message) =>
+        new()
+        {
+            ["requestId"] = message.RequestId,
+            ["channel"] = message.Channel ?? string.Empty,
+            ["priority"] = message.Priority ?? "normal",
+            ["isPma"] = message.IsPma,
+            ["facilityLimit"] = message.FacilityLimit ?? 0m,
+            ["hasAppraisalBook"] = message.HasAppraisalBook,
+            ["requestSubmissionPayload"] = JsonSerializer.Serialize(message)
+        };
+
+    private static AppraisalCreationRequestedIntegrationEvent BuildCreationRequestedEvent(
+        RequestSubmittedIntegrationEvent message) =>
+        new()
+        {
+            RequestId = message.RequestId,
+            RequestTitles = message.RequestTitles,
+            Appointment = message.Appointment,
+            Fee = message.Fee,
+            Contact = message.Contact,
+            CreatedBy = message.CreatedBy,
+            Priority = message.Priority,
+            IsPma = message.IsPma,
+            Purpose = message.Purpose,
+            Channel = message.Channel,
+            BankingSegment = message.BankingSegment,
+            FacilityLimit = message.FacilityLimit,
+            HasAppraisalBook = message.HasAppraisalBook,
+            RequestedBy = message.RequestedBy,
+            RequestedAt = message.RequestedAt
+        };
+
+    private static bool IsAppraisalCreationRequested(Dictionary<string, object>? variables)
+    {
+        if (variables is null || !variables.TryGetValue("appraisalCreationRequested", out var flag))
+            return false;
+
+        return flag switch
+        {
+            bool b => b,
+            string s => bool.TryParse(s, out var parsed) && parsed,
+            JsonElement je => je.ValueKind == JsonValueKind.True,
+            _ => false
+        };
     }
 }

--- a/Modules/Workflow/Workflow/Infrastructure/Migrations/20260410120000_SeedAppraisalCreationTriggerSteps.cs
+++ b/Modules/Workflow/Workflow/Infrastructure/Migrations/20260410120000_SeedAppraisalCreationTriggerSteps.cs
@@ -1,0 +1,56 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Workflow.Infrastructure.Migrations;
+
+/// <summary>
+/// Seeds ActivityProcessConfiguration rows for the configurable appraisal creation trigger.
+/// Uses IF NOT EXISTS to be safe on both fresh and existing databases.
+/// </summary>
+public partial class SeedAppraisalCreationTriggerSteps : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        // Non-manual channel: immediate appraisal creation at workflow start
+        migrationBuilder.Sql("""
+            IF NOT EXISTS (
+                SELECT 1 FROM workflow.ActivityProcessConfigurations
+                WHERE ActivityName = '__on_workflow_start__'
+                  AND ProcessorName = 'EmitAppraisalCreationRequested'
+            )
+            BEGIN
+                INSERT INTO workflow.ActivityProcessConfigurations
+                    (Id, ActivityName, StepName, ProcessorName, SortOrder, Parameters, IsActive, CreatedAt, CreatedBy, UpdatedAt, UpdatedBy)
+                VALUES
+                    (NEWID(), '__on_workflow_start__', 'Emit appraisal creation (non-manual)', 'EmitAppraisalCreationRequested', 1,
+                     '{"condition": "channel != ''MANUAL''"}', 1, GETUTCDATE(), 'system', GETUTCDATE(), 'system')
+            END
+            """);
+
+        // Manual channel: deferred appraisal creation at initiation-check approval
+        migrationBuilder.Sql("""
+            IF NOT EXISTS (
+                SELECT 1 FROM workflow.ActivityProcessConfigurations
+                WHERE ActivityName = 'appraisal-initiation-check'
+                  AND ProcessorName = 'EmitAppraisalCreationRequested'
+            )
+            BEGIN
+                INSERT INTO workflow.ActivityProcessConfigurations
+                    (Id, ActivityName, StepName, ProcessorName, SortOrder, Parameters, IsActive, CreatedAt, CreatedBy, UpdatedAt, UpdatedBy)
+                VALUES
+                    (NEWID(), 'appraisal-initiation-check', 'Emit appraisal creation (manual)', 'EmitAppraisalCreationRequested', 1,
+                     '{"condition": "channel == ''MANUAL''", "requireDecision": "P"}', 1, GETUTCDATE(), 'system', GETUTCDATE(), 'system')
+            END
+            """);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql("""
+            DELETE FROM workflow.ActivityProcessConfigurations
+            WHERE ProcessorName = 'EmitAppraisalCreationRequested'
+              AND ActivityName IN ('__on_workflow_start__', 'appraisal-initiation-check')
+            """);
+    }
+}

--- a/Modules/Workflow/Workflow/Tasks/Features/GetTaskById/GetTaskByIdQuery.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/GetTaskById/GetTaskByIdQuery.cs
@@ -7,7 +7,7 @@ public record GetTaskByIdQuery(Guid TaskId) : IQuery<TaskDetailResult>;
 public record TaskDetailResult
 {
     public Guid TaskId { get; init; }
-    public Guid AppraisalId { get; init; }
+    public Guid? AppraisalId { get; init; }
     public Guid WorkflowInstanceId { get; init; }
     public string ActivityId { get; init; } = default!;
     public string AssigneeUserId { get; init; } = default!;

--- a/Modules/Workflow/Workflow/Tasks/Features/GetTaskById/GetTaskByIdQueryHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/GetTaskById/GetTaskByIdQueryHandler.cs
@@ -13,7 +13,9 @@ public class GetTaskByIdQueryHandler(
     private const string Sql = """
         SELECT
             pt.Id                              AS TaskId,
-            (SELECT TOP 1 Id FROM appraisal.Appraisals WHERE RequestId = pt.CorrelationId) AS AppraisalId,
+            (SELECT TOP 1 Id FROM appraisal.Appraisals
+              WHERE RequestId = pt.CorrelationId
+              ORDER BY CreatedAt DESC) AS AppraisalId,
             pt.WorkflowInstanceId,
             pt.ActivityId,
             pt.AssignedTo                      AS AssigneeUserId,

--- a/Modules/Workflow/Workflow/Tasks/Features/GetTaskById/GetTaskByIdQueryHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/GetTaskById/GetTaskByIdQueryHandler.cs
@@ -58,7 +58,7 @@ public class GetTaskByIdQueryHandler(
 
     private sealed record TaskDetailDto(
         Guid TaskId,
-        Guid AppraisalId,
+        Guid? AppraisalId,
         Guid WorkflowInstanceId,
         string ActivityId,
         string AssigneeUserId,

--- a/Modules/Workflow/Workflow/Tasks/Features/GetTaskById/GetTaskByIdQueryHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/GetTaskById/GetTaskByIdQueryHandler.cs
@@ -12,16 +12,16 @@ public class GetTaskByIdQueryHandler(
 {
     private const string Sql = """
         SELECT
-            Id                              AS TaskId,
-            CorrelationId                   AS AppraisalId,
-            WorkflowInstanceId,
-            ActivityId,
-            AssignedTo                      AS AssigneeUserId,
-            AssignedType,
-            CAST(TaskName AS nvarchar(100)) AS TaskName,
-            TaskDescription
-        FROM workflow.PendingTasks
-        WHERE Id = @TaskId
+            pt.Id                              AS TaskId,
+            (SELECT TOP 1 Id FROM appraisal.Appraisals WHERE RequestId = pt.CorrelationId) AS AppraisalId,
+            pt.WorkflowInstanceId,
+            pt.ActivityId,
+            pt.AssignedTo                      AS AssigneeUserId,
+            pt.AssignedType,
+            CAST(pt.TaskName AS nvarchar(100)) AS TaskName,
+            pt.TaskDescription
+        FROM workflow.PendingTasks pt
+        WHERE pt.Id = @TaskId
         """;
 
     public async Task<TaskDetailResult> Handle(

--- a/Modules/Workflow/Workflow/Workflow/Pipeline/ActivityProcessPipeline.cs
+++ b/Modules/Workflow/Workflow/Workflow/Pipeline/ActivityProcessPipeline.cs
@@ -40,8 +40,10 @@ public class ActivityProcessPipeline(
                                ?? throw new InvalidOperationException(
                                    $"Workflow instance {workflowInstanceId} not found");
 
-        // CorrelationId (requestId) — always available
-        var correlationId = Guid.TryParse(workflowInstance.CorrelationId, out var cid) ? cid : Guid.Empty;
+        // CorrelationId (requestId) — fail fast if missing/invalid rather than silently using Guid.Empty
+        if (!Guid.TryParse(workflowInstance.CorrelationId, out var correlationId))
+            throw new InvalidOperationException(
+                $"Workflow instance {workflowInstanceId} has invalid CorrelationId '{workflowInstance.CorrelationId}'");
 
         // AppraisalId from Variables — null before appraisal creation
         Guid? appraisalId = ResolveAppraisalId(workflowInstance.Variables);

--- a/Modules/Workflow/Workflow/Workflow/Pipeline/ActivityProcessPipeline.cs
+++ b/Modules/Workflow/Workflow/Workflow/Pipeline/ActivityProcessPipeline.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Workflow.Data;
@@ -34,14 +35,16 @@ public class ActivityProcessPipeline(
             return ProcessStepResult.Ok();
         }
 
-        // Get AppraisalId from workflow instance's CorrelationId
+        // Load workflow instance for CorrelationId + Variables
         var workflowInstance = await workflowInstanceRepository.GetByIdAsync(workflowInstanceId, ct)
                                ?? throw new InvalidOperationException(
                                    $"Workflow instance {workflowInstanceId} not found");
 
-        if (!Guid.TryParse(workflowInstance.CorrelationId, out var appraisalId))
-            throw new InvalidOperationException(
-                $"Cannot parse CorrelationId '{workflowInstance.CorrelationId}' as AppraisalId");
+        // CorrelationId (requestId) — always available
+        var correlationId = Guid.TryParse(workflowInstance.CorrelationId, out var cid) ? cid : Guid.Empty;
+
+        // AppraisalId from Variables — null before appraisal creation
+        Guid? appraisalId = ResolveAppraisalId(workflowInstance.Variables);
 
         // Run each step sequentially
         foreach (var config in configs)
@@ -57,6 +60,7 @@ public class ActivityProcessPipeline(
 
             var context = new ProcessStepContext
             {
+                CorrelationId = correlationId,
                 AppraisalId = appraisalId,
                 WorkflowInstanceId = workflowInstanceId,
                 ActivityName = activityId,
@@ -82,5 +86,20 @@ public class ActivityProcessPipeline(
         }
 
         return ProcessStepResult.Ok();
+    }
+
+    private static Guid? ResolveAppraisalId(Dictionary<string, object>? variables)
+    {
+        if (variables is null || !variables.TryGetValue("appraisalId", out var aidObj))
+            return null;
+
+        return aidObj switch
+        {
+            Guid g => g,
+            string s when Guid.TryParse(s, out var parsed) => parsed,
+            JsonElement je when je.ValueKind == JsonValueKind.String
+                && Guid.TryParse(je.GetString(), out var jp) => jp,
+            _ => null
+        };
     }
 }

--- a/Modules/Workflow/Workflow/Workflow/Pipeline/AppraisalCreationTriggerEvaluator.cs
+++ b/Modules/Workflow/Workflow/Workflow/Pipeline/AppraisalCreationTriggerEvaluator.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Workflow.Data;
+using Workflow.Workflow.Engine.Expression;
+
+namespace Workflow.Workflow.Pipeline;
+
+/// <summary>
+/// Evaluates whether appraisal creation should be triggered based on
+/// ActivityProcessConfiguration rows. Used by both the consumer (immediate path)
+/// and the pipeline step (deferred path).
+/// </summary>
+public class AppraisalCreationTriggerEvaluator(
+    WorkflowDbContext dbContext,
+    IExpressionEvaluator expressionEvaluator,
+    ILogger<AppraisalCreationTriggerEvaluator> logger)
+{
+    /// <summary>
+    /// Reads config rows for the given activity name and evaluates whether
+    /// the appraisal creation condition is satisfied.
+    /// </summary>
+    public async Task<bool> ShouldEmitAsync(
+        string activityName,
+        Dictionary<string, object> variables,
+        Dictionary<string, object>? input = null,
+        CancellationToken ct = default)
+    {
+        var configs = await dbContext.ActivityProcessConfigurations
+            .Where(c => c.ActivityName == activityName
+                        && c.ProcessorName == "EmitAppraisalCreationRequested"
+                        && c.IsActive)
+            .OrderBy(c => c.SortOrder)
+            .ToListAsync(ct);
+
+        if (configs.Count == 0)
+        {
+            logger.LogDebug("No EmitAppraisalCreationRequested config for activity {ActivityName}", activityName);
+            return false;
+        }
+
+        foreach (var config in configs)
+        {
+            if (EvaluateConfig(config.Parameters, variables, input))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Evaluates a single config row's condition and optional requireDecision check.
+    /// </summary>
+    public bool EvaluateConfig(
+        string? parameters,
+        Dictionary<string, object> variables,
+        Dictionary<string, object>? input = null)
+    {
+        if (string.IsNullOrWhiteSpace(parameters))
+            return true;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(parameters);
+            var root = doc.RootElement;
+
+            // Check requireDecision against input
+            if (root.TryGetProperty("requireDecision", out var reqDecision))
+            {
+                var requiredValue = reqDecision.GetString();
+                if (!string.IsNullOrEmpty(requiredValue))
+                {
+                    var decisionField = root.TryGetProperty("decisionField", out var df)
+                        ? df.GetString() ?? "decisionTaken"
+                        : "decisionTaken";
+
+                    if (input is null || !input.TryGetValue(decisionField, out var rawDecision))
+                        return false;
+
+                    var actual = rawDecision switch
+                    {
+                        JsonElement je => je.GetString() ?? je.ToString(),
+                        string s => s,
+                        _ => rawDecision?.ToString()
+                    };
+
+                    if (!string.Equals(actual, requiredValue, StringComparison.OrdinalIgnoreCase))
+                        return false;
+                }
+            }
+
+            // Evaluate condition expression
+            if (root.TryGetProperty("condition", out var conditionElement))
+            {
+                var condition = conditionElement.GetString();
+                if (!string.IsNullOrWhiteSpace(condition))
+                {
+                    var result = expressionEvaluator.EvaluateExpression(condition, variables);
+                    logger.LogDebug(
+                        "Condition '{Condition}' evaluated to {Result}", condition, result);
+                    return result;
+                }
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to evaluate trigger config: {Parameters}", parameters);
+            return false;
+        }
+    }
+}

--- a/Modules/Workflow/Workflow/Workflow/Pipeline/ProcessStepContext.cs
+++ b/Modules/Workflow/Workflow/Workflow/Pipeline/ProcessStepContext.cs
@@ -5,7 +5,16 @@ namespace Workflow.Workflow.Pipeline;
 /// </summary>
 public record ProcessStepContext
 {
-    public Guid AppraisalId { get; init; }
+    /// <summary>
+    /// Workflow correlation ID (requestId). Always available.
+    /// </summary>
+    public Guid CorrelationId { get; init; }
+
+    /// <summary>
+    /// Appraisal ID from Variables["appraisalId"]. Null before appraisal creation.
+    /// </summary>
+    public Guid? AppraisalId { get; init; }
+
     public Guid WorkflowInstanceId { get; init; }
     public string ActivityName { get; init; } = default!;
     public string CompletedBy { get; init; } = default!;

--- a/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/EmitAppraisalCreationRequestedStep.cs
+++ b/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/EmitAppraisalCreationRequestedStep.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Shared.Data.Outbox;
+using Shared.Messaging.Events;
+using Workflow.Workflow.Engine.Expression;
+
+namespace Workflow.Workflow.Pipeline.Steps;
+
+/// <summary>
+/// Pipeline step that publishes AppraisalCreationRequestedIntegrationEvent via the outbox.
+/// Used for the deferred (manual channel) path during activity completion.
+/// Condition and requireDecision are read from the step's Parameters JSON.
+/// </summary>
+public class EmitAppraisalCreationRequestedStep(
+    IIntegrationEventOutbox outbox,
+    IExpressionEvaluator expressionEvaluator,
+    ILogger<EmitAppraisalCreationRequestedStep> logger) : IActivityProcessStep
+{
+    public string Name => "EmitAppraisalCreationRequested";
+
+    public Task<ProcessStepResult> ExecuteAsync(ProcessStepContext context, CancellationToken ct)
+    {
+        var variables = context.Variables ?? new Dictionary<string, object>();
+
+        // Idempotent guard: skip if already triggered
+        if (variables.TryGetValue("appraisalCreationRequested", out var flagObj) && IsTruthy(flagObj))
+        {
+            logger.LogInformation("Appraisal creation already requested for workflow {WorkflowInstanceId}, skipping",
+                context.WorkflowInstanceId);
+            return Task.FromResult(ProcessStepResult.Ok());
+        }
+
+        if (string.IsNullOrWhiteSpace(context.Parameters))
+            return Task.FromResult(ProcessStepResult.Fail("Missing step parameters"));
+
+        try
+        {
+            using var doc = JsonDocument.Parse(context.Parameters);
+            var root = doc.RootElement;
+
+            // Check requireDecision against input
+            if (root.TryGetProperty("requireDecision", out var reqDecision))
+            {
+                var requiredValue = reqDecision.GetString();
+                if (!string.IsNullOrEmpty(requiredValue))
+                {
+                    var decisionField = root.TryGetProperty("decisionField", out var df)
+                        ? df.GetString() ?? "decisionTaken"
+                        : "decisionTaken";
+
+                    if (!context.Input.TryGetValue(decisionField, out var rawDecision))
+                        return Task.FromResult(ProcessStepResult.Ok()); // No decision yet — not our turn
+
+                    var actual = rawDecision switch
+                    {
+                        JsonElement je => je.GetString() ?? je.ToString(),
+                        string s => s,
+                        _ => rawDecision?.ToString()
+                    };
+
+                    if (!string.Equals(actual, requiredValue, StringComparison.OrdinalIgnoreCase))
+                        return Task.FromResult(ProcessStepResult.Ok()); // Different decision — not our turn
+                }
+            }
+
+            // Evaluate condition expression
+            if (root.TryGetProperty("condition", out var conditionElement))
+            {
+                var condition = conditionElement.GetString();
+                if (!string.IsNullOrWhiteSpace(condition))
+                {
+                    var result = expressionEvaluator.EvaluateExpression(condition, variables);
+                    if (!result)
+                    {
+                        logger.LogDebug("Condition '{Condition}' not met for workflow {WorkflowInstanceId}",
+                            condition, context.WorkflowInstanceId);
+                        return Task.FromResult(ProcessStepResult.Ok()); // Condition not met — not our turn
+                    }
+                }
+            }
+
+            // Rehydrate the stashed request payload
+            if (!variables.TryGetValue("requestSubmissionPayload", out var payloadObj))
+                return Task.FromResult(ProcessStepResult.Fail("Missing requestSubmissionPayload in workflow variables"));
+
+            var payloadJson = payloadObj switch
+            {
+                string s => s,
+                JsonElement je => je.GetString() ?? je.GetRawText(),
+                _ => payloadObj?.ToString()
+            };
+
+            if (string.IsNullOrWhiteSpace(payloadJson))
+                return Task.FromResult(ProcessStepResult.Fail("requestSubmissionPayload is empty"));
+
+            var source = JsonSerializer.Deserialize<RequestSubmittedIntegrationEvent>(payloadJson,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            if (source is null)
+                return Task.FromResult(ProcessStepResult.Fail("Failed to deserialize requestSubmissionPayload"));
+
+            // Publish via outbox (flushed on next SaveChangesAsync)
+            outbox.Publish(new AppraisalCreationRequestedIntegrationEvent
+            {
+                RequestId = source.RequestId,
+                RequestTitles = source.RequestTitles,
+                Appointment = source.Appointment,
+                Fee = source.Fee,
+                Contact = source.Contact,
+                CreatedBy = source.CreatedBy,
+                Priority = source.Priority,
+                IsPma = source.IsPma,
+                Purpose = source.Purpose,
+                Channel = source.Channel,
+                BankingSegment = source.BankingSegment,
+                FacilityLimit = source.FacilityLimit,
+                HasAppraisalBook = source.HasAppraisalBook,
+                RequestedBy = source.RequestedBy,
+                RequestedAt = source.RequestedAt
+            }, source.RequestId.ToString());
+
+            // Set idempotency flag (mutates the tracked entity's Variables dictionary)
+            variables["appraisalCreationRequested"] = true;
+
+            logger.LogInformation(
+                "Published AppraisalCreationRequestedIntegrationEvent for RequestId {RequestId} from workflow {WorkflowInstanceId}",
+                source.RequestId, context.WorkflowInstanceId);
+
+            return Task.FromResult(ProcessStepResult.Ok());
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to emit appraisal creation request for workflow {WorkflowInstanceId}",
+                context.WorkflowInstanceId);
+            return Task.FromResult(ProcessStepResult.Fail(ex.Message));
+        }
+    }
+
+    private static bool IsTruthy(object? value) => value switch
+    {
+        bool b => b,
+        string s => bool.TryParse(s, out var parsed) && parsed,
+        JsonElement je => je.ValueKind == JsonValueKind.True,
+        _ => false
+    };
+}

--- a/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/EmitAppraisalCreationRequestedStep.cs
+++ b/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/EmitAppraisalCreationRequestedStep.cs
@@ -2,18 +2,17 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Shared.Data.Outbox;
 using Shared.Messaging.Events;
-using Workflow.Workflow.Engine.Expression;
 
 namespace Workflow.Workflow.Pipeline.Steps;
 
 /// <summary>
 /// Pipeline step that publishes AppraisalCreationRequestedIntegrationEvent via the outbox.
 /// Used for the deferred (manual channel) path during activity completion.
-/// Condition and requireDecision are read from the step's Parameters JSON.
+/// Delegates condition evaluation to AppraisalCreationTriggerEvaluator.
 /// </summary>
 public class EmitAppraisalCreationRequestedStep(
     IIntegrationEventOutbox outbox,
-    IExpressionEvaluator expressionEvaluator,
+    AppraisalCreationTriggerEvaluator triggerEvaluator,
     ILogger<EmitAppraisalCreationRequestedStep> logger) : IActivityProcessStep
 {
     public string Name => "EmitAppraisalCreationRequested";
@@ -35,48 +34,11 @@ public class EmitAppraisalCreationRequestedStep(
 
         try
         {
-            using var doc = JsonDocument.Parse(context.Parameters);
-            var root = doc.RootElement;
-
-            // Check requireDecision against input
-            if (root.TryGetProperty("requireDecision", out var reqDecision))
+            // Delegate condition + requireDecision evaluation to shared helper
+            if (!triggerEvaluator.EvaluateConfig(context.Parameters, variables, context.Input))
             {
-                var requiredValue = reqDecision.GetString();
-                if (!string.IsNullOrEmpty(requiredValue))
-                {
-                    var decisionField = root.TryGetProperty("decisionField", out var df)
-                        ? df.GetString() ?? "decisionTaken"
-                        : "decisionTaken";
-
-                    if (!context.Input.TryGetValue(decisionField, out var rawDecision))
-                        return Task.FromResult(ProcessStepResult.Ok()); // No decision yet — not our turn
-
-                    var actual = rawDecision switch
-                    {
-                        JsonElement je => je.GetString() ?? je.ToString(),
-                        string s => s,
-                        _ => rawDecision?.ToString()
-                    };
-
-                    if (!string.Equals(actual, requiredValue, StringComparison.OrdinalIgnoreCase))
-                        return Task.FromResult(ProcessStepResult.Ok()); // Different decision — not our turn
-                }
-            }
-
-            // Evaluate condition expression
-            if (root.TryGetProperty("condition", out var conditionElement))
-            {
-                var condition = conditionElement.GetString();
-                if (!string.IsNullOrWhiteSpace(condition))
-                {
-                    var result = expressionEvaluator.EvaluateExpression(condition, variables);
-                    if (!result)
-                    {
-                        logger.LogDebug("Condition '{Condition}' not met for workflow {WorkflowInstanceId}",
-                            condition, context.WorkflowInstanceId);
-                        return Task.FromResult(ProcessStepResult.Ok()); // Condition not met — not our turn
-                    }
-                }
+                logger.LogDebug("Trigger condition not met for workflow {WorkflowInstanceId}", context.WorkflowInstanceId);
+                return Task.FromResult(ProcessStepResult.Ok());
             }
 
             // Rehydrate the stashed request payload

--- a/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/EmitAppraisalCreationRequestedStep.cs
+++ b/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/EmitAppraisalCreationRequestedStep.cs
@@ -19,7 +19,10 @@ public class EmitAppraisalCreationRequestedStep(
 
     public Task<ProcessStepResult> ExecuteAsync(ProcessStepContext context, CancellationToken ct)
     {
-        var variables = context.Variables ?? new Dictionary<string, object>();
+        if (context.Variables is null)
+            return Task.FromResult(ProcessStepResult.Fail("Workflow variables are null"));
+
+        var variables = context.Variables;
 
         // Idempotent guard: skip if already triggered
         if (variables.TryGetValue("appraisalCreationRequested", out var flagObj) && IsTruthy(flagObj))

--- a/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/UpdateAppraisalStatusStep.cs
+++ b/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/UpdateAppraisalStatusStep.cs
@@ -16,6 +16,9 @@ public class UpdateAppraisalStatusStep(
 
     public async Task<ProcessStepResult> ExecuteAsync(ProcessStepContext context, CancellationToken ct)
     {
+        if (context.AppraisalId is null)
+            return ProcessStepResult.Fail("Appraisal not yet created");
+
         var targetStatus = GetTargetStatus(context.Parameters);
         if (targetStatus is null)
             return ProcessStepResult.Fail("Missing 'targetStatus' in step parameters");
@@ -23,7 +26,7 @@ public class UpdateAppraisalStatusStep(
         try
         {
             await appraisalStatusService.UpdateStatusAsync(
-                context.AppraisalId, targetStatus, context.CompletedBy, ct);
+                context.AppraisalId.Value, targetStatus, context.CompletedBy, ct);
 
             logger.LogInformation(
                 "Updated appraisal {AppraisalId} status to {TargetStatus}",

--- a/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/UpdateAssignmentStatusStep.cs
+++ b/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/UpdateAssignmentStatusStep.cs
@@ -16,6 +16,9 @@ public class UpdateAssignmentStatusStep(
 
     public async Task<ProcessStepResult> ExecuteAsync(ProcessStepContext context, CancellationToken ct)
     {
+        if (context.AppraisalId is null)
+            return ProcessStepResult.Fail("Appraisal not yet created");
+
         var targetStatus = GetTargetStatus(context.Parameters);
         if (targetStatus is null)
             return ProcessStepResult.Fail("Missing 'targetStatus' in step parameters");
@@ -23,7 +26,7 @@ public class UpdateAssignmentStatusStep(
         try
         {
             await appraisalStatusService.UpdateAssignmentStatusAsync(
-                context.AppraisalId, targetStatus, context.CompletedBy, ct);
+                context.AppraisalId.Value, targetStatus, context.CompletedBy, ct);
 
             logger.LogInformation(
                 "Updated assignment for appraisal {AppraisalId} status to {TargetStatus}",

--- a/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/ValidateHasAppraisedValueStep.cs
+++ b/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/ValidateHasAppraisedValueStep.cs
@@ -16,6 +16,9 @@ public class ValidateHasAppraisedValueStep(
 
     public async Task<ProcessStepResult> ExecuteAsync(ProcessStepContext context, CancellationToken ct)
     {
+        if (context.AppraisalId is null)
+            return ProcessStepResult.Fail("Appraisal not yet created");
+
         try
         {
             using var connection = connectionFactory.GetOpenConnection();
@@ -28,7 +31,7 @@ public class ValidateHasAppraisedValueStep(
                       AND AppraisedValue > 0
                 ) THEN 1 ELSE 0 END
                 """,
-                new { context.AppraisalId });
+                new { AppraisalId = context.AppraisalId.Value });
 
             if (!hasValue)
             {

--- a/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/ValidateTaskOwnershipStep.cs
+++ b/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/ValidateTaskOwnershipStep.cs
@@ -36,7 +36,7 @@ public class ValidateTaskOwnershipStep(
             {
                 logger.LogWarning(
                     "No pending task found for correlation {CorrelationId}", context.CorrelationId);
-                return ProcessStepResult.Fail("No pending task found for this appraisal");
+                return ProcessStepResult.Fail("No pending task found for this request");
             }
 
             var username = currentUserService.Username;

--- a/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/ValidateTaskOwnershipStep.cs
+++ b/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/ValidateTaskOwnershipStep.cs
@@ -27,15 +27,15 @@ public class ValidateTaskOwnershipStep(
                 """
                 SELECT AssignedTo, AssignedType, WorkingBy
                 FROM workflow.PendingTasks
-                WHERE CorrelationId = @AppraisalId
+                WHERE CorrelationId = @CorrelationId
                 """,
-                new { context.AppraisalId });
+                new { context.CorrelationId });
 
             var taskList = tasks.ToList();
             if (taskList.Count == 0)
             {
                 logger.LogWarning(
-                    "No pending task found for appraisal {AppraisalId}", context.AppraisalId);
+                    "No pending task found for correlation {CorrelationId}", context.CorrelationId);
                 return ProcessStepResult.Fail("No pending task found for this appraisal");
             }
 
@@ -49,9 +49,9 @@ public class ValidateTaskOwnershipStep(
             if (!isOwner)
             {
                 logger.LogWarning(
-                    "User {Username} attempted to complete task for appraisal {AppraisalId} but is not assigned to any of {TaskCount} pending tasks",
+                    "User {Username} attempted to complete task for correlation {CorrelationId} but is not assigned to any of {TaskCount} pending tasks",
                     username,
-                    context.AppraisalId,
+                    context.CorrelationId,
                     taskList.Count);
                 return ProcessStepResult.Fail("You are not authorized to complete this task");
             }
@@ -61,7 +61,7 @@ public class ValidateTaskOwnershipStep(
         catch (Exception ex)
         {
             logger.LogError(ex,
-                "Failed to validate task ownership for appraisal {AppraisalId}", context.AppraisalId);
+                "Failed to validate task ownership for correlation {CorrelationId}", context.CorrelationId);
             return ProcessStepResult.Fail(ex.Message);
         }
     }

--- a/Modules/Workflow/Workflow/Workflow/Services/WorkflowService.cs
+++ b/Modules/Workflow/Workflow/Workflow/Services/WorkflowService.cs
@@ -288,15 +288,22 @@ public class WorkflowService : IWorkflowService
     /// </summary>
     private async Task PublishPostCommitEventsAsync(WorkflowInstance instance, CancellationToken cancellationToken)
     {
-        var correlationId = ParseCorrelationId(instance);
+        var appraisalId = ResolveAppraisalIdFromVariables(instance);
+        if (appraisalId is null)
+        {
+            _logger.LogWarning(
+                "AppraisalId not yet available in Variables for workflow {WorkflowInstanceId}, skipping post-commit events",
+                instance.Id);
+            return;
+        }
 
         if (instance.CurrentActivityId == "ext-appraisal-assignment")
         {
-            PublishCompanyAssignedEvent(instance, correlationId);
+            PublishCompanyAssignedEvent(instance, appraisalId.Value);
         }
         else if (instance.CurrentActivityId == "int-appraisal-execution")
         {
-            PublishInternalAssignedEvent(instance, correlationId);
+            PublishInternalAssignedEvent(instance, appraisalId.Value);
         }
     }
 
@@ -362,9 +369,18 @@ public class WorkflowService : IWorkflowService
             correlationId, assigneeUserId, method);
     }
 
-    private Guid ParseCorrelationId(WorkflowInstance instance)
+    private static Guid? ResolveAppraisalIdFromVariables(WorkflowInstance instance)
     {
-        return !string.IsNullOrEmpty(instance.CorrelationId)
-            && Guid.TryParse(instance.CorrelationId, out var parsed) ? parsed : instance.Id;
+        if (!instance.Variables.TryGetValue("appraisalId", out var aidObj))
+            return null;
+
+        return aidObj switch
+        {
+            Guid g => g,
+            string s when Guid.TryParse(s, out var parsed) => parsed,
+            JsonElement je when je.ValueKind == JsonValueKind.String
+                && Guid.TryParse(je.GetString(), out var jp) => jp,
+            _ => null
+        };
     }
 }

--- a/Modules/Workflow/Workflow/WorkflowModule.cs
+++ b/Modules/Workflow/Workflow/WorkflowModule.cs
@@ -161,8 +161,10 @@ public static class WorkflowModule
         services.AddScoped<IActivityProcessStep, ValidateHasAppraisedValueStep>();
         services.AddScoped<IActivityProcessStep, ValidateTaskOwnershipStep>();
         services.AddScoped<IActivityProcessStep, ValidateDecisionConstraintsStep>();
+        services.AddScoped<IActivityProcessStep, EmitAppraisalCreationRequestedStep>();
         services.AddScoped<ProcessStepResolver>();
         services.AddScoped<IActivityProcessPipeline, ActivityProcessPipeline>();
+        services.AddScoped<AppraisalCreationTriggerEvaluator>();
 
         // Document followup services
         services.AddScoped<IDocumentFollowupGate, DocumentFollowupGate>();

--- a/Shared/Shared.Messaging/Events/AppraisalCreationRequestedIntegrationEvent.cs
+++ b/Shared/Shared.Messaging/Events/AppraisalCreationRequestedIntegrationEvent.cs
@@ -1,0 +1,27 @@
+using Request.Contracts.Requests.Dtos;
+
+namespace Shared.Messaging.Events;
+
+/// <summary>
+/// Published by the Workflow module when an appraisal should be created for a request.
+/// Consumed by the Appraisal module to trigger appraisal creation.
+/// The timing is table-driven: immediate for non-manual channels, deferred for manual.
+/// </summary>
+public record AppraisalCreationRequestedIntegrationEvent : IntegrationEvent
+{
+    public Guid RequestId { get; set; }
+    public List<RequestTitleDto> RequestTitles { get; set; } = default!;
+    public AppointmentDto? Appointment { get; set; }
+    public FeeDto? Fee { get; set; }
+    public ContactDto? Contact { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? Priority { get; set; }
+    public bool IsPma { get; set; }
+    public string? Purpose { get; set; }
+    public string? Channel { get; set; }
+    public string? BankingSegment { get; set; }
+    public decimal? FacilityLimit { get; set; }
+    public bool HasAppraisalBook { get; set; }
+    public string? RequestedBy { get; set; }
+    public DateTime? RequestedAt { get; set; }
+}

--- a/Tests/Unit/Workflow.Tests/EventHandlers/AppraisalCreatedIntegrationEventConsumerTests.cs
+++ b/Tests/Unit/Workflow.Tests/EventHandlers/AppraisalCreatedIntegrationEventConsumerTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using MassTransit;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Shared.Messaging.Events;
@@ -14,37 +15,30 @@ namespace Workflow.Tests.EventHandlers;
 
 public class AppraisalCreatedIntegrationEventConsumerTests
 {
-    private readonly IWorkflowInstanceRepository _instanceRepository;
-    private readonly IWorkflowUnitOfWork _unitOfWork;
-    private readonly AppraisalCreatedIntegrationEventConsumer _sut;
-
-    public AppraisalCreatedIntegrationEventConsumerTests()
-    {
-        var logger = Substitute.For<ILogger<AppraisalCreatedIntegrationEventConsumer>>();
-        _instanceRepository = Substitute.For<IWorkflowInstanceRepository>();
-        _unitOfWork = Substitute.For<IWorkflowUnitOfWork>();
-        var inboxGuard = Substitute.For<InboxGuard<WorkflowDbContext>>(
-            Substitute.For<WorkflowDbContext>(),
-            Substitute.For<ILogger<InboxGuard<WorkflowDbContext>>>());
-
-        // InboxGuard returns false (= proceed with processing)
-        inboxGuard.TryClaimAsync(Arg.Any<Guid?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(false);
-
-        _sut = new AppraisalCreatedIntegrationEventConsumer(
-            logger, _instanceRepository, _unitOfWork, inboxGuard);
-    }
+    private static WorkflowDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<WorkflowDbContext>()
+            .UseInMemoryDatabase($"ac-link-{Guid.NewGuid()}").Options);
 
     [Fact]
     public async Task Consume_WorkflowExists_SetsAppraisalIdInVariables()
     {
+        await using var db = NewDb();
+        var instanceRepository = Substitute.For<IWorkflowInstanceRepository>();
+        var unitOfWork = Substitute.For<IWorkflowUnitOfWork>();
+        var inboxGuard = new InboxGuard<WorkflowDbContext>(
+            db, Substitute.For<ILogger<InboxGuard<WorkflowDbContext>>>());
+
         var requestId = Guid.NewGuid();
         var appraisalId = Guid.NewGuid();
         var instance = WorkflowInstance.Create(
             Guid.NewGuid(), "test-workflow", requestId.ToString(), "system");
 
-        _instanceRepository.GetByCorrelationId(requestId.ToString(), Arg.Any<CancellationToken>())
+        instanceRepository.GetByCorrelationId(requestId.ToString(), Arg.Any<CancellationToken>())
             .Returns(instance);
+
+        var consumer = new AppraisalCreatedIntegrationEventConsumer(
+            Substitute.For<ILogger<AppraisalCreatedIntegrationEventConsumer>>(),
+            instanceRepository, unitOfWork, inboxGuard);
 
         var ctx = BuildContext(new AppraisalCreatedIntegrationEvent
         {
@@ -56,21 +50,31 @@ public class AppraisalCreatedIntegrationEventConsumerTests
             CreatedAt = DateTime.UtcNow
         });
 
-        await _sut.Consume(ctx);
+        await consumer.Consume(ctx);
 
         instance.Variables["appraisalId"].Should().Be(appraisalId);
         instance.Variables["appraisalNumber"].Should().Be("APR-001");
         instance.Variables["appraisalType"].Should().Be("Initial");
-        await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+        await unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task Consume_NoWorkflowFound_DoesNotThrow()
+    public async Task Consume_NoWorkflowFound_MarksProcessedAndDoesNotSave()
     {
+        await using var db = NewDb();
+        var instanceRepository = Substitute.For<IWorkflowInstanceRepository>();
+        var unitOfWork = Substitute.For<IWorkflowUnitOfWork>();
+        var inboxGuard = new InboxGuard<WorkflowDbContext>(
+            db, Substitute.For<ILogger<InboxGuard<WorkflowDbContext>>>());
+
         var requestId = Guid.NewGuid();
 
-        _instanceRepository.GetByCorrelationId(requestId.ToString(), Arg.Any<CancellationToken>())
+        instanceRepository.GetByCorrelationId(requestId.ToString(), Arg.Any<CancellationToken>())
             .Returns((WorkflowInstance?)null);
+
+        var consumer = new AppraisalCreatedIntegrationEventConsumer(
+            Substitute.For<ILogger<AppraisalCreatedIntegrationEventConsumer>>(),
+            instanceRepository, unitOfWork, inboxGuard);
 
         var ctx = BuildContext(new AppraisalCreatedIntegrationEvent
         {
@@ -80,9 +84,9 @@ public class AppraisalCreatedIntegrationEventConsumerTests
             CreatedAt = DateTime.UtcNow
         });
 
-        await _sut.Consume(ctx);
+        await consumer.Consume(ctx);
 
-        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+        await unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
     }
 
     // ── Helpers ──

--- a/Tests/Unit/Workflow.Tests/EventHandlers/AppraisalCreatedIntegrationEventConsumerTests.cs
+++ b/Tests/Unit/Workflow.Tests/EventHandlers/AppraisalCreatedIntegrationEventConsumerTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shared.Messaging.Events;
+using Shared.Messaging.Filters;
+using Workflow.Data;
+using Workflow.EventHandlers;
+using Workflow.Workflow.Models;
+using Workflow.Workflow.Repositories;
+using Xunit;
+
+namespace Workflow.Tests.EventHandlers;
+
+public class AppraisalCreatedIntegrationEventConsumerTests
+{
+    private readonly IWorkflowInstanceRepository _instanceRepository;
+    private readonly IWorkflowUnitOfWork _unitOfWork;
+    private readonly AppraisalCreatedIntegrationEventConsumer _sut;
+
+    public AppraisalCreatedIntegrationEventConsumerTests()
+    {
+        var logger = Substitute.For<ILogger<AppraisalCreatedIntegrationEventConsumer>>();
+        _instanceRepository = Substitute.For<IWorkflowInstanceRepository>();
+        _unitOfWork = Substitute.For<IWorkflowUnitOfWork>();
+        var inboxGuard = Substitute.For<InboxGuard<WorkflowDbContext>>(
+            Substitute.For<WorkflowDbContext>(),
+            Substitute.For<ILogger<InboxGuard<WorkflowDbContext>>>());
+
+        // InboxGuard returns false (= proceed with processing)
+        inboxGuard.TryClaimAsync(Arg.Any<Guid?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        _sut = new AppraisalCreatedIntegrationEventConsumer(
+            logger, _instanceRepository, _unitOfWork, inboxGuard);
+    }
+
+    [Fact]
+    public async Task Consume_WorkflowExists_SetsAppraisalIdInVariables()
+    {
+        var requestId = Guid.NewGuid();
+        var appraisalId = Guid.NewGuid();
+        var instance = WorkflowInstance.Create(
+            Guid.NewGuid(), "test-workflow", requestId.ToString(), "system");
+
+        _instanceRepository.GetByCorrelationId(requestId.ToString(), Arg.Any<CancellationToken>())
+            .Returns(instance);
+
+        var ctx = BuildContext(new AppraisalCreatedIntegrationEvent
+        {
+            AppraisalId = appraisalId,
+            RequestId = requestId,
+            AppraisalNumber = "APR-001",
+            AppraisalType = "Initial",
+            CreatedBy = "system",
+            CreatedAt = DateTime.UtcNow
+        });
+
+        await _sut.Consume(ctx);
+
+        instance.Variables["appraisalId"].Should().Be(appraisalId);
+        instance.Variables["appraisalNumber"].Should().Be("APR-001");
+        instance.Variables["appraisalType"].Should().Be("Initial");
+        await _unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Consume_NoWorkflowFound_DoesNotThrow()
+    {
+        var requestId = Guid.NewGuid();
+
+        _instanceRepository.GetByCorrelationId(requestId.ToString(), Arg.Any<CancellationToken>())
+            .Returns((WorkflowInstance?)null);
+
+        var ctx = BuildContext(new AppraisalCreatedIntegrationEvent
+        {
+            AppraisalId = Guid.NewGuid(),
+            RequestId = requestId,
+            CreatedBy = "system",
+            CreatedAt = DateTime.UtcNow
+        });
+
+        await _sut.Consume(ctx);
+
+        await _unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    // ── Helpers ──
+
+    private static ConsumeContext<AppraisalCreatedIntegrationEvent> BuildContext(
+        AppraisalCreatedIntegrationEvent message)
+    {
+        var ctx = Substitute.For<ConsumeContext<AppraisalCreatedIntegrationEvent>>();
+        ctx.Message.Returns(message);
+        ctx.MessageId.Returns(Guid.NewGuid());
+        ctx.CancellationToken.Returns(CancellationToken.None);
+        return ctx;
+    }
+}

--- a/Tests/Unit/Workflow.Tests/Workflow/Pipeline/AppraisalCreationTriggerEvaluatorTests.cs
+++ b/Tests/Unit/Workflow.Tests/Workflow/Pipeline/AppraisalCreationTriggerEvaluatorTests.cs
@@ -1,0 +1,181 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Workflow.Workflow.Engine.Expression;
+using Workflow.Workflow.Pipeline;
+using Xunit;
+
+namespace Workflow.Tests.Workflow.Pipeline;
+
+public class AppraisalCreationTriggerEvaluatorTests
+{
+    private readonly IExpressionEvaluator _expressionEvaluator;
+    private readonly ILogger<AppraisalCreationTriggerEvaluator> _logger;
+
+    public AppraisalCreationTriggerEvaluatorTests()
+    {
+        _expressionEvaluator = new ExpressionEvaluator();
+        _logger = Substitute.For<ILogger<AppraisalCreationTriggerEvaluator>>();
+    }
+
+    // ── EvaluateConfig: condition evaluation ──
+
+    [Fact]
+    public void EvaluateConfig_NullParameters_ReturnsTrue()
+    {
+        var evaluator = BuildEvaluator();
+        var variables = new Dictionary<string, object> { ["channel"] = "ONLINE" };
+
+        evaluator.EvaluateConfig(null, variables).Should().BeTrue();
+    }
+
+    [Fact]
+    public void EvaluateConfig_EmptyParameters_ReturnsTrue()
+    {
+        var evaluator = BuildEvaluator();
+        var variables = new Dictionary<string, object>();
+
+        evaluator.EvaluateConfig("", variables).Should().BeTrue();
+    }
+
+    [Fact]
+    public void EvaluateConfig_ConditionMatches_ReturnsTrue()
+    {
+        var evaluator = BuildEvaluator();
+        var variables = new Dictionary<string, object> { ["channel"] = "ONLINE" };
+
+        var result = evaluator.EvaluateConfig(
+            """{"condition": "channel != 'MANUAL'"}""", variables);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EvaluateConfig_ConditionDoesNotMatch_ReturnsFalse()
+    {
+        var evaluator = BuildEvaluator();
+        var variables = new Dictionary<string, object> { ["channel"] = "MANUAL" };
+
+        var result = evaluator.EvaluateConfig(
+            """{"condition": "channel != 'MANUAL'"}""", variables);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void EvaluateConfig_ManualConditionMatches_ReturnsTrue()
+    {
+        var evaluator = BuildEvaluator();
+        var variables = new Dictionary<string, object> { ["channel"] = "MANUAL" };
+
+        var result = evaluator.EvaluateConfig(
+            """{"condition": "channel == 'MANUAL'"}""", variables);
+
+        result.Should().BeTrue();
+    }
+
+    // ── EvaluateConfig: requireDecision ──
+
+    [Fact]
+    public void EvaluateConfig_RequireDecision_MatchingInput_ReturnsTrue()
+    {
+        var evaluator = BuildEvaluator();
+        var variables = new Dictionary<string, object> { ["channel"] = "MANUAL" };
+        var input = new Dictionary<string, object> { ["decisionTaken"] = "P" };
+
+        var result = evaluator.EvaluateConfig(
+            """{"condition": "channel == 'MANUAL'", "requireDecision": "P"}""",
+            variables, input);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EvaluateConfig_RequireDecision_NonMatchingInput_ReturnsFalse()
+    {
+        var evaluator = BuildEvaluator();
+        var variables = new Dictionary<string, object> { ["channel"] = "MANUAL" };
+        var input = new Dictionary<string, object> { ["decisionTaken"] = "R" };
+
+        var result = evaluator.EvaluateConfig(
+            """{"condition": "channel == 'MANUAL'", "requireDecision": "P"}""",
+            variables, input);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void EvaluateConfig_RequireDecision_NoInput_ReturnsFalse()
+    {
+        var evaluator = BuildEvaluator();
+        var variables = new Dictionary<string, object> { ["channel"] = "MANUAL" };
+
+        var result = evaluator.EvaluateConfig(
+            """{"condition": "channel == 'MANUAL'", "requireDecision": "P"}""",
+            variables, input: null);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void EvaluateConfig_RequireDecision_MissingDecisionField_ReturnsFalse()
+    {
+        var evaluator = BuildEvaluator();
+        var variables = new Dictionary<string, object> { ["channel"] = "MANUAL" };
+        var input = new Dictionary<string, object> { ["otherField"] = "P" };
+
+        var result = evaluator.EvaluateConfig(
+            """{"condition": "channel == 'MANUAL'", "requireDecision": "P"}""",
+            variables, input);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void EvaluateConfig_CustomDecisionField_UsesCorrectField()
+    {
+        var evaluator = BuildEvaluator();
+        var variables = new Dictionary<string, object> { ["channel"] = "MANUAL" };
+        var input = new Dictionary<string, object> { ["action"] = "APPROVE" };
+
+        var result = evaluator.EvaluateConfig(
+            """{"condition": "channel == 'MANUAL'", "requireDecision": "APPROVE", "decisionField": "action"}""",
+            variables, input);
+
+        result.Should().BeTrue();
+    }
+
+    // ── EvaluateConfig: invalid JSON ──
+
+    [Fact]
+    public void EvaluateConfig_InvalidJson_ReturnsFalse()
+    {
+        var evaluator = BuildEvaluator();
+        var variables = new Dictionary<string, object>();
+
+        var result = evaluator.EvaluateConfig("not json", variables);
+
+        result.Should().BeFalse();
+    }
+
+    // ── EvaluateConfig: no condition property ──
+
+    [Fact]
+    public void EvaluateConfig_NoConditionProperty_ReturnsTrue()
+    {
+        var evaluator = BuildEvaluator();
+        var variables = new Dictionary<string, object>();
+
+        var result = evaluator.EvaluateConfig("""{"someOtherProp": "value"}""", variables);
+
+        result.Should().BeTrue();
+    }
+
+    // ── Helpers ──
+
+    private AppraisalCreationTriggerEvaluator BuildEvaluator()
+    {
+        // Use a null dbContext since EvaluateConfig doesn't query the database
+        return new AppraisalCreationTriggerEvaluator(null!, _expressionEvaluator, _logger);
+    }
+}

--- a/Tests/Unit/Workflow.Tests/Workflow/Pipeline/EmitAppraisalCreationRequestedStepTests.cs
+++ b/Tests/Unit/Workflow.Tests/Workflow/Pipeline/EmitAppraisalCreationRequestedStepTests.cs
@@ -1,0 +1,196 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shared.Data.Outbox;
+using Shared.Messaging.Events;
+using Workflow.Workflow.Engine.Expression;
+using Workflow.Workflow.Pipeline;
+using Workflow.Workflow.Pipeline.Steps;
+using Xunit;
+
+namespace Workflow.Tests.Workflow.Pipeline;
+
+public class EmitAppraisalCreationRequestedStepTests
+{
+    private readonly IIntegrationEventOutbox _outbox;
+    private readonly AppraisalCreationTriggerEvaluator _triggerEvaluator;
+    private readonly ILogger<EmitAppraisalCreationRequestedStep> _logger;
+    private readonly EmitAppraisalCreationRequestedStep _sut;
+
+    public EmitAppraisalCreationRequestedStepTests()
+    {
+        _outbox = Substitute.For<IIntegrationEventOutbox>();
+        var expressionEvaluator = new ExpressionEvaluator();
+        var evaluatorLogger = Substitute.For<ILogger<AppraisalCreationTriggerEvaluator>>();
+        _triggerEvaluator = new AppraisalCreationTriggerEvaluator(null!, expressionEvaluator, evaluatorLogger);
+        _logger = Substitute.For<ILogger<EmitAppraisalCreationRequestedStep>>();
+        _sut = new EmitAppraisalCreationRequestedStep(_outbox, _triggerEvaluator, _logger);
+    }
+
+    [Fact]
+    public void Name_ShouldBeEmitAppraisalCreationRequested()
+    {
+        _sut.Name.Should().Be("EmitAppraisalCreationRequested");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AlreadyRequested_ReturnsOkWithoutPublishing()
+    {
+        var context = BuildContext(
+            variables: new Dictionary<string, object>
+            {
+                ["appraisalCreationRequested"] = true,
+                ["channel"] = "MANUAL"
+            },
+            parameters: """{"condition": "channel == 'MANUAL'", "requireDecision": "P"}""");
+
+        var result = await _sut.ExecuteAsync(context, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _outbox.DidNotReceive().Publish(
+            Arg.Any<AppraisalCreationRequestedIntegrationEvent>(),
+            Arg.Any<string>(), Arg.Any<Dictionary<string, string>?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingParameters_ReturnsFail()
+    {
+        var context = BuildContext(
+            variables: new Dictionary<string, object> { ["channel"] = "MANUAL" },
+            parameters: null);
+
+        var result = await _sut.ExecuteAsync(context, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().Contain("Missing step parameters");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ConditionNotMet_ReturnsOkWithoutPublishing()
+    {
+        var context = BuildContext(
+            variables: new Dictionary<string, object>
+            {
+                ["channel"] = "ONLINE",
+                ["requestSubmissionPayload"] = BuildSamplePayload()
+            },
+            parameters: """{"condition": "channel == 'MANUAL'"}""");
+
+        var result = await _sut.ExecuteAsync(context, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _outbox.DidNotReceive().Publish(
+            Arg.Any<AppraisalCreationRequestedIntegrationEvent>(),
+            Arg.Any<string>(), Arg.Any<Dictionary<string, string>?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RequireDecisionNotMet_ReturnsOkWithoutPublishing()
+    {
+        var context = BuildContext(
+            variables: new Dictionary<string, object>
+            {
+                ["channel"] = "MANUAL",
+                ["requestSubmissionPayload"] = BuildSamplePayload()
+            },
+            parameters: """{"condition": "channel == 'MANUAL'", "requireDecision": "P"}""",
+            input: new Dictionary<string, object> { ["decisionTaken"] = "R" });
+
+        var result = await _sut.ExecuteAsync(context, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _outbox.DidNotReceive().Publish(
+            Arg.Any<AppraisalCreationRequestedIntegrationEvent>(),
+            Arg.Any<string>(), Arg.Any<Dictionary<string, string>?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ConditionMet_PublishesEventAndSetsFlag()
+    {
+        var variables = new Dictionary<string, object>
+        {
+            ["channel"] = "MANUAL",
+            ["requestSubmissionPayload"] = BuildSamplePayload()
+        };
+
+        var context = BuildContext(
+            variables: variables,
+            parameters: """{"condition": "channel == 'MANUAL'", "requireDecision": "P"}""",
+            input: new Dictionary<string, object> { ["decisionTaken"] = "P" });
+
+        var result = await _sut.ExecuteAsync(context, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _outbox.Received(1).Publish(
+            Arg.Any<AppraisalCreationRequestedIntegrationEvent>(),
+            Arg.Any<string>(), Arg.Any<Dictionary<string, string>?>());
+        variables["appraisalCreationRequested"].Should().Be(true);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingPayload_ReturnsFail()
+    {
+        var context = BuildContext(
+            variables: new Dictionary<string, object> { ["channel"] = "ONLINE" },
+            parameters: """{"condition": "channel != 'MANUAL'"}""");
+
+        var result = await _sut.ExecuteAsync(context, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().Contain("Missing requestSubmissionPayload in workflow variables");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonManualChannel_ConditionMet_Publishes()
+    {
+        var variables = new Dictionary<string, object>
+        {
+            ["channel"] = "ONLINE",
+            ["requestSubmissionPayload"] = BuildSamplePayload()
+        };
+
+        var context = BuildContext(
+            variables: variables,
+            parameters: """{"condition": "channel != 'MANUAL'"}""");
+
+        var result = await _sut.ExecuteAsync(context, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _outbox.Received(1).Publish(
+            Arg.Any<AppraisalCreationRequestedIntegrationEvent>(),
+            Arg.Any<string>(), Arg.Any<Dictionary<string, string>?>());
+    }
+
+    // ── Helpers ──
+
+    private static ProcessStepContext BuildContext(
+        Dictionary<string, object> variables,
+        string? parameters,
+        Dictionary<string, object>? input = null) =>
+        new()
+        {
+            CorrelationId = Guid.NewGuid(),
+            AppraisalId = null,
+            WorkflowInstanceId = Guid.NewGuid(),
+            ActivityName = "appraisal-initiation-check",
+            CompletedBy = "test.user",
+            Input = input ?? new Dictionary<string, object>(),
+            Variables = variables,
+            Parameters = parameters
+        };
+
+    private static string BuildSamplePayload()
+    {
+        var evt = new RequestSubmittedIntegrationEvent
+        {
+            RequestId = Guid.NewGuid(),
+            RequestTitles = [],
+            CreatedBy = "test.user",
+            Priority = "Normal",
+            IsPma = false,
+            Channel = "MANUAL"
+        };
+        return JsonSerializer.Serialize(evt);
+    }
+}

--- a/Tests/Unit/Workflow.Tests/Workflow/Pipeline/ValidateTaskOwnershipStepTests.cs
+++ b/Tests/Unit/Workflow.Tests/Workflow/Pipeline/ValidateTaskOwnershipStepTests.cs
@@ -79,6 +79,7 @@ public class ValidateTaskOwnershipStepTests
 
         var ctx = new ProcessStepContext
         {
+            CorrelationId = appraisalId,
             AppraisalId = appraisalId,
             WorkflowInstanceId = workflowInstanceId,
             ActivityName = "int-appraisal-staff",
@@ -86,6 +87,7 @@ public class ValidateTaskOwnershipStepTests
             Input = new Dictionary<string, object> { ["key"] = "value" }
         };
 
+        ctx.CorrelationId.Should().Be(appraisalId);
         ctx.AppraisalId.Should().Be(appraisalId);
         ctx.WorkflowInstanceId.Should().Be(workflowInstanceId);
         ctx.ActivityName.Should().Be("int-appraisal-staff");
@@ -194,10 +196,11 @@ public class ValidateTaskOwnershipStepTests
 
     // ── Helpers ──
 
-    private static ProcessStepContext BuildContext(Guid appraisalId) =>
+    private static ProcessStepContext BuildContext(Guid correlationId) =>
         new()
         {
-            AppraisalId = appraisalId,
+            CorrelationId = correlationId,
+            AppraisalId = correlationId,
             WorkflowInstanceId = Guid.NewGuid(),
             ActivityName = "int-appraisal-staff",
             CompletedBy = "john.doe",


### PR DESCRIPTION
This pull request introduces a major refactor and redesign of the workflow and appraisal integration, enabling table-driven, channel-dependent triggering of appraisal creation. It separates workflow instance creation (correlated by `requestId`) from appraisal creation (which may be immediate or deferred), and ensures robust linkage and variable propagation between workflow and appraisal entities. The changes also improve idempotency, error handling, and configurability.

The most important changes are:

### Workflow/Appraisal Event Handling Redesign

* Introduced a new `RequestSubmittedIntegrationEventConsumer` that starts a workflow instance for each request and conditionally triggers appraisal creation based on table-driven configuration (immediate for non-manual channels, deferred for manual channels) (`RequestSubmittedIntegrationEventConsumer.cs`).
* Refactored the appraisal creation event handler to consume the new `AppraisalCreationRequestedIntegrationEvent`, reflecting the new event-driven, channel-aware design (`AppraisalCreationRequestedIntegrationEventHandler.cs`, renamed and updated). [[1]](diffhunk://#diff-30ecbef62032e1eb95b379e78e6501b5b5cc853738d8e6daf079f8f754d195c2L9-R23) [[2]](diffhunk://#diff-30ecbef62032e1eb95b379e78e6501b5b5cc853738d8e6daf079f8f754d195c2L47-L57)

### Table-driven Appraisal Creation Trigger

* Added seed data and a migration to configure immediate or deferred appraisal creation triggers in `ActivityProcessConfiguration`, based on the request channel (`ActivityProcessConfigurationSeeder.cs`, `20260410120000_SeedAppraisalCreationTriggerSteps.cs`). [[1]](diffhunk://#diff-0dcaacbce67a9329378af6c8c4089a63b1d5289bb3a31c3b5d03fe0b600e0321R63-R80) [[2]](diffhunk://#diff-2eeb1c0cb599494490df0281669a2a57b491b11a68f93d2f3cbaa68748fc5654R1-R56)

### Workflow/Appraisal Linking and Variable Management

* Changed the `AppraisalCreatedIntegrationEventConsumer` to link `appraisalId` to the correct workflow instance (found by `requestId`), and update workflow variables accordingly, instead of starting a new workflow per appraisal (`AppraisalCreatedIntegrationEventConsumer.cs`). [[1]](diffhunk://#diff-458283bab99621cfee036db67db3673f4ae5ec47e184336311c4c77dbf020221L5-L17) [[2]](diffhunk://#diff-458283bab99621cfee036db67db3673f4ae5ec47e184336311c4c77dbf020221L33-R66)
* Fixed variable assignment and clarified the use of `requestId` and `appraisalId` in document followup and reporting logic, ensuring consistent correlation throughout the workflow (`RaiseDocumentFollowupCommandHandler.cs`, SQL view updates). [[1]](diffhunk://#diff-6831dd28ca5a757b247c2e40d128e99723b33518574d8102f0d09bbe336d3e30L44-R44) [[2]](diffhunk://#diff-6831dd28ca5a757b247c2e40d128e99723b33518574d8102f0d09bbe336d3e30L61-R62) [[3]](diffhunk://#diff-d749fd6a53ca1d65c42d2d9d4131757f2ce3b13d2d41838339304486bfa5b30dL21-R21) [[4]](diffhunk://#diff-3aae26744d240dcac21ff0a988b0fb70bd933a3e0fee99194b17cb743b7ca2b3L33-R33) [[5]](diffhunk://#diff-79bc4f782fe90b009b4c2239e40d6a29da2676b0a91bd60933c64839826a0599L34-R39)

### API and Data Contract Improvements

* Made `AppraisalId` nullable in `TaskDetailResult` to reflect that not all tasks are guaranteed to have an appraisal at creation time (`GetTaskByIdQuery.cs`).

These changes collectively enable more flexible, maintainable, and auditable workflow/appraisal orchestration, with clear separation of concerns and improved support for different business channels.