### PR TITLE
feat(appraisal): list filters, export, saved searches + committee-approval event

### DIFF
--- a/Database/Scripts/Views/Appraisal/vw_AppraisalDetail.sql
+++ b/Database/Scripts/Views/Appraisal/vw_AppraisalDetail.sql
@@ -4,7 +4,14 @@ VIEW appraisal.vw_AppraisalDetail AS
 SELECT a.Id,
        a.AppraisalNumber,
        a.RequestId,
-       a.Status,
+       -- Derive status: CompletedAt trumps all; then workflow activity; fallback to stored status
+       CASE
+           WHEN a.CompletedAt IS NOT NULL THEN 'Completed'
+           WHEN wpt.ActivityId IN ('appraisal-initiation-check', 'appraisal-assignment') THEN 'Pending'
+           WHEN wpt.ActivityId IN ('appraisal-book-verification', 'int-appraisal-check', 'int-appraisal-verification', 'pending-approval') THEN 'UnderReview'
+           WHEN wpt.ActivityId IS NOT NULL THEN 'InProgress'
+           ELSE a.Status
+       END AS Status,
        a.AppraisalType,
        a.Priority,
        a.SLADays,
@@ -20,3 +27,7 @@ SELECT a.Id,
        a.UpdatedAt,
        a.UpdatedBy
 FROM appraisal.Appraisals a
+         OUTER APPLY (SELECT TOP 1 pt.ActivityId
+                      FROM workflow.PendingTasks pt
+                      WHERE pt.CorrelationId = a.RequestId
+                      ORDER BY pt.AssignedAt DESC) wpt

--- a/Database/Scripts/Views/Appraisal/vw_AppraisalList.sql
+++ b/Database/Scripts/Views/Appraisal/vw_AppraisalList.sql
@@ -4,28 +4,83 @@ VIEW appraisal.vw_AppraisalList AS
 SELECT a.Id,
        a.AppraisalNumber,
        a.RequestId,
-       a.Status,
+       r.RequestNumber,
+       -- Derive status: CompletedAt trumps all; then workflow activity; fallback to stored status
+       CASE
+           WHEN a.CompletedAt IS NOT NULL THEN 'Completed'
+           WHEN wpt.ActivityId IN ('appraisal-initiation-check', 'appraisal-assignment') THEN 'Pending'
+           WHEN wpt.ActivityId IN ('appraisal-book-verification', 'int-appraisal-check', 'int-appraisal-verification', 'pending-approval') THEN 'UnderReview'
+           WHEN wpt.ActivityId IS NOT NULL THEN 'InProgress'
+           ELSE a.Status
+       END AS Status,
        a.AppraisalType,
        a.Priority,
+       a.IsPma,
+       a.Purpose,
+       a.Channel,
+       a.BankingSegment,
+       a.FacilityLimit,
+       a.RequestedBy,
+       a.RequestedAt,
        a.SLADays,
        a.SLADueDate,
        a.SLAStatus,
        a.CreatedAt,
        (SELECT COUNT(*) FROM appraisal.AppraisalProperties ap WHERE ap.AppraisalId = a.Id) AS PropertyCount,
+       -- Latest active assignment info
        la.AssigneeUserId,
+       la.AssigneeCompanyId,
+       la.AssignmentType,
        la.AssignmentStatus,
        la.AssignedAt                                                                       AS AssignedDate,
-       ld.Province
+       -- Company name for external assignments
+       comp.Name                                                                           AS CompanyName,
+       -- Customer name from request
+       c.Name                                                                              AS CustomerName,
+       -- First property location
+       ld.Province,
+       ld.District,
+       -- Latest appointment
+       apt.AppointmentDateTime,
+       -- SLA computed fields
+       DATEDIFF(HOUR, a.CreatedAt, GETUTCDATE())                                           AS ElapsedHours,
+       CASE
+           WHEN a.SLADueDate IS NOT NULL
+               THEN DATEDIFF(HOUR, GETUTCDATE(), a.SLADueDate)
+           END                                                                             AS RemainingHours
 FROM appraisal.Appraisals a
-         LEFT JOIN (SELECT aa.AppraisalId,
+         LEFT JOIN request.Requests r ON r.Id = a.RequestId
+         OUTER APPLY (SELECT TOP 1 Name
+                      FROM request.RequestCustomers
+                      WHERE RequestId = a.RequestId) c
+         LEFT JOIN (SELECT aa.Id,
+                           aa.AppraisalId,
                            aa.AssigneeUserId,
+                           aa.AssigneeCompanyId,
+                           aa.AssignmentType,
                            aa.AssignmentStatus,
                            aa.AssignedAt,
                            ROW_NUMBER() OVER (PARTITION BY aa.AppraisalId ORDER BY aa.AssignedAt DESC) AS rn
-                    FROM appraisal.AppraisalAssignments aa) la ON la.AppraisalId = a.Id AND la.rn = 1
+                    FROM appraisal.AppraisalAssignments aa
+                    WHERE aa.AssignmentStatus NOT IN ('Rejected', 'Cancelled')) la
+                   ON la.AppraisalId = a.Id AND la.rn = 1
+         LEFT JOIN auth.Companies comp
+                   ON comp.Id = TRY_CAST(la.AssigneeCompanyId AS uniqueidentifier)
          LEFT JOIN (SELECT ap2.AppraisalId,
                            lad.Province,
+                           lad.District,
                            ROW_NUMBER() OVER (PARTITION BY ap2.AppraisalId ORDER BY ap2.SequenceNumber) AS rn
                     FROM appraisal.AppraisalProperties ap2
                              JOIN appraisal.LandAppraisalDetails lad ON lad.AppraisalPropertyId = ap2.Id
                     WHERE lad.Province IS NOT NULL) ld ON ld.AppraisalId = a.Id AND ld.rn = 1
+         OUTER APPLY (SELECT TOP 1 AppointmentDateTime
+                      FROM appraisal.Appointments
+                      WHERE AssignmentId = la.Id
+                        AND Status != 'Cancelled'
+                      ORDER BY AppointmentDateTime DESC) apt
+         -- Current workflow activity for status derivation
+         OUTER APPLY (SELECT TOP 1 pt.ActivityId
+                      FROM workflow.PendingTasks pt
+                      WHERE pt.CorrelationId = a.RequestId
+                      ORDER BY pt.AssignedAt DESC) wpt
+WHERE a.IsDeleted = 0

--- a/Database/Scripts/Views/Common/vw_DailyAppraisalCountsFromSource.sql
+++ b/Database/Scripts/Views/Common/vw_DailyAppraisalCountsFromSource.sql
@@ -6,13 +6,8 @@ VIEW common.vw_DailyAppraisalCountsFromSource AS
  * Used by POST /dashboard/reconcile-appraisal-counts to correct drift in
  * the event-sourced common.DailyAppraisalCounts read-model.
  *
- * CreatedCount  — appraisals created on each calendar day.
- * CompletedCount — appraisals whose Status = 'Completed' and UpdatedAt falls on
- *                  that day.  appraisal.Appraisals has no dedicated CompletedAt
- *                  column; UpdatedAt is the best available proxy.
- *
- * TODO: add a CompletedAt column to appraisal.Appraisals and update this view
- *       to use it for an exact completion date.
+ * CreatedCount   — appraisals created on each calendar day.
+ * CompletedCount — appraisals whose CompletedAt falls on that day.
  */
 SELECT
     d.Date,
