### PR TITLE
fix(income): orphan removal deletes newly-added sections on save

### DIFF
--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveIncomeAnalysis/SaveIncomeAnalysisCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveIncomeAnalysis/SaveIncomeAnalysisCommandHandler.cs
@@ -188,8 +188,11 @@ public class SaveIncomeAnalysisCommandHandler(
             allAssumptionPairs.AddRange(asmPairs);
         }
 
-        foreach (var orphan in analysis.Sections.Where(s => !processedIds.Contains(s.Id)).ToList())
-            analysis.RemoveSection(orphan);
+        // Only remove sections that existed BEFORE this sync started and were not matched.
+        // Newly-added sections (Id = Guid.Empty) are not in existingById, so they're safe.
+        foreach (var (id, section) in existingById)
+            if (!processedIds.Contains(id))
+                analysis.RemoveSection(section);
 
         return (sectionPairs, allCategoryPairs, allAssumptionPairs);
     }
@@ -229,8 +232,10 @@ public class SaveIncomeAnalysisCommandHandler(
             allAssumptionPairs.AddRange(asmPairs);
         }
 
-        foreach (var orphan in section.Categories.Where(c => !processedIds.Contains(c.Id)).ToList())
-            section.RemoveCategory(orphan);
+        // Only remove categories that existed BEFORE this sync started.
+        foreach (var (id, category) in existingById)
+            if (!processedIds.Contains(id))
+                section.RemoveCategory(category);
 
         return (categoryPairs, allAssumptionPairs);
     }
@@ -265,8 +270,10 @@ public class SaveIncomeAnalysisCommandHandler(
             pairs.Add((aInput, assumption));
         }
 
-        foreach (var orphan in category.Assumptions.Where(a => !processedIds.Contains(a.Id)).ToList())
-            category.RemoveAssumption(orphan);
+        // Only remove assumptions that existed BEFORE this sync started.
+        foreach (var (id, assumption) in existingById)
+            if (!processedIds.Contains(id))
+                category.RemoveAssumption(assumption);
 
         return pairs;
     }


### PR DESCRIPTION
## Summary
- **Bug**: `SyncSections`/`SyncCategories`/`SyncAssumptions` orphan removal iterated the full live collection (including just-added entities) but `processedIds` only tracked UPDATE'd entities. On first save, every section was treated as an orphan and immediately removed → response returned `sections: []`.
- **Fix**: Changed orphan removal to iterate `existingById` (snapshot of entities that existed before sync started) instead of the live collection. Newly-added entities are never in `existingById`, so they're never considered for removal.
- All 20 existing tests pass, 0 build errors.

## Test plan
- [ ] First save: Generate DCF-Hotel → Save → response includes all sections with categories/assumptions
- [ ] Re-save: Edit a value → Save again → sections preserved, IDs stable
- [ ] Add new assumption → Save → existing IDs unchanged, new row appears
- [ ] Remove assumption → Save → removed row gone, others preserved
- [ ] Reload page → income/expense sections render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)