@@ -22,7 +17,7 @@ FROM (
     -- Union of all distinct dates from both created and completed events
     SELECT CAST(a.CreatedAt AS DATE) AS Date FROM appraisal.Appraisals a WHERE a.IsDeleted = 0
     UNION
-    SELECT CAST(a.UpdatedAt AS DATE) AS Date FROM appraisal.Appraisals a WHERE a.IsDeleted = 0 AND a.Status = 'Completed' AND a.UpdatedAt IS NOT NULL
+    SELECT CAST(a.CompletedAt AS DATE) AS Date FROM appraisal.Appraisals a WHERE a.IsDeleted = 0 AND a.CompletedAt IS NOT NULL
 ) d
 LEFT JOIN (
     SELECT
@@ -33,13 +28,11 @@ LEFT JOIN (
     GROUP BY CAST(a.CreatedAt AS DATE)
 ) c ON c.Date = d.Date
 LEFT JOIN (
-    -- Approximate completion date via UpdatedAt where Status = 'Completed'.
     SELECT
-        CAST(a.UpdatedAt AS DATE) AS Date,
-        COUNT(*)                   AS CompletedCount
+        CAST(a.CompletedAt AS DATE) AS Date,
+        COUNT(*)                    AS CompletedCount
     FROM appraisal.Appraisals a
     WHERE a.IsDeleted = 0
-      AND a.Status = 'Completed'
-      AND a.UpdatedAt IS NOT NULL
-    GROUP BY CAST(a.UpdatedAt AS DATE)
+      AND a.CompletedAt IS NOT NULL
+    GROUP BY CAST(a.CompletedAt AS DATE)
 ) x ON x.Date = d.Date;

--- a/Database/Scripts/Views/Workflow/vw_TaskList.sql
+++ b/Database/Scripts/Views/Workflow/vw_TaskList.sql
@@ -14,10 +14,18 @@ SELECT pt.Id                                                                    
        pt.TaskDescription,
        r.Purpose,
        p.PropertyType                                                                     AS PropertyType,
-       COALESCE(a.Status, r.Status)                                                       AS Status,
+       -- Derive appraisal status: CompletedAt trumps all; then workflow activity; fallback to request status
+       CASE
+           WHEN a.CompletedAt IS NOT NULL THEN 'Completed'
+           WHEN pt.ActivityId IN ('appraisal-initiation-check', 'appraisal-assignment') THEN 'Pending'
+           WHEN pt.ActivityId IN ('appraisal-book-verification', 'int-appraisal-check', 'int-appraisal-verification', 'pending-approval') THEN 'UnderReview'
+           WHEN a.Id IS NOT NULL THEN 'InProgress'
+           ELSE r.Status
+       END AS Status,
        pt.TaskStatus                                                                      AS PendingTaskStatus,
        ap.AppointmentDateTime,
        pt.AssignedTo                                                                      AS AssigneeUserId,
+       pt.AssignedType                                                                    AS AssignedType,
        COALESCE(a.RequestedBy, r.Requestor)                                               AS RequestedBy,
        COALESCE(CONCAT(u.FirstName, ' ', u.LastName), ISNULL(a.RequestedBy, r.Requestor)) AS RequestedByName,
        COALESCE(a.RequestedAt, r.RequestedAt)                                             AS RequestReceivedDate,

--- a/Modules/Appraisal/Appraisal/Application/EventHandlers/AppraisalApprovedByCommitteeIntegrationEventHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/EventHandlers/AppraisalApprovedByCommitteeIntegrationEventHandler.cs
@@ -1,0 +1,63 @@
+using Appraisal.Domain.Appraisals;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using Shared.Messaging.Events;
+
+namespace Appraisal.Application.EventHandlers;
+
+/// <summary>
+/// Handles AppraisalApprovedByCommitteeIntegrationEvent by stamping CompletedAt and
+/// ApprovedByCommittee on the Appraisal aggregate.
+/// Published by the Workflow module's EmitAppraisalApprovedByCommitteeStep pipeline step
+/// when pending-approval completes with decision == "approve".
+/// </summary>
+public class AppraisalApprovedByCommitteeIntegrationEventHandler(
+    ILogger<AppraisalApprovedByCommitteeIntegrationEventHandler> logger,
+    IAppraisalRepository appraisalRepository,
+    IAppraisalUnitOfWork unitOfWork)
+    : IConsumer<AppraisalApprovedByCommitteeIntegrationEvent>
+{
+    public async Task Consume(ConsumeContext<AppraisalApprovedByCommitteeIntegrationEvent> context)
+    {
+        var message = context.Message;
+
+        logger.LogInformation(
+            "Integration Event received: {IntegrationEvent} for AppraisalId: {AppraisalId} CommitteeCode: {CommitteeCode}",
+            nameof(AppraisalApprovedByCommitteeIntegrationEvent),
+            message.AppraisalId,
+            message.CommitteeCode);
+
+        try
+        {
+            var appraisal = await appraisalRepository.GetByIdWithAllDataAsync(
+                message.AppraisalId, context.CancellationToken);
+
+            if (appraisal is null)
+            {
+                logger.LogWarning(
+                    "Appraisal {AppraisalId} not found when handling {IntegrationEvent}",
+                    message.AppraisalId,
+                    nameof(AppraisalApprovedByCommitteeIntegrationEvent));
+                return;
+            }
+
+            appraisal.MarkApprovedByCommittee(message.CommitteeCode, message.ApprovedAt);
+
+            await unitOfWork.SaveChangesAsync(context.CancellationToken);
+
+            logger.LogInformation(
+                "Successfully stamped committee approval for AppraisalId {AppraisalId} CommitteeCode {CommitteeCode}",
+                message.AppraisalId,
+                message.CommitteeCode);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Error processing {IntegrationEvent} for AppraisalId: {AppraisalId}",
+                nameof(AppraisalApprovedByCommitteeIntegrationEvent),
+                message.AppraisalId);
+
+            throw;
+        }
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/ExportAppraisals/ExportAppraisalsEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/ExportAppraisals/ExportAppraisalsEndpoint.cs
@@ -1,20 +1,19 @@
+using Appraisal.Application.Features.Appraisals.GetAppraisals;
 using Carter;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using Shared.Pagination;
 
-namespace Appraisal.Application.Features.Appraisals.GetAppraisals;
+namespace Appraisal.Application.Features.Appraisals.ExportAppraisals;
 
-public class GetAppraisalsEndpoint : ICarterModule
+public class ExportAppraisalsEndpoint : ICarterModule
 {
     public void AddRoutes(IEndpointRouteBuilder app)
     {
         app.MapGet(
-                "/appraisals",
+                "/appraisals/export",
                 async (
-                    [AsParameters] PaginationRequest pagination,
                     // Text search
                     [FromQuery] string? search,
                     // Multi-value filters
@@ -23,7 +22,7 @@ public class GetAppraisalsEndpoint : ICarterModule
                     [FromQuery] string? appraisalType,
                     [FromQuery] string? slaStatus,
                     [FromQuery] string? assignmentType,
-                    // Assignment (username like "P5229", not GUID)
+                    // Assignment (username like "P5229")
                     [FromQuery] string? assigneeUserId,
                     [FromQuery] string? assigneeCompanyId,
                     // Request metadata
@@ -45,6 +44,8 @@ public class GetAppraisalsEndpoint : ICarterModule
                     // Sorting
                     [FromQuery] string? sortBy,
                     [FromQuery] string? sortDir,
+                    // Export format: "xlsx" (default) or "csv"
+                    [FromQuery] string? format,
                     ISender sender,
                     CancellationToken cancellationToken
                 ) =>
@@ -75,22 +76,19 @@ public class GetAppraisalsEndpoint : ICarterModule
                         SortDir: sortDir
                     );
 
-                    var query = new GetAppraisalsQuery(pagination, filter);
-
+                    var query = new ExportAppraisalsQuery(filter, format ?? "xlsx");
                     var result = await sender.Send(query, cancellationToken);
 
-                    return Results.Ok(new GetAppraisalsResponse(result.Result, result.Facets));
+                    return Results.File(result.FileBytes, result.ContentType, result.FileName);
                 }
             )
-            .WithName("GetAppraisals")
-            .Produces<GetAppraisalsResponse>()
-            .ProducesProblem(StatusCodes.Status404NotFound)
-            .WithSummary("Get all appraisals")
+            .WithName("ExportAppraisals")
+            .Produces(StatusCodes.Status200OK)
+            .WithSummary("Export appraisals to file")
             .WithDescription(
-                "Retrieves all appraisals with pagination, filtering, sorting, and facet counts. " +
-                "Supports text search (search), multi-value filters (comma-separated status, priority, appraisalType, slaStatus, assignmentType), " +
-                "date ranges (createdFrom/To, slaDueDateFrom/To, assignedDateFrom/To, appointmentDateFrom/To), " +
-                "geographic filters (province, district), and sorting (sortBy, sortDir).")
+                "Exports all matching appraisals (up to 10,000 rows) as a file download. " +
+                "Accepts the same filter parameters as GET /appraisals. " +
+                "Use format=xlsx (default) for Excel or format=csv for CSV with UTF-8 BOM.")
             .WithTags("Appraisal");
     }
 }

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/ExportAppraisals/ExportAppraisalsQuery.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/ExportAppraisals/ExportAppraisalsQuery.cs
@@ -1,0 +1,21 @@
+using Appraisal.Application.Features.Appraisals.GetAppraisals;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.Appraisals.ExportAppraisals;
+
+/// <summary>
+/// Query to export all matching appraisals as a file download (no pagination, max 10,000 rows).
+/// </summary>
+public record ExportAppraisalsQuery(
+    GetAppraisalsFilterRequest? Filter,
+    string Format // "xlsx" (default) or "csv"
+) : IQuery<ExportAppraisalsResult>;
+
+/// <summary>
+/// Result carrying the raw file bytes, MIME type, and suggested file name.
+/// </summary>
+public record ExportAppraisalsResult(
+    byte[] FileBytes,
+    string ContentType,
+    string FileName
+);

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/ExportAppraisals/ExportAppraisalsQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/ExportAppraisals/ExportAppraisalsQueryHandler.cs
@@ -1,0 +1,125 @@
+using System.Text;
+using Appraisal.Application.Features.Appraisals.GetAppraisals;
+using ClosedXML.Excel;
+using Dapper;
+using Shared.CQRS;
+using Shared.Data;
+
+namespace Appraisal.Application.Features.Appraisals.ExportAppraisals;
+
+/// <summary>
+/// Handles export of appraisals to XLSX or CSV.
+/// Applies the same filters as the list query but returns ALL matching rows (up to MaxExportRows).
+/// </summary>
+public class ExportAppraisalsQueryHandler(
+    ISqlConnectionFactory connectionFactory
+) : IQueryHandler<ExportAppraisalsQuery, ExportAppraisalsResult>
+{
+    private const int MaxExportRows = 10_000;
+
+    public async Task<ExportAppraisalsResult> Handle(
+        ExportAppraisalsQuery query,
+        CancellationToken cancellationToken)
+    {
+        var (whereClause, parameters) = AppraisalFilterBuilder.BuildFilter(query.Filter);
+        var orderBy = AppraisalFilterBuilder.BuildOrderBy(query.Filter);
+
+        var sql = $"SELECT TOP({MaxExportRows}) * FROM appraisal.vw_AppraisalList{whereClause} ORDER BY {orderBy}";
+
+        using var connection = connectionFactory.GetOpenConnection();
+        var rows = await connection.QueryAsync<AppraisalDto>(sql, parameters);
+        var rowList = rows.ToList();
+
+        byte[] fileBytes;
+        string contentType;
+        string fileName;
+        var timestamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
+
+        if (string.Equals(query.Format, "csv", StringComparison.OrdinalIgnoreCase))
+        {
+            fileBytes = GenerateCsv(rowList);
+            contentType = "text/csv";
+            fileName = $"appraisals-{timestamp}.csv";
+        }
+        else
+        {
+            fileBytes = GenerateExcel(rowList);
+            contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+            fileName = $"appraisals-{timestamp}.xlsx";
+        }
+
+        return new ExportAppraisalsResult(fileBytes, contentType, fileName);
+    }
+
+    private static byte[] GenerateExcel(List<AppraisalDto> rows)
+    {
+        using var workbook = new XLWorkbook();
+        var ws = workbook.Worksheets.Add("Appraisals");
+
+        // Headers
+        var headers = new[]
+        {
+            "Appraisal Number", "Request Number", "Customer", "Status", "Type", "Priority",
+            "Province", "District", "SLA Status", "SLA Due Date", "Assignment Type",
+            "Company", "Created At", "Facility Limit", "Property Count"
+        };
+        for (var i = 0; i < headers.Length; i++)
+            ws.Cell(1, i + 1).Value = headers[i];
+
+        // Style header row
+        var headerRow = ws.Row(1);
+        headerRow.Style.Font.Bold = true;
+        headerRow.Style.Fill.BackgroundColor = XLColor.LightGray;
+
+        // Data rows
+        var row = 2;
+        foreach (var item in rows)
+        {
+            ws.Cell(row, 1).Value = item.AppraisalNumber ?? "";
+            ws.Cell(row, 2).Value = item.RequestNumber ?? "";
+            ws.Cell(row, 3).Value = item.CustomerName ?? "";
+            ws.Cell(row, 4).Value = item.Status;
+            ws.Cell(row, 5).Value = item.AppraisalType;
+            ws.Cell(row, 6).Value = item.Priority;
+            ws.Cell(row, 7).Value = item.Province ?? "";
+            ws.Cell(row, 8).Value = item.District ?? "";
+            ws.Cell(row, 9).Value = item.SLAStatus ?? "";
+            ws.Cell(row, 10).SetValue(item.SLADueDate);
+            ws.Cell(row, 11).Value = item.AssignmentType ?? "";
+            ws.Cell(row, 12).Value = item.CompanyName ?? "";
+            ws.Cell(row, 13).SetValue(item.CreatedAt);
+            ws.Cell(row, 14).SetValue(item.FacilityLimit ?? 0);
+            ws.Cell(row, 15).Value = item.PropertyCount;
+            row++;
+        }
+
+        ws.Columns().AdjustToContents();
+
+        using var ms = new MemoryStream();
+        workbook.SaveAs(ms);
+        return ms.ToArray();
+    }
+
+    private static byte[] GenerateCsv(List<AppraisalDto> rows)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(
+            "Appraisal Number,Request Number,Customer,Status,Type,Priority,Province,District,SLA Status,SLA Due Date,Assignment Type,Company,Created At,Facility Limit,Property Count");
+
+        foreach (var item in rows)
+        {
+            sb.AppendLine(
+                $"\"{Esc(item.AppraisalNumber)}\",\"{Esc(item.RequestNumber)}\",\"{Esc(item.CustomerName)}\"," +
+                $"\"{item.Status}\",\"{item.AppraisalType}\",\"{item.Priority}\"," +
+                $"\"{Esc(item.Province)}\",\"{Esc(item.District)}\",\"{item.SLAStatus}\"," +
+                $"\"{item.SLADueDate:yyyy-MM-dd}\",\"{item.AssignmentType}\"," +
+                $"\"{Esc(item.CompanyName)}\",\"{item.CreatedAt:yyyy-MM-dd HH:mm}\"," +
+                $"{item.FacilityLimit ?? 0},{item.PropertyCount}");
+        }
+
+        // UTF-8 BOM ensures Excel opens the file with correct encoding
+        return Encoding.UTF8.GetPreamble().Concat(Encoding.UTF8.GetBytes(sb.ToString())).ToArray();
+    }
+
+    private static string Esc(string? value) => (value ?? "").Replace("\"", "\"\"");
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalViews/GetAppraisalViewsEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalViews/GetAppraisalViewsEndpoint.cs
@@ -1,0 +1,30 @@
+using Carter;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Appraisal.Application.Features.Appraisals.GetAppraisalViews;
+
+public class GetAppraisalViewsEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet(
+                "/appraisals/views",
+                async (ISender sender, CancellationToken cancellationToken) =>
+                {
+                    var result = await sender.Send(new GetAppraisalViewsQuery(), cancellationToken);
+                    return Results.Ok(result);
+                }
+            )
+            .WithName("GetAppraisalViews")
+            .Produces<GetAppraisalViewsResult>()
+            .WithSummary("Get smart view presets")
+            .WithDescription(
+                "Returns pre-built filter combinations for the appraisals list. " +
+                "Each view's Filters dictionary contains query parameter names that can be " +
+                "applied directly to GET /appraisals. User-specific views (My Assignments, " +
+                "My Company Queue) populate filter values from the current user's identity claims.")
+            .WithTags("Appraisal");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalViews/GetAppraisalViewsQuery.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalViews/GetAppraisalViewsQuery.cs
@@ -1,0 +1,9 @@
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.Appraisals.GetAppraisalViews;
+
+/// <summary>
+/// Query to get smart view presets for the appraisals list.
+/// Returns pre-built filter combinations that clients can apply directly to GET /appraisals.
+/// </summary>
+public record GetAppraisalViewsQuery() : IQuery<GetAppraisalViewsResult>;

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalViews/GetAppraisalViewsQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalViews/GetAppraisalViewsQueryHandler.cs
@@ -1,0 +1,121 @@
+using Shared.CQRS;
+using Shared.Identity;
+
+namespace Appraisal.Application.Features.Appraisals.GetAppraisalViews;
+
+/// <summary>
+/// Builds the smart view presets list in memory.
+/// No database access — filter values are either static strings or derived from the current user context.
+/// </summary>
+public class GetAppraisalViewsQueryHandler(
+    ICurrentUserService currentUserService
+) : IQueryHandler<GetAppraisalViewsQuery, GetAppraisalViewsResult>
+{
+    public Task<GetAppraisalViewsResult> Handle(
+        GetAppraisalViewsQuery query,
+        CancellationToken cancellationToken)
+    {
+        var today = DateTime.UtcNow.Date;
+        var todayStr = today.ToString("yyyy-MM-dd");
+        var plusThreeDays = today.AddDays(3).ToString("yyyy-MM-dd");
+
+        var activeStatuses = "Pending,Assigned,InProgress,UnderReview";
+
+        var views = new List<SmartViewDto>
+        {
+            BuildMyAssignments(currentUserService.Username),
+            new(
+                Key: "sla-at-risk",
+                Name: "SLA At Risk",
+                Description: "Active appraisals where the SLA is at risk or already breached",
+                Filters: new Dictionary<string, string>
+                {
+                    ["slaStatus"] = "AtRisk,Breached",
+                    ["status"] = activeStatuses
+                }
+            ),
+            new(
+                Key: "todays-appointments",
+                Name: "Today's Appointments",
+                Description: "Appraisals with a site visit scheduled for today",
+                Filters: new Dictionary<string, string>
+                {
+                    ["appointmentDateFrom"] = todayStr,
+                    ["appointmentDateTo"] = todayStr
+                }
+            ),
+            new(
+                Key: "unassigned",
+                Name: "Unassigned",
+                Description: "Appraisals that have not yet been assigned",
+                Filters: new Dictionary<string, string>
+                {
+                    ["status"] = "Pending"
+                }
+            ),
+            new(
+                Key: "high-priority-active",
+                Name: "High Priority Active",
+                Description: "High priority appraisals that are currently in progress",
+                Filters: new Dictionary<string, string>
+                {
+                    ["priority"] = "High",
+                    ["status"] = activeStatuses
+                }
+            ),
+            new(
+                Key: "nearing-deadline",
+                Name: "Nearing Deadline",
+                Description: "Appraisals whose SLA due date falls within the next 3 days",
+                Filters: new Dictionary<string, string>
+                {
+                    ["slaDueDateFrom"] = todayStr,
+                    ["slaDueDateTo"] = plusThreeDays
+                }
+            ),
+            new(
+                Key: "external-assignments",
+                Name: "External Assignments",
+                Description: "Appraisals assigned to external companies that are active",
+                Filters: new Dictionary<string, string>
+                {
+                    ["assignmentType"] = "External",
+                    ["status"] = "Assigned,InProgress"
+                }
+            ),
+            BuildMyCompanyQueue(currentUserService.CompanyId)
+        };
+
+        return Task.FromResult(new GetAppraisalViewsResult(views));
+    }
+
+    private static SmartViewDto BuildMyAssignments(string? username)
+    {
+        var filters = new Dictionary<string, string>();
+
+        if (!string.IsNullOrWhiteSpace(username))
+            filters["assigneeUserId"] = username;
+
+        return new SmartViewDto(
+            Key: "my-assignments",
+            Name: "My Assignments",
+            Description: "Appraisals currently assigned to you",
+            Filters: filters
+        );
+    }
+
+    private static SmartViewDto BuildMyCompanyQueue(Guid? companyId)
+    {
+        var filters = new Dictionary<string, string>();
+
+        if (companyId.HasValue)
+            filters["assigneeCompanyId"] = companyId.Value.ToString();
+
+        return new SmartViewDto(
+            Key: "my-company-queue",
+            Name: "My Company Queue",
+            Description: "Appraisals assigned to your company",
+            Filters: filters
+        );
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalViews/GetAppraisalViewsResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalViews/GetAppraisalViewsResult.cs
@@ -1,0 +1,10 @@
+namespace Appraisal.Application.Features.Appraisals.GetAppraisalViews;
+
+public record GetAppraisalViewsResult(IReadOnlyList<SmartViewDto> Views);
+
+public record SmartViewDto(
+    string Key,
+    string Name,
+    string Description,
+    Dictionary<string, string> Filters
+);

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/AppraisalFilterBuilder.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/AppraisalFilterBuilder.cs
@@ -1,0 +1,149 @@
+using Dapper;
+
+namespace Appraisal.Application.Features.Appraisals.GetAppraisals;
+
+/// <summary>
+/// Shared filter and sort builder for Appraisal list queries.
+/// Used by both the paginated list handler and the export handler.
+/// </summary>
+internal static class AppraisalFilterBuilder
+{
+    private static readonly HashSet<string> AllowedSortFields = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "AppraisalNumber", "RequestNumber", "CustomerName", "Status", "AppraisalType",
+        "Priority", "SLADueDate", "SLAStatus", "CreatedAt", "AssignedDate",
+        "AppointmentDateTime", "Province", "Channel", "BankingSegment",
+        "FacilityLimit", "PropertyCount", "ElapsedHours", "RemainingHours",
+        "AssignmentType", "CompanyName", "RequestedAt"
+    };
+
+    public static (string WhereClause, DynamicParameters Parameters) BuildFilter(GetAppraisalsFilterRequest? filter)
+    {
+        var conditions = new List<string>();
+        var parameters = new DynamicParameters();
+
+        if (filter is not null)
+        {
+            // Text search across AppraisalNumber, CustomerName, and RequestNumber
+            if (!string.IsNullOrWhiteSpace(filter.Search))
+            {
+                conditions.Add(
+                    "(AppraisalNumber LIKE '%' + @Search + '%' OR CustomerName LIKE '%' + @Search + '%' OR RequestNumber LIKE '%' + @Search + '%')");
+                parameters.Add("Search", filter.Search.Trim());
+            }
+
+            // Multi-value filters (comma-separated -> IN clause)
+            AddMultiValueFilter(conditions, parameters, filter.Status, "Status", "@Statuses");
+            AddMultiValueFilter(conditions, parameters, filter.Priority, "Priority", "@Priorities");
+            AddMultiValueFilter(conditions, parameters, filter.AppraisalType, "AppraisalType", "@AppraisalTypes");
+            AddMultiValueFilter(conditions, parameters, filter.SlaStatus, "SLAStatus", "@SlaStatuses");
+            AddMultiValueFilter(conditions, parameters, filter.AssignmentType, "AssignmentType", "@AssignmentTypes");
+
+            // Exact match filters
+            if (!string.IsNullOrWhiteSpace(filter.AssigneeUserId))
+            {
+                conditions.Add("AssigneeUserId = @AssigneeUserId");
+                parameters.Add("AssigneeUserId", filter.AssigneeUserId);
+            }
+
+            if (!string.IsNullOrWhiteSpace(filter.AssigneeCompanyId))
+            {
+                conditions.Add("AssigneeCompanyId = @AssigneeCompanyId");
+                parameters.Add("AssigneeCompanyId", filter.AssigneeCompanyId);
+            }
+
+            if (!string.IsNullOrWhiteSpace(filter.Channel))
+            {
+                conditions.Add("Channel = @Channel");
+                parameters.Add("Channel", filter.Channel);
+            }
+
+            if (!string.IsNullOrWhiteSpace(filter.BankingSegment))
+            {
+                conditions.Add("BankingSegment = @BankingSegment");
+                parameters.Add("BankingSegment", filter.BankingSegment);
+            }
+
+            if (filter.IsPma.HasValue)
+            {
+                conditions.Add("IsPma = @IsPma");
+                parameters.Add("IsPma", filter.IsPma.Value);
+            }
+
+            // Geographic filters
+            if (!string.IsNullOrWhiteSpace(filter.Province))
+            {
+                conditions.Add("Province = @Province");
+                parameters.Add("Province", filter.Province);
+            }
+
+            if (!string.IsNullOrWhiteSpace(filter.District))
+            {
+                conditions.Add("District = @District");
+                parameters.Add("District", filter.District);
+            }
+
+            // Date range filters
+            AddDateRangeFilter(conditions, parameters, filter.CreatedFrom, filter.CreatedTo,
+                "CreatedAt", "CreatedFrom", "CreatedTo");
+
+            AddDateRangeFilter(conditions, parameters, filter.SlaDueDateFrom, filter.SlaDueDateTo,
+                "SLADueDate", "SlaDueDateFrom", "SlaDueDateTo");
+
+            AddDateRangeFilter(conditions, parameters, filter.AssignedDateFrom, filter.AssignedDateTo,
+                "AssignedDate", "AssignedDateFrom", "AssignedDateTo");
+
+            AddDateRangeFilter(conditions, parameters, filter.AppointmentDateFrom, filter.AppointmentDateTo,
+                "AppointmentDateTime", "AppointmentDateFrom", "AppointmentDateTo");
+        }
+
+        var whereClause = conditions.Count > 0 ? " WHERE " + string.Join(" AND ", conditions) : "";
+        return (whereClause, parameters);
+    }
+
+    public static string BuildOrderBy(GetAppraisalsFilterRequest? filter)
+    {
+        var sortField = AllowedSortFields.Contains(filter?.SortBy ?? "") ? filter!.SortBy! : "CreatedAt";
+        var sortDir = string.Equals(filter?.SortDir, "asc", StringComparison.OrdinalIgnoreCase) ? "ASC" : "DESC";
+        return $"{sortField} {sortDir}";
+    }
+
+    private static void AddMultiValueFilter(
+        List<string> conditions, DynamicParameters parameters,
+        string? value, string columnName, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return;
+
+        var values = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (values.Length == 0) return;
+
+        if (values.Length == 1)
+        {
+            conditions.Add($"{columnName} = {paramName}");
+            parameters.Add(paramName.TrimStart('@'), values[0]);
+        }
+        else
+        {
+            conditions.Add($"{columnName} IN {paramName}");
+            parameters.Add(paramName.TrimStart('@'), values);
+        }
+    }
+
+    private static void AddDateRangeFilter(
+        List<string> conditions, DynamicParameters parameters,
+        DateTime? from, DateTime? to,
+        string columnName, string fromParam, string toParam)
+    {
+        if (from.HasValue)
+        {
+            conditions.Add($"{columnName} >= @{fromParam}");
+            parameters.Add(fromParam, from.Value);
+        }
+
+        if (to.HasValue)
+        {
+            conditions.Add($"{columnName} < DATEADD(day, 1, @{toParam})");
+            parameters.Add(toParam, to.Value);
+        }
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsFilterRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsFilterRequest.cs
@@ -1,11 +1,44 @@
 namespace Appraisal.Application.Features.Appraisals.GetAppraisals;
 
 /// <summary>
-/// Filter request for GetAppraisals query
+/// Filter request for GetAppraisals query.
+/// Supports text search, multi-value filters, date ranges, geographic, and sorting.
 /// </summary>
 public record GetAppraisalsFilterRequest(
+    // Text search (matches AppraisalNumber or CustomerName)
+    string? Search = null,
+
+    // Exact / multi-value filters (comma-separated for IN)
     string? Status = null,
     string? Priority = null,
     string? AppraisalType = null,
-    Guid? AssigneeUserId = null
+    string? SlaStatus = null,
+    string? AssignmentType = null,
+
+    // Assignment filters (AssigneeUserId stores username like "P5229", not a GUID)
+    string? AssigneeUserId = null,
+    string? AssigneeCompanyId = null,
+
+    // Request metadata
+    string? Channel = null,
+    string? BankingSegment = null,
+    bool? IsPma = null,
+
+    // Geographic
+    string? Province = null,
+    string? District = null,
+
+    // Date ranges
+    DateTime? CreatedFrom = null,
+    DateTime? CreatedTo = null,
+    DateTime? SlaDueDateFrom = null,
+    DateTime? SlaDueDateTo = null,
+    DateTime? AssignedDateFrom = null,
+    DateTime? AssignedDateTo = null,
+    DateTime? AppointmentDateFrom = null,
+    DateTime? AppointmentDateTo = null,
+
+    // Sorting
+    string? SortBy = null,
+    string? SortDir = null
 );

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsQueryHandler.cs
@@ -6,7 +6,7 @@ using Shared.Pagination;
 namespace Appraisal.Application.Features.Appraisals.GetAppraisals;
 
 /// <summary>
-/// Handler for getting all Appraisals with pagination and filtering.
+/// Handler for getting all Appraisals with pagination, filtering, sorting, and facets.
 /// Uses SQL view + Dapper for efficient read queries.
 /// </summary>
 public class GetAppraisalsQueryHandler(
@@ -17,46 +17,63 @@ public class GetAppraisalsQueryHandler(
         GetAppraisalsQuery query,
         CancellationToken cancellationToken)
     {
-        var sql = "SELECT * FROM appraisal.vw_AppraisalList";
-        var conditions = new List<string>();
-        var parameters = new DynamicParameters();
-
         var filter = query.Filter;
-        if (filter is not null)
-        {
-            if (!string.IsNullOrWhiteSpace(filter.Status))
-            {
-                conditions.Add("Status = @Status");
-                parameters.Add("Status", filter.Status);
-            }
+        var (whereClause, parameters) = AppraisalFilterBuilder.BuildFilter(filter);
+        var orderBy = AppraisalFilterBuilder.BuildOrderBy(filter);
 
-            if (!string.IsNullOrWhiteSpace(filter.Priority))
-            {
-                conditions.Add("Priority = @Priority");
-                parameters.Add("Priority", filter.Priority);
-            }
+        var baseSql = "SELECT * FROM appraisal.vw_AppraisalList" + whereClause;
 
-            if (!string.IsNullOrWhiteSpace(filter.AppraisalType))
-            {
-                conditions.Add("AppraisalType = @AppraisalType");
-                parameters.Add("AppraisalType", filter.AppraisalType);
-            }
-
-            if (filter.AssigneeUserId.HasValue)
-            {
-                conditions.Add("AssigneeUserId = @AssigneeUserId");
-                parameters.Add("AssigneeUserId", filter.AssigneeUserId.Value);
-            }
-        }
-
-        if (conditions.Count > 0) sql += " WHERE " + string.Join(" AND ", conditions);
-
+        // Execute paginated query
         var result = await connectionFactory.QueryPaginatedAsync<AppraisalDto>(
-            sql,
-            "CreatedAt DESC",
+            baseSql,
+            orderBy,
             query.PaginationRequest,
             parameters);
 
-        return new GetAppraisalsResult(result);
+        // Execute facet counts in a single pass (not 5x UNION ALL)
+        var facetsSql = $"""
+            SELECT Status, SLAStatus, Priority, AppraisalType, AssignmentType
+            FROM appraisal.vw_AppraisalList{whereClause}
+            """;
+
+        var connection = connectionFactory.GetOpenConnection();
+        var facetRows = await connection.QueryAsync<FacetRawRow>(facetsSql, parameters);
+        var facetList = facetRows.ToList();
+
+        var facets = BuildFacets(facetList);
+
+        return new GetAppraisalsResult(result, facets);
+    }
+
+    private static AppraisalFacets BuildFacets(List<FacetRawRow> rows)
+    {
+        return new AppraisalFacets
+        {
+            Status = GroupCount(rows, r => r.Status),
+            SlaStatus = GroupCount(rows, r => r.SLAStatus),
+            Priority = GroupCount(rows, r => r.Priority),
+            AppraisalType = GroupCount(rows, r => r.AppraisalType),
+            AssignmentType = GroupCount(rows, r => r.AssignmentType)
+        };
+    }
+
+    private static List<FacetItem> GroupCount(List<FacetRawRow> rows, Func<FacetRawRow, string?> selector)
+    {
+        return rows
+            .Select(selector)
+            .Where(v => v is not null)
+            .GroupBy(v => v!)
+            .Select(g => new FacetItem(g.Key, g.Count()))
+            .OrderByDescending(f => f.Count)
+            .ToList();
+    }
+
+    private class FacetRawRow
+    {
+        public string Status { get; set; } = "";
+        public string? SLAStatus { get; set; }
+        public string Priority { get; set; } = "";
+        public string AppraisalType { get; set; } = "";
+        public string? AssignmentType { get; set; }
     }
 }

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsResponse.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsResponse.cs
@@ -2,4 +2,4 @@ using Shared.Pagination;
 
 namespace Appraisal.Application.Features.Appraisals.GetAppraisals;
 
-public record GetAppraisalsResponse(PaginatedResult<AppraisalDto> Result);
+public record GetAppraisalsResponse(PaginatedResult<AppraisalDto> Result, AppraisalFacets? Facets = null);

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsResult.cs
@@ -5,7 +5,7 @@ namespace Appraisal.Application.Features.Appraisals.GetAppraisals;
 /// <summary>
 /// Result of getting all Appraisals
 /// </summary>
-public record GetAppraisalsResult(PaginatedResult<AppraisalDto> Result);
+public record GetAppraisalsResult(PaginatedResult<AppraisalDto> Result, AppraisalFacets? Facets = null);
 
 /// <summary>
 /// DTO for Appraisal list item
@@ -16,25 +16,56 @@ public record AppraisalDto
     public Guid Id { get; init; }
     public string? AppraisalNumber { get; init; }
     public Guid RequestId { get; init; }
+    public string? RequestNumber { get; init; }
     public string Status { get; init; } = null!;
     public string AppraisalType { get; init; } = null!;
     public string Priority { get; init; } = null!;
     public bool IsPma { get; init; }
+    public string? Purpose { get; init; }
     public string? Channel { get; init; }
     public string? BankingSegment { get; init; }
     public decimal? FacilityLimit { get; init; }
+    public string? RequestedBy { get; init; }
+    public DateTime? RequestedAt { get; init; }
     public int? SLADays { get; init; }
     public DateTime? SLADueDate { get; init; }
     public string? SLAStatus { get; init; }
     public int PropertyCount { get; init; }
     public DateTime? CreatedAt { get; init; }
-    public DateTime? AppointmentDateTime { get; init; }
 
-    // Assignment Info (from latest assignment)
-    public Guid? AssigneeUserId { get; init; }
+    // Assignment Info (from latest active assignment — stores username like "P5229")
+    public string? AssigneeUserId { get; init; }
+    public string? AssigneeCompanyId { get; init; }
+    public string? AssignmentType { get; init; }
     public string? AssignmentStatus { get; init; }
     public DateTime? AssignedDate { get; init; }
+    public string? CompanyName { get; init; }
+
+    // Customer Info
+    public string? CustomerName { get; init; }
 
     // Location Info (from first property's land detail)
     public string? Province { get; init; }
+    public string? District { get; init; }
+
+    // Appointment
+    public DateTime? AppointmentDateTime { get; init; }
+
+    // SLA Computed
+    public int? ElapsedHours { get; init; }
+    public int? RemainingHours { get; init; }
 }
+
+/// <summary>
+/// Aggregated facet counts for filter UI
+/// </summary>
+public record AppraisalFacets
+{
+    public List<FacetItem> Status { get; init; } = [];
+    public List<FacetItem> SlaStatus { get; init; } = [];
+    public List<FacetItem> Priority { get; init; } = [];
+    public List<FacetItem> AppraisalType { get; init; } = [];
+    public List<FacetItem> AssignmentType { get; init; } = [];
+}
+
+public record FacetItem(string Value, int Count);

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/Appraisal.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/Appraisal.cs
@@ -61,6 +61,10 @@ public class Appraisal : Aggregate<Guid>
     public int? ActualDaysToComplete { get; private set; }
     public bool? IsWithinSLA { get; private set; }
 
+    // Committee approval evidence
+    public DateTime? CompletedAt { get; private set; }
+    public string? ApprovedByCommittee { get; private set; }
+
     // Soft Delete
     public SoftDelete SoftDelete { get; private set; } = SoftDelete.NotDeleted();
 
@@ -655,6 +659,17 @@ public class Appraisal : Aggregate<Guid>
         IsWithinSLA = !SLADueDate.HasValue || DateTime.UtcNow <= SLADueDate.Value;
 
         AddDomainEvent(new AppraisalCompletedEvent(this));
+    }
+
+    /// <summary>
+    /// Stamps committee approval evidence. Idempotent — no-op if already stamped.
+    /// Does NOT touch Status; status will be derived from workflow state later.
+    /// </summary>
+    public void MarkApprovedByCommittee(string committeeCode, DateTime approvedAt)
+    {
+        if (CompletedAt.HasValue) return; // idempotent guard — safe on pipeline retries
+        CompletedAt = approvedAt;
+        ApprovedByCommittee = committeeCode;
     }
 
     /// <summary>

--- a/Modules/Appraisal/Appraisal/Infrastructure/Configurations/AppraisalAggregateConfiguration.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Configurations/AppraisalAggregateConfiguration.cs
@@ -65,6 +65,11 @@ public class AppraisalAggregateConfiguration : IEntityTypeConfiguration<Domain.A
                 .HasMaxLength(30);
         });
 
+        // Committee approval evidence
+        builder.Property(a => a.CompletedAt);
+        builder.Property(a => a.ApprovedByCommittee)
+            .HasMaxLength(50);
+
         // SLA Tracking
         builder.Property(a => a.SLADays);
         builder.Property(a => a.SLADueDate);

--- a/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260416183759_AddAppraisalCommitteeApprovalFields.Designer.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260416183759_AddAppraisalCommitteeApprovalFields.Designer.cs
@@ -4,16 +4,19 @@ using Appraisal.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace Appraisal.Infrastructure.Migrations
+namespace Appraisal.infrastructure.Migrations
 {
     [DbContext(typeof(AppraisalDbContext))]
-    partial class AppraisalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260416183759_AddAppraisalCommitteeApprovalFields")]
+    partial class AddAppraisalCommitteeApprovalFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260416183759_AddAppraisalCommitteeApprovalFields.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260416183759_AddAppraisalCommitteeApprovalFields.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Appraisal.infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAppraisalCommitteeApprovalFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ApprovedByCommittee",
+                schema: "appraisal",
+                table: "Appraisals",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CompletedAt",
+                schema: "appraisal",
+                table: "Appraisals",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ApprovedByCommittee",
+                schema: "appraisal",
+                table: "Appraisals");
+
+            migrationBuilder.DropColumn(
+                name: "CompletedAt",
+                schema: "appraisal",
+                table: "Appraisals");
+        }
+    }
+}

--- a/Modules/Auth/Auth/AuthModule.cs
+++ b/Modules/Auth/Auth/AuthModule.cs
@@ -61,7 +61,7 @@ public static class AuthModule
 
                 options.Lockout.MaxFailedAccessAttempts = lockoutConfig.GetValue("MaxFailedAccessAttempts", 5);
                 options.Lockout.DefaultLockoutTimeSpan = lockoutConfig.GetValue("PermanentLockout", true)
-                    ? TimeSpan.MaxValue
+                    ? TimeSpan.FromDays(365 * 200)
                     : TimeSpan.FromMinutes(lockoutConfig.GetValue("DefaultLockoutTimeSpanInMinutes", 5));
                 options.Lockout.AllowedForNewUsers = lockoutConfig.GetValue("LockoutEnabled", true);
             })

--- a/Modules/Common/Common/Application/Features/Dashboard/GetReminders/GetRemindersQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Dashboard/GetReminders/GetRemindersQueryHandler.cs
@@ -29,21 +29,20 @@ public class GetRemindersQueryHandler(
             FROM (
                 -- Source 1: tasks assigned to me that are overdue or due within 24 h
                 SELECT
-                    pt.Id                                       AS Id,
+                    tl.Id                                       AS Id,
                     'task_due'                                  AS Type,
                     COALESCE(
-                        pt.TaskDescription,
-                        CAST(pt.TaskName AS nvarchar(200))
+                        tl.TaskDescription,
+                        CAST(tl.TaskType AS nvarchar(200))
                     )                                           AS Title,
-                    a.AppraisalNumber                           AS AppraisalNumber,
-                    CAST(pt.DueAt AS datetimeoffset)            AS DueAt,
-                    CASE WHEN pt.DueAt < GETUTCDATE() THEN 1 ELSE 0 END AS Overdue
-                FROM workflow.PendingTasks pt
-                LEFT JOIN appraisal.Appraisals a ON a.Id = pt.AppraisalId
-                WHERE pt.AssignedTo    = @Username
-                  AND pt.TaskStatus   != 'Completed'
-                  AND pt.DueAt        IS NOT NULL
-                  AND pt.DueAt        <= DATEADD(HOUR, 24, GETUTCDATE())
+                    COALESCE(tl.AppraisalNumber, tl.RequestNumber, CONCAT('REQ-', LEFT(CAST(tl.RequestId AS nvarchar(36)), 8))) AS AppraisalNumber,
+                    CAST(tl.DueAt AS datetimeoffset)            AS DueAt,
+                    CASE WHEN tl.DueAt < GETUTCDATE() THEN 1 ELSE 0 END AS Overdue
+                FROM workflow.vw_TaskList tl
+                WHERE tl.AssigneeUserId = @Username
+                  AND tl.PendingTaskStatus != 'Completed'
+                  AND tl.DueAt         IS NOT NULL
+                  AND tl.DueAt         <= DATEADD(HOUR, 24, GETUTCDATE())
 
                 UNION ALL
 

--- a/Modules/Common/Common/Application/Features/SavedSearches/CreateSavedSearch/CreateSavedSearchCommand.cs
+++ b/Modules/Common/Common/Application/Features/SavedSearches/CreateSavedSearch/CreateSavedSearchCommand.cs
@@ -1,0 +1,10 @@
+using Shared.CQRS;
+
+namespace Common.Application.Features.SavedSearches.CreateSavedSearch;
+
+public record CreateSavedSearchCommand(
+    string Name,
+    string EntityType,
+    string FiltersJson,
+    string? SortBy,
+    string? SortDir) : ICommand<CreateSavedSearchResult>;

--- a/Modules/Common/Common/Application/Features/SavedSearches/CreateSavedSearch/CreateSavedSearchCommandHandler.cs
+++ b/Modules/Common/Common/Application/Features/SavedSearches/CreateSavedSearch/CreateSavedSearchCommandHandler.cs
@@ -1,0 +1,41 @@
+using Common.Domain.SavedSearches;
+using Common.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Shared.CQRS;
+using Shared.Identity;
+
+namespace Common.Application.Features.SavedSearches.CreateSavedSearch;
+
+public class CreateSavedSearchCommandHandler(
+    CommonDbContext dbContext,
+    ICurrentUserService currentUserService
+) : ICommandHandler<CreateSavedSearchCommand, CreateSavedSearchResult>
+{
+    public async Task<CreateSavedSearchResult> Handle(
+        CreateSavedSearchCommand command,
+        CancellationToken cancellationToken)
+    {
+        var userId = currentUserService.UserId
+            ?? throw new InvalidOperationException("User must be authenticated to save a search.");
+
+        var count = await dbContext.SavedSearches
+            .CountAsync(s => s.UserId == userId, cancellationToken);
+
+        if (count >= SavedSearch.MaxPerUser)
+            throw new InvalidOperationException(
+                $"Cannot exceed {SavedSearch.MaxPerUser} saved searches per user. Delete an existing one first.");
+
+        var savedSearch = SavedSearch.Create(
+            userId,
+            command.Name,
+            command.EntityType,
+            command.FiltersJson,
+            command.SortBy,
+            command.SortDir);
+
+        dbContext.SavedSearches.Add(savedSearch);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return new CreateSavedSearchResult(savedSearch.Id, savedSearch.Name);
+    }
+}

--- a/Modules/Common/Common/Application/Features/SavedSearches/CreateSavedSearch/CreateSavedSearchEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/SavedSearches/CreateSavedSearch/CreateSavedSearchEndpoint.cs
@@ -1,0 +1,36 @@
+using Carter;
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Common.Application.Features.SavedSearches.CreateSavedSearch;
+
+public class CreateSavedSearchEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/saved-searches",
+                async (
+                    CreateSavedSearchRequest request,
+                    ISender sender,
+                    CancellationToken cancellationToken) =>
+                {
+                    var command = new CreateSavedSearchCommand(
+                        request.Name,
+                        request.EntityType,
+                        request.FiltersJson,
+                        request.SortBy,
+                        request.SortDir);
+
+                    var result = await sender.Send(command, cancellationToken);
+                    return Results.Created($"/saved-searches/{result.Id}", result);
+                })
+            .WithName("CreateSavedSearch")
+            .Produces<CreateSavedSearchResult>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .WithSummary("Save a named search filter configuration for the current user")
+            .WithTags("Saved Searches")
+            .RequireAuthorization();
+    }
+}

--- a/Modules/Common/Common/Application/Features/SavedSearches/CreateSavedSearch/CreateSavedSearchRequest.cs
+++ b/Modules/Common/Common/Application/Features/SavedSearches/CreateSavedSearch/CreateSavedSearchRequest.cs
@@ -1,0 +1,8 @@
+namespace Common.Application.Features.SavedSearches.CreateSavedSearch;
+
+public record CreateSavedSearchRequest(
+    string Name,
+    string EntityType,
+    string FiltersJson,
+    string? SortBy,
+    string? SortDir);

--- a/Modules/Common/Common/Application/Features/SavedSearches/CreateSavedSearch/CreateSavedSearchResult.cs
+++ b/Modules/Common/Common/Application/Features/SavedSearches/CreateSavedSearch/CreateSavedSearchResult.cs
@@ -1,0 +1,3 @@
+namespace Common.Application.Features.SavedSearches.CreateSavedSearch;
+
+public sealed record CreateSavedSearchResult(Guid Id, string Name);

--- a/Modules/Common/Common/Application/Features/SavedSearches/DeleteSavedSearch/DeleteSavedSearchCommand.cs
+++ b/Modules/Common/Common/Application/Features/SavedSearches/DeleteSavedSearch/DeleteSavedSearchCommand.cs
@@ -1,0 +1,5 @@
+using Shared.CQRS;
+
+namespace Common.Application.Features.SavedSearches.DeleteSavedSearch;
+
+public record DeleteSavedSearchCommand(Guid Id) : ICommand<bool>;

--- a/Modules/Common/Common/Application/Features/SavedSearches/DeleteSavedSearch/DeleteSavedSearchCommandHandler.cs
+++ b/Modules/Common/Common/Application/Features/SavedSearches/DeleteSavedSearch/DeleteSavedSearchCommandHandler.cs
@@ -1,0 +1,32 @@
+using Common.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Shared.CQRS;
+using Shared.Identity;
+
+namespace Common.Application.Features.SavedSearches.DeleteSavedSearch;
+
+public class DeleteSavedSearchCommandHandler(
+    CommonDbContext dbContext,
+    ICurrentUserService currentUserService
+) : ICommandHandler<DeleteSavedSearchCommand, bool>
+{
+    public async Task<bool> Handle(
+        DeleteSavedSearchCommand command,
+        CancellationToken cancellationToken)
+    {
+        var userId = currentUserService.UserId
+            ?? throw new InvalidOperationException("User must be authenticated to delete a saved search.");
+
+        // Filter by both Id AND UserId — foreign users receive 404, not 403.
+        var savedSearch = await dbContext.SavedSearches
+            .FirstOrDefaultAsync(s => s.Id == command.Id && s.UserId == userId, cancellationToken);
+
+        if (savedSearch is null)
+            return false;
+
+        dbContext.SavedSearches.Remove(savedSearch);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return true;
+    }
+}

--- a/Modules/Common/Common/Application/Features/SavedSearches/DeleteSavedSearch/DeleteSavedSearchEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/SavedSearches/DeleteSavedSearch/DeleteSavedSearchEndpoint.cs
@@ -1,0 +1,32 @@
+using Carter;
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Common.Application.Features.SavedSearches.DeleteSavedSearch;
+
+public class DeleteSavedSearchEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapDelete("/saved-searches/{id:guid}",
+                async (
+                    Guid id,
+                    ISender sender,
+                    CancellationToken cancellationToken) =>
+                {
+                    var deleted = await sender.Send(new DeleteSavedSearchCommand(id), cancellationToken);
+
+                    // Handler returns false when the search is not found or not owned by the current user.
+                    // Responding 404 in both cases — not 403 — to avoid leaking ownership information.
+                    return deleted ? Results.NoContent() : Results.NotFound();
+                })
+            .WithName("DeleteSavedSearch")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Delete a saved search; 404 if not found or not owned by the current user")
+            .WithTags("Saved Searches")
+            .RequireAuthorization();
+    }
+}

--- a/Modules/Common/Common/Application/Features/SavedSearches/GetSavedSearches/GetSavedSearchesEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/SavedSearches/GetSavedSearches/GetSavedSearchesEndpoint.cs
@@ -1,0 +1,28 @@
+using Carter;
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Common.Application.Features.SavedSearches.GetSavedSearches;
+
+public class GetSavedSearchesEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/saved-searches",
+                async (
+                    string? entityType,
+                    ISender sender,
+                    CancellationToken cancellationToken) =>
+                {
+                    var result = await sender.Send(new GetSavedSearchesQuery(entityType), cancellationToken);
+                    return Results.Ok(result);
+                })
+            .WithName("GetSavedSearches")
+            .Produces<GetSavedSearchesResponse>()
+            .WithSummary("List saved search configurations for the current user, optionally filtered by entity type")
+            .WithTags("Saved Searches")
+            .RequireAuthorization();
+    }
+}

--- a/Modules/Common/Common/Application/Features/SavedSearches/GetSavedSearches/GetSavedSearchesQuery.cs
+++ b/Modules/Common/Common/Application/Features/SavedSearches/GetSavedSearches/GetSavedSearchesQuery.cs
@@ -1,0 +1,5 @@
+using Shared.CQRS;
+
+namespace Common.Application.Features.SavedSearches.GetSavedSearches;
+
+public record GetSavedSearchesQuery(string? EntityType) : IQuery<GetSavedSearchesResponse>;

--- a/Modules/Common/Common/Application/Features/SavedSearches/GetSavedSearches/GetSavedSearchesQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/SavedSearches/GetSavedSearches/GetSavedSearchesQueryHandler.cs
@@ -1,0 +1,42 @@
+using Common.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Shared.CQRS;
+using Shared.Identity;
+
+namespace Common.Application.Features.SavedSearches.GetSavedSearches;
+
+public class GetSavedSearchesQueryHandler(
+    CommonDbContext dbContext,
+    ICurrentUserService currentUserService
+) : IQueryHandler<GetSavedSearchesQuery, GetSavedSearchesResponse>
+{
+    public async Task<GetSavedSearchesResponse> Handle(
+        GetSavedSearchesQuery query,
+        CancellationToken cancellationToken)
+    {
+        var userId = currentUserService.UserId;
+        if (userId is null)
+            return new GetSavedSearchesResponse([]);
+
+        var dbQuery = dbContext.SavedSearches
+            .Where(s => s.UserId == userId.Value);
+
+        if (!string.IsNullOrWhiteSpace(query.EntityType))
+            dbQuery = dbQuery.Where(s => s.EntityType == query.EntityType.Trim().ToLowerInvariant());
+
+        var items = await dbQuery
+            .OrderByDescending(s => s.UpdatedAt)
+            .Select(s => new SavedSearchDto(
+                s.Id,
+                s.Name,
+                s.EntityType,
+                s.FiltersJson,
+                s.SortBy,
+                s.SortDir,
+                s.CreatedAt,
+                s.UpdatedAt))
+            .ToListAsync(cancellationToken);
+
+        return new GetSavedSearchesResponse(items);
+    }
+}

--- a/Modules/Common/Common/Application/Features/SavedSearches/GetSavedSearches/GetSavedSearchesResponse.cs
+++ b/Modules/Common/Common/Application/Features/SavedSearches/GetSavedSearches/GetSavedSearchesResponse.cs
@@ -1,0 +1,3 @@
+namespace Common.Application.Features.SavedSearches.GetSavedSearches;
+
+public sealed record GetSavedSearchesResponse(List<SavedSearchDto> Items);

--- a/Modules/Common/Common/Application/Features/SavedSearches/GetSavedSearches/SavedSearchDto.cs
+++ b/Modules/Common/Common/Application/Features/SavedSearches/GetSavedSearches/SavedSearchDto.cs
@@ -1,0 +1,14 @@
+namespace Common.Application.Features.SavedSearches.GetSavedSearches;
+
+/// <summary>
+/// Shared projection used in list responses for the Saved Searches feature.
+/// </summary>
+public sealed record SavedSearchDto(
+    Guid Id,
+    string Name,
+    string EntityType,
+    string FiltersJson,
+    string? SortBy,
+    string? SortDir,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt);

--- a/Modules/Common/Common/Domain/SavedSearches/SavedSearch.cs
+++ b/Modules/Common/Common/Domain/SavedSearches/SavedSearch.cs
@@ -1,0 +1,101 @@
+namespace Common.Domain.SavedSearches;
+
+/// <summary>
+/// A named snapshot of a user's search filter configuration.
+/// Scoped strictly to the owning user — all handlers enforce UserId filtering.
+/// The FiltersJson payload is stored opaquely; no structural validation is applied.
+/// </summary>
+public class SavedSearch
+{
+    public const int MaxNameLength = 100;
+    public const int MaxEntityTypeLength = 50;
+    public const int MaxSortByLength = 50;
+    public const int MaxSortDirLength = 10;
+    public const int MaxFiltersJsonLength = 8_000;
+    public const int MaxPerUser = 50;
+
+    public Guid Id { get; private set; }
+
+    /// <summary>
+    /// The authenticated user who owns this saved search (from the "sub" JWT claim).
+    /// Scoping enforced in all handlers — foreign users receive 404, not 403.
+    /// </summary>
+    public Guid UserId { get; private set; }
+
+    public string Name { get; private set; } = null!;
+
+    /// <summary>
+    /// The entity kind this search applies to, e.g. "appraisal", "request".
+    /// Stored in lower-invariant form.
+    /// </summary>
+    public string EntityType { get; private set; } = null!;
+
+    /// <summary>
+    /// Opaque JSON blob of the filter parameters. Structure is owned by the client.
+    /// </summary>
+    public string FiltersJson { get; private set; } = null!;
+
+    public string? SortBy { get; private set; }
+
+    public string? SortDir { get; private set; }
+
+    public DateTimeOffset CreatedAt { get; private set; }
+
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    // Required by EF Core
+    private SavedSearch()
+    {
+    }
+
+    /// <summary>
+    /// Factory — creates a new saved search for the given user.
+    /// </summary>
+    /// <param name="userId">The authenticated user's Id (from ICurrentUserService.UserId).</param>
+    /// <param name="name">Non-empty display name (max 100 characters).</param>
+    /// <param name="entityType">Non-empty entity kind, e.g. "appraisal" (stored lower-invariant).</param>
+    /// <param name="filtersJson">Non-empty JSON string representing the filter state.</param>
+    /// <param name="sortBy">Optional sort column name (max 50 characters).</param>
+    /// <param name="sortDir">Optional sort direction, e.g. "asc" / "desc" (max 10 characters).</param>
+    public static SavedSearch Create(
+        Guid userId,
+        string name,
+        string entityType,
+        string filtersJson,
+        string? sortBy,
+        string? sortDir)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Saved search name cannot be empty.", nameof(name));
+
+        if (name.Trim().Length > MaxNameLength)
+            throw new ArgumentException(
+                $"Saved search name exceeds the maximum allowed length of {MaxNameLength} characters.",
+                nameof(name));
+
+        if (string.IsNullOrWhiteSpace(entityType))
+            throw new ArgumentException("Entity type cannot be empty.", nameof(entityType));
+
+        if (string.IsNullOrWhiteSpace(filtersJson))
+            throw new ArgumentException("FiltersJson cannot be empty.", nameof(filtersJson));
+
+        if (filtersJson.Length > MaxFiltersJsonLength)
+            throw new ArgumentException(
+                $"FiltersJson exceeds the maximum allowed length of {MaxFiltersJsonLength} characters.",
+                nameof(filtersJson));
+
+        var now = DateTimeOffset.UtcNow;
+        return new SavedSearch
+        {
+            Id = Guid.CreateVersion7(),
+            UserId = userId,
+            Name = name.Trim(),
+            EntityType = entityType.Trim().ToLowerInvariant(),
+            FiltersJson = filtersJson,
+            SortBy = sortBy,
+            SortDir = sortDir,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+    }
+}

--- a/Modules/Common/Common/Infrastructure/CommonDbContext.cs
+++ b/Modules/Common/Common/Infrastructure/CommonDbContext.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Common.Domain.Notes;
 using Common.Domain.ReadModels;
+using Common.Domain.SavedSearches;
 using Microsoft.EntityFrameworkCore;
 using Shared.Data.Outbox;
 
@@ -12,6 +13,7 @@ public class CommonDbContext(DbContextOptions<CommonDbContext> options) : DbCont
     public DbSet<AppraisalStatusSummary> AppraisalStatusSummaries => Set<AppraisalStatusSummary>();
     public DbSet<CompanyAppraisalSummary> CompanyAppraisalSummaries => Set<CompanyAppraisalSummary>();
     public DbSet<DashboardNote> DashboardNotes => Set<DashboardNote>();
+    public DbSet<SavedSearch> SavedSearches => Set<SavedSearch>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/Modules/Common/Common/Infrastructure/Configurations/SavedSearchConfiguration.cs
+++ b/Modules/Common/Common/Infrastructure/Configurations/SavedSearchConfiguration.cs
@@ -1,0 +1,49 @@
+using Common.Domain.SavedSearches;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Common.Infrastructure.Configurations;
+
+public class SavedSearchConfiguration : IEntityTypeConfiguration<SavedSearch>
+{
+    public void Configure(EntityTypeBuilder<SavedSearch> builder)
+    {
+        builder.ToTable("SavedSearches", "common");
+
+        builder.HasKey(s => s.Id);
+        builder.Property(s => s.Id)
+            .HasDefaultValueSql("NEWSEQUENTIALID()");
+
+        builder.Property(s => s.UserId)
+            .IsRequired();
+
+        builder.Property(s => s.Name)
+            .IsRequired()
+            .HasMaxLength(SavedSearch.MaxNameLength);
+
+        builder.Property(s => s.EntityType)
+            .IsRequired()
+            .HasMaxLength(SavedSearch.MaxEntityTypeLength);
+
+        builder.Property(s => s.FiltersJson)
+            .IsRequired()
+            .HasColumnType("nvarchar(max)");
+
+        builder.Property(s => s.SortBy)
+            .HasMaxLength(SavedSearch.MaxSortByLength);
+
+        builder.Property(s => s.SortDir)
+            .HasMaxLength(SavedSearch.MaxSortDirLength);
+
+        builder.Property(s => s.CreatedAt)
+            .IsRequired()
+            .HasColumnType("datetimeoffset");
+
+        builder.Property(s => s.UpdatedAt)
+            .IsRequired()
+            .HasColumnType("datetimeoffset");
+
+        builder.HasIndex(s => s.UserId)
+            .HasDatabaseName("IX_SavedSearches_UserId");
+    }
+}

--- a/Modules/Common/Common/Migrations/20260416140208_AddSavedSearches.Designer.cs
+++ b/Modules/Common/Common/Migrations/20260416140208_AddSavedSearches.Designer.cs
@@ -4,6 +4,7 @@ using Common.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Common.Migrations
 {
     [DbContext(typeof(CommonDbContext))]
-    partial class CommonDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260416140208_AddSavedSearches")]
+    partial class AddSavedSearches
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modules/Common/Common/Migrations/20260416140208_AddSavedSearches.cs
+++ b/Modules/Common/Common/Migrations/20260416140208_AddSavedSearches.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Common.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSavedSearches : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SavedSearches",
+                schema: "common",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false, defaultValueSql: "NEWSEQUENTIALID()"),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    EntityType = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    FiltersJson = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    SortBy = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    SortDir = table.Column<string>(type: "nvarchar(10)", maxLength: 10, nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SavedSearches", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SavedSearches_UserId",
+                schema: "common",
+                table: "SavedSearches",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SavedSearches",
+                schema: "common");
+        }
+    }
+}

--- a/Modules/Workflow/Workflow/Infrastructure/Migrations/20260417000000_SeedSetAssignmentTypeStep.cs
+++ b/Modules/Workflow/Workflow/Infrastructure/Migrations/20260417000000_SeedSetAssignmentTypeStep.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Workflow.Infrastructure.Migrations;
+
+/// <summary>
+/// Seeds ActivityProcessConfiguration for int-appraisal-execution to set
+/// assignmentType = 'Internal' on completion, enabling the conditional
+/// "Proceed" action at appraisal-assignment on revisits.
+/// </summary>
+public partial class SeedSetAssignmentTypeStep : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql("""
+            IF NOT EXISTS (
+                SELECT 1 FROM workflow.ActivityProcessConfigurations
+                WHERE ActivityName = 'int-appraisal-execution'
+                  AND ProcessorName = 'SetVariable'
+            )
+            BEGIN
+                INSERT INTO workflow.ActivityProcessConfigurations
+                    (Id, ActivityName, StepName, ProcessorName, SortOrder, Parameters, IsActive, CreatedAt, CreatedBy, UpdatedAt, UpdatedBy)
+                VALUES
+                    (NEWID(), 'int-appraisal-execution', 'Set assignment type to Internal', 'SetVariable', 1,
+                     '{"variable": "assignmentType", "value": "Internal"}', 1, GETUTCDATE(), 'system', GETUTCDATE(), 'system')
+            END
+            """);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql("""
+            DELETE FROM workflow.ActivityProcessConfigurations
+            WHERE ActivityName = 'int-appraisal-execution'
+              AND ProcessorName = 'SetVariable'
+            """);
+    }
+}

--- a/Modules/Workflow/Workflow/Tasks/Features/GetPoolTasks/GetPoolTasksQueryHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/GetPoolTasks/GetPoolTasksQueryHandler.cs
@@ -37,6 +37,10 @@ public class GetPoolTasksQueryHandler(
         var conditions = new List<string>();
         var parameters = new DynamicParameters();
 
+        // Restrict to pool-assigned tasks (AssignedType = '2'); individual assignments are excluded
+        conditions.Add("AssignedType = @PoolAssignedType");
+        parameters.Add("PoolAssignedType", "2");
+
         // Pool tasks are assigned to a group (AssigneeUserId contains a group name)
         var groupConditions = new List<string>();
         for (var i = 0; i < userGroups.Count; i++)

--- a/Modules/Workflow/Workflow/Workflow/Activities/ApprovalActivity.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/ApprovalActivity.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Shared.Data.Outbox;
+using Shared.Messaging.Events;
 using Workflow.Data.Repository;
 using Workflow.Domain;
 using Workflow.Domain.Committees;
@@ -17,6 +19,7 @@ public class ApprovalActivity : WorkflowActivityBase
     private readonly IApprovalMemberResolver _memberResolver;
     private readonly IApprovalVoteRepository _voteRepository;
     private readonly IPublisher _publisher;
+    private readonly IIntegrationEventOutbox _outbox;
     private readonly ExpressionEvaluator _expressionEvaluator;
     private readonly ILogger<ApprovalActivity> _logger;
 
@@ -24,11 +27,13 @@ public class ApprovalActivity : WorkflowActivityBase
         IApprovalMemberResolver memberResolver,
         IApprovalVoteRepository voteRepository,
         IPublisher publisher,
+        IIntegrationEventOutbox outbox,
         ILogger<ApprovalActivity> logger)
     {
         _memberResolver = memberResolver;
         _voteRepository = voteRepository;
         _publisher = publisher;
+        _outbox = outbox;
         _expressionEvaluator = new ExpressionEvaluator();
         _logger = logger;
     }
@@ -297,6 +302,38 @@ public class ApprovalActivity : WorkflowActivityBase
                     "ApprovalActivity {ActivityId}: Decision reached - {Decision}. Votes: {Approve}/{Reject}/{RouteBack}",
                     context.ActivityId, successOutput["decision"], approveCount, rejectCount, routeBackCount);
 
+                // Emit committee approval event when decision == "approve".
+                // Consumer in Appraisal module stamps CompletedAt + ApprovedByCommittee on the aggregate.
+                if (successOutput["decision"] is string finalDecision &&
+                    string.Equals(finalDecision, "approve", StringComparison.OrdinalIgnoreCase))
+                {
+                    var appraisalId = ResolveAppraisalId(context.Variables);
+                    if (appraisalId is not null)
+                    {
+                        var committeeCode = GetVariable<string>(context, $"{normalizedId}_committeeCode") ?? string.Empty;
+                        var committeeName = GetVariable<string>(context, $"{normalizedId}_committeeName");
+
+                        _outbox.Publish(new AppraisalApprovedByCommitteeIntegrationEvent
+                        {
+                            AppraisalId = appraisalId.Value,
+                            CommitteeCode = committeeCode,
+                            CommitteeName = committeeName,
+                            ApprovedAt = DateTime.UtcNow,
+                            ApprovedBy = voter
+                        }, appraisalId.Value.ToString());
+
+                        _logger.LogInformation(
+                            "ApprovalActivity {ActivityId}: Published AppraisalApprovedByCommitteeIntegrationEvent for AppraisalId {AppraisalId} CommitteeCode {CommitteeCode}",
+                            context.ActivityId, appraisalId.Value, committeeCode);
+                    }
+                    else
+                    {
+                        _logger.LogWarning(
+                            "ApprovalActivity {ActivityId}: Decision=approve but no appraisalId in workflow variables; skipping committee approval emit",
+                            context.ActivityId);
+                    }
+                }
+
                 return ActivityResult.Success(successOutput);
             }
 
@@ -417,5 +454,20 @@ public class ApprovalActivity : WorkflowActivityBase
         }
 
         return output;
+    }
+
+    private static Guid? ResolveAppraisalId(Dictionary<string, object>? variables)
+    {
+        if (variables is null || !variables.TryGetValue("appraisalId", out var raw))
+            return null;
+
+        return raw switch
+        {
+            Guid g => g,
+            string s when Guid.TryParse(s, out var parsed) => parsed,
+            JsonElement je when je.ValueKind == JsonValueKind.String
+                                && Guid.TryParse(je.GetString(), out var jp) => jp,
+            _ => null
+        };
     }
 }

--- a/Modules/Workflow/Workflow/Workflow/Activities/CompanySelectionActivity.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/CompanySelectionActivity.cs
@@ -36,7 +36,8 @@ public class CompanySelectionActivity : WorkflowActivityBase
         var outputData = new Dictionary<string, object>
         {
             ["selectionMethod"] = selectionMethod,
-            ["selectedAt"] = DateTime.UtcNow
+            ["selectedAt"] = DateTime.UtcNow,
+            ["assignmentType"] = "External"
         };
 
         if (selectionMethod == "manual")

--- a/Modules/Workflow/Workflow/Workflow/Config/appraisal-workflow.json
+++ b/Modules/Workflow/Workflow/Workflow/Config/appraisal-workflow.json
@@ -30,7 +30,6 @@
         "description": "Request checker reviews the initiated appraisal request for completeness and accuracy",
         "properties": {
           "activityName": "InitiationCheck",
-          "canRaiseFollowup": true,
           "assigneeGroup": "RequestChecker",
           "assignmentStrategies": "started_by",
           "initialAssignmentStrategies": [
@@ -172,7 +171,8 @@
             "route_external": "appraisal_assignment_decisionTaken == 'EXT'",
             "route_internal": "appraisal_assignment_decisionTaken == 'INT'",
             "reject": "appraisal_assignment_decisionTaken == 'REJ'",
-            "request_more_info": "appraisal_assignment_decisionTaken == 'R'"
+            "request_more_info": "appraisal_assignment_decisionTaken == 'R'",
+            "proceed": "appraisal_assignment_decisionTaken == 'P'"
           },
           "actions": [
             {
@@ -194,6 +194,12 @@
               "value": "R",
               "label": "Request More Info",
               "assignmentMode": "system"
+            },
+            {
+              "value": "P",
+              "label": "Proceed",
+              "assignmentMode": "system",
+              "condition": "assignmentType == 'External' || assignmentType == 'Internal'"
             }
           ],
           "inputMappings": {
@@ -271,7 +277,7 @@
             {
               "value": "P",
               "label": "Proceed",
-              "assignmentMode": "system"
+              "assignmentMode": "user"
             },
             {
               "value": "C",
@@ -323,7 +329,7 @@
             {
               "value": "P",
               "label": "Proceed",
-              "assignmentMode": "system"
+              "assignmentMode": "user"
             },
             {
               "value": "R",
@@ -370,7 +376,7 @@
             {
               "value": "P",
               "label": "Proceed",
-              "assignmentMode": "system"
+              "assignmentMode": "user"
             },
             {
               "value": "R",
@@ -851,6 +857,22 @@
         "type": "Conditional"
       },
       {
+        "id": "admin-proceed-external",
+        "from": "appraisal-assignment",
+        "to": "company-selection",
+        "condition": "decision == 'proceed' && assignmentType == 'External'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "admin-proceed-internal",
+        "from": "appraisal-assignment",
+        "to": "int-appraisal-execution",
+        "condition": "decision == 'proceed' && assignmentType == 'Internal'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
         "id": "company-selected",
         "from": "company-selection",
         "to": "internal-followup-selection",
@@ -1006,7 +1028,7 @@
         "id": "int-check-back-to-book-verification",
         "from": "int-appraisal-check",
         "to": "appraisal-book-verification",
-        "condition": "decision == 'route_back' && routingPath == 'external'",
+        "condition": "decision == 'route_back' && assignmentType == 'External'",
         "properties": {},
         "type": "Conditional"
       },
@@ -1014,7 +1036,7 @@
         "id": "int-check-back-to-execution",
         "from": "int-appraisal-check",
         "to": "int-appraisal-execution",
-        "condition": "decision == 'route_back' && routingPath == 'internal'",
+        "condition": "decision == 'route_back' && assignmentType == 'Internal'",
         "properties": {},
         "type": "Conditional"
       },
@@ -1070,7 +1092,7 @@
         "id": "approval-back-to-book-verification",
         "from": "pending-approval",
         "to": "appraisal-book-verification",
-        "condition": "decision == 'route_back' && routingPath == 'external'",
+        "condition": "decision == 'route_back' && assignmentType == 'External'",
         "properties": {},
         "type": "Conditional"
       },
@@ -1078,7 +1100,7 @@
         "id": "approval-back-to-execution",
         "from": "pending-approval",
         "to": "int-appraisal-execution",
-        "condition": "decision == 'route_back' && routingPath == 'internal'",
+        "condition": "decision == 'route_back' && assignmentType == 'Internal'",
         "properties": {},
         "type": "Conditional"
       }

--- a/Modules/Workflow/Workflow/Workflow/Features/GetActivityActions/GetActivityDecisionsQueryHandler.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/GetActivityActions/GetActivityDecisionsQueryHandler.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+using Workflow.Workflow.Engine.Expression;
 using Workflow.Workflow.Repositories;
 
 namespace Workflow.Workflow.Features.GetActivityActions;
@@ -7,17 +7,22 @@ public class GetActivityActionsQueryHandler
     : IRequestHandler<GetActivityActionsQuery, GetActivityActionsResponse>
 {
     private readonly IWorkflowInstanceRepository _instanceRepository;
+    private readonly IExpressionEvaluator _expressionEvaluator;
 
-    public GetActivityActionsQueryHandler(IWorkflowInstanceRepository instanceRepository)
+    public GetActivityActionsQueryHandler(
+        IWorkflowInstanceRepository instanceRepository,
+        IExpressionEvaluator expressionEvaluator)
     {
         _instanceRepository = instanceRepository;
+        _expressionEvaluator = expressionEvaluator;
     }
 
     public async Task<GetActivityActionsResponse> Handle(
         GetActivityActionsQuery request, CancellationToken cancellationToken)
     {
         var instance = await _instanceRepository.GetByIdAsync(request.WorkflowInstanceId, cancellationToken)
-            ?? throw new InvalidOperationException($"Workflow instance {request.WorkflowInstanceId} not found");
+                       ?? throw new InvalidOperationException(
+                           $"Workflow instance {request.WorkflowInstanceId} not found");
 
         var definition = instance.WorkflowDefinition;
         if (definition is null || string.IsNullOrEmpty(definition.JsonDefinition))
@@ -55,7 +60,7 @@ public class GetActivityActionsQueryHandler
                                  bool.TryParse(crf.GetString(), out var b) && b));
 
         // Read actions array from properties, or voteOptions for ApprovalActivity
-        var actions = ReadActions(properties);
+        var actions = ReadActions(properties, instance.Variables);
         if (actions.Count == 0)
             actions = ReadVoteOptions(properties);
 
@@ -67,13 +72,9 @@ public class GetActivityActionsQueryHandler
 
         // Resolve targetActivityId for each action
         foreach (var action in actions)
-        {
             if (valueToConditionKey.TryGetValue(action.Value, out var conditionKey)
                 && conditionKeyToTarget.TryGetValue(conditionKey, out var targetId))
-            {
                 action.TargetActivityId = targetId;
-            }
-        }
 
         return new GetActivityActionsResponse
         {
@@ -91,10 +92,8 @@ public class GetActivityActionsQueryHandler
             return null;
 
         foreach (var activity in activities.EnumerateArray())
-        {
             if (activity.TryGetProperty("id", out var idProp) && idProp.GetString() == activityId)
                 return activity;
-        }
 
         return null;
     }
@@ -111,20 +110,18 @@ public class GetActivityActionsQueryHandler
         {
             var value = item.GetString();
             if (!string.IsNullOrEmpty(value))
-            {
                 actions.Add(new ActionDto
                 {
                     Value = value,
                     Label = value.Replace("_", " "),
                     AssignmentMode = "system"
                 });
-            }
         }
 
         return actions;
     }
 
-    private static List<ActionDto> ReadActions(JsonElement properties)
+    private List<ActionDto> ReadActions(JsonElement properties, Dictionary<string, object> variables)
     {
         var actions = new List<ActionDto>();
 
@@ -137,16 +134,26 @@ public class GetActivityActionsQueryHandler
             var value = item.TryGetProperty("value", out var v) ? v.GetString() : null;
             var label = item.TryGetProperty("label", out var l) ? l.GetString() : null;
             var mode = item.TryGetProperty("assignmentMode", out var m) ? m.GetString() : "system";
+            var condition = item.TryGetProperty("condition", out var cond) ? cond.GetString() : null;
 
-            if (!string.IsNullOrEmpty(value))
-            {
+            if (!string.IsNullOrEmpty(condition))
+                try
+                {
+                    if (!_expressionEvaluator.EvaluateExpression(condition, variables))
+                        continue;
+                }
+                catch
+                {
+                    continue; // fail closed — hide action if evaluation throws
+                }
+
+            if (!string.IsNullOrEmpty(value) && value != "EXT" && value != "INT")
                 actions.Add(new ActionDto
                 {
                     Value = value,
                     Label = label ?? value,
                     AssignmentMode = mode ?? "system"
                 });
-            }
         }
 
         return actions;

--- a/Modules/Workflow/Workflow/Workflow/Features/GetActivityFormSchema/GetActivityFormSchemaQueryHandler.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/GetActivityFormSchema/GetActivityFormSchemaQueryHandler.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Workflow.Workflow.Engine.Expression;
 using Workflow.Workflow.Repositories;
 
 namespace Workflow.Workflow.Features.GetActivityFormSchema;
@@ -7,10 +8,14 @@ public class GetActivityFormSchemaQueryHandler
     : IRequestHandler<GetActivityFormSchemaQuery, GetActivityFormSchemaResponse>
 {
     private readonly IWorkflowInstanceRepository _instanceRepository;
+    private readonly IExpressionEvaluator _expressionEvaluator;
 
-    public GetActivityFormSchemaQueryHandler(IWorkflowInstanceRepository instanceRepository)
+    public GetActivityFormSchemaQueryHandler(
+        IWorkflowInstanceRepository instanceRepository,
+        IExpressionEvaluator expressionEvaluator)
     {
         _instanceRepository = instanceRepository;
+        _expressionEvaluator = expressionEvaluator;
     }
 
     public async Task<GetActivityFormSchemaResponse> Handle(
@@ -53,7 +58,7 @@ public class GetActivityFormSchemaQueryHandler
 
         if (activity.Value.TryGetProperty("properties", out var properties))
         {
-            actions = ReadActions(properties);
+            actions = ReadActions(properties, instance.Variables);
             formFields = ReadFormFields(properties);
 
             // Resolve targetActivityId for actions (same logic as GetActivityActions)
@@ -104,7 +109,7 @@ public class GetActivityFormSchemaQueryHandler
         return null;
     }
 
-    private static List<ActionDto> ReadActions(JsonElement properties)
+    private List<ActionDto> ReadActions(JsonElement properties, Dictionary<string, object> variables)
     {
         var actions = new List<ActionDto>();
 
@@ -117,6 +122,20 @@ public class GetActivityFormSchemaQueryHandler
             var value = item.TryGetProperty("value", out var v) ? v.GetString() : null;
             var label = item.TryGetProperty("label", out var l) ? l.GetString() : null;
             var mode = item.TryGetProperty("assignmentMode", out var m) ? m.GetString() : "system";
+            var condition = item.TryGetProperty("condition", out var cond) ? cond.GetString() : null;
+
+            if (!string.IsNullOrEmpty(condition))
+            {
+                try
+                {
+                    if (!_expressionEvaluator.EvaluateExpression(condition, variables))
+                        continue;
+                }
+                catch
+                {
+                    continue; // fail closed — hide action if evaluation throws
+                }
+            }
 
             if (!string.IsNullOrEmpty(value))
             {

--- a/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/SetVariableStep.cs
+++ b/Modules/Workflow/Workflow/Workflow/Pipeline/Steps/SetVariableStep.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Workflow.Workflow.Pipeline.Steps;
+
+/// <summary>
+/// Sets a workflow variable from step parameters.
+/// Parameters JSON: {"variable": "assignmentType", "value": "Internal"}
+/// </summary>
+public class SetVariableStep(ILogger<SetVariableStep> logger) : IActivityProcessStep
+{
+    public string Name => "SetVariable";
+
+    public Task<ProcessStepResult> ExecuteAsync(ProcessStepContext context, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(context.Parameters))
+            return Task.FromResult(ProcessStepResult.Fail("Missing parameters for SetVariable step"));
+
+        try
+        {
+            using var doc = JsonDocument.Parse(context.Parameters);
+            var root = doc.RootElement;
+
+            var variable = root.TryGetProperty("variable", out var v) ? v.GetString() : null;
+            var value = root.TryGetProperty("value", out var val) ? val.GetString() : null;
+
+            if (string.IsNullOrEmpty(variable) || value is null)
+                return Task.FromResult(ProcessStepResult.Fail("Missing 'variable' or 'value' in parameters"));
+
+            if (context.Variables is not null)
+            {
+                context.Variables[variable] = value;
+                logger.LogInformation(
+                    "SetVariableStep: set {Variable} = {Value} for activity {ActivityName}",
+                    variable, value, context.ActivityName);
+            }
+
+            return Task.FromResult(ProcessStepResult.Ok());
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "SetVariableStep failed for activity {ActivityName}", context.ActivityName);
+            return Task.FromResult(ProcessStepResult.Fail(ex.Message));
+        }
+    }
+}

--- a/Modules/Workflow/Workflow/WorkflowModule.cs
+++ b/Modules/Workflow/Workflow/WorkflowModule.cs
@@ -174,6 +174,7 @@ public static class WorkflowModule
         services.AddScoped<IActivityProcessStep, ValidateTaskOwnershipStep>();
         services.AddScoped<IActivityProcessStep, ValidateDecisionConstraintsStep>();
         services.AddScoped<IActivityProcessStep, EmitAppraisalCreationRequestedStep>();
+        services.AddScoped<IActivityProcessStep, SetVariableStep>();
         services.AddScoped<ProcessStepResolver>();
         services.AddScoped<IActivityProcessPipeline, ActivityProcessPipeline>();
         services.AddScoped<AppraisalCreationTriggerEvaluator>();

--- a/Shared/Shared.Messaging/Events/AppraisalApprovedByCommitteeIntegrationEvent.cs
+++ b/Shared/Shared.Messaging/Events/AppraisalApprovedByCommitteeIntegrationEvent.cs
@@ -1,0 +1,15 @@
+namespace Shared.Messaging.Events;
+
+/// <summary>
+/// Published by the Workflow module when the pending-approval activity completes
+/// with decision == "approve". Consumed by the Appraisal module to stamp
+/// CompletedAt and ApprovedByCommittee on the aggregate.
+/// </summary>
+public record AppraisalApprovedByCommitteeIntegrationEvent : IntegrationEvent
+{
+    public Guid AppraisalId { get; init; }
+    public string CommitteeCode { get; init; } = null!;
+    public string? CommitteeName { get; init; }
+    public DateTime ApprovedAt { get; init; }
+    public string? ApprovedBy { get; init; } // user that cast the deciding vote
+}


### PR DESCRIPTION
## Summary
- Saved searches CRUD (new Common subdomain) to persist appraisal list views
- Appraisal list enhancements: central `AppraisalFilterBuilder`, richer filters, saved-view lookups, export endpoint, SQL view updates (`vw_AppraisalList`, `vw_AppraisalDetail`)
- Committee approval integration event: emitted from `ApprovalActivity` via outbox on `approve` decision; Appraisal handler stamps `CompletedAt` / `ApprovedByCommittee` idempotently (new domain fields + migration `20260416183759_AddAppraisalCommitteeApprovalFields`)
- Workflow engine: new `SetVariableStep` + seed migration, new `Proceed` action and `admin-proceed-external`/`admin-proceed-internal` transitions in `appraisal-workflow.json`, assignment-mode refinements
- Misc: `GetReminders`, `GetPoolTasks`, `vw_DailyAppraisalCountsFromSource`, `vw_TaskList`, `AuthModule`

## Test plan
- [ ] `dotnet build` succeeds
- [ ] Migrations apply cleanly on a fresh DB: `dotnet ef database update` for Appraisal, Common, Workflow
- [ ] Create / list / delete a saved search via the new endpoints
- [ ] Appraisal list + export + saved views return expected shapes
- [ ] Run an appraisal through committee approval — `appraisal.CompletedAt` and `ApprovedByCommittee` are stamped exactly once (retry-safe)
- [ ] Workflow admin-proceed transition routes correctly to `company-selection` (Ext) and `int-appraisal-execution` (Int)

🤖 Generated with [Claude Code](https://claude.com/claude-code)