### PR TITLE
chore: switch domain timestamps from UTC to server local time

### DIFF
--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/Appointment.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/Appointment.cs
@@ -81,8 +81,8 @@ public class Appointment : Entity<Guid>
         RecordHistory("StatusChanged", approvedBy, "Approved from Pending");
         Status = "Approved";
         ApprovedBy = approvedBy;
-        ApprovedAt = DateTime.UtcNow;
-        ActionDate = DateTime.UtcNow;
+        ApprovedAt = DateTime.Now;
+        ActionDate = DateTime.Now;
     }
 
     public void Complete(string changedBy)
@@ -92,7 +92,7 @@ public class Appointment : Entity<Guid>
 
         RecordHistory("StatusChanged", changedBy, "Completed");
         Status = "Completed";
-        ActionDate = DateTime.UtcNow;
+        ActionDate = DateTime.Now;
     }
 
     public void Cancel(string changedBy, string? reason = null)
@@ -103,7 +103,7 @@ public class Appointment : Entity<Guid>
         RecordHistory("Cancelled", changedBy, reason);
         Status = "Cancelled";
         Reason = reason;
-        ActionDate = DateTime.UtcNow;
+        ActionDate = DateTime.Now;
     }
 
     public void Reschedule(string changedBy, DateTime newDate, string? reason = null)
@@ -116,7 +116,7 @@ public class Appointment : Entity<Guid>
         Reason = reason;
         RescheduleCount++;
         Status = "Pending"; // Reset to pending for re-approval
-        ActionDate = DateTime.UtcNow;
+        ActionDate = DateTime.Now;
     }
 
     private void RecordHistory(string changeType, string changedBy, string? reason)

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/AppointmentHistory.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/AppointmentHistory.cs
@@ -44,7 +44,7 @@ public class AppointmentHistory : Entity<Guid>
             PreviousLocationDetail = previousLocationDetail,
             ChangeType = changeType,
             ChangeReason = changeReason,
-            ChangedAt = DateTime.UtcNow,
+            ChangedAt = DateTime.Now,
             ChangedBy = changedBy
         };
     }

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/Appraisal.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/Appraisal.cs
@@ -110,7 +110,7 @@ public class Appraisal : Aggregate<Guid>
 
         if (slaDays.HasValue)
         {
-            SLADueDate = DateTime.UtcNow.AddDays(slaDays.Value);
+            SLADueDate = DateTime.Now.AddDays(slaDays.Value);
             SLAStatus = "OnTrack";
         }
     }
@@ -660,8 +660,8 @@ public class Appraisal : Aggregate<Guid>
         UpdateStatus(AppraisalStatus.Completed);
 
         // Calculate actual days
-        ActualDaysToComplete = CreatedAt.HasValue ? (DateTime.UtcNow - CreatedAt.Value).Days : null;
-        IsWithinSLA = !SLADueDate.HasValue || DateTime.UtcNow <= SLADueDate.Value;
+        ActualDaysToComplete = CreatedAt.HasValue ? (DateTime.Now - CreatedAt.Value).Days : null;
+        IsWithinSLA = !SLADueDate.HasValue || DateTime.Now <= SLADueDate.Value;
 
         AddDomainEvent(new AppraisalCompletedEvent(this));
     }
@@ -677,8 +677,8 @@ public class Appraisal : Aggregate<Guid>
         ApprovedByCommittee = committeeCode;
         
         // Calculate actual days
-        ActualDaysToComplete = CreatedAt.HasValue ? (DateTime.UtcNow - CreatedAt.Value).Days : null;
-        IsWithinSLA = !SLADueDate.HasValue || DateTime.UtcNow <= SLADueDate.Value;
+        ActualDaysToComplete = CreatedAt.HasValue ? (DateTime.Now - CreatedAt.Value).Days : null;
+        IsWithinSLA = !SLADueDate.HasValue || DateTime.Now <= SLADueDate.Value;
 
         AddDomainEvent(new AppraisalCompletedEvent(this));
     }
@@ -741,7 +741,7 @@ public class Appraisal : Aggregate<Guid>
     {
         if (!SLADueDate.HasValue) return;
 
-        var daysRemaining = (SLADueDate.Value - DateTime.UtcNow).Days;
+        var daysRemaining = (SLADueDate.Value - DateTime.Now).Days;
         SLAStatus = daysRemaining switch
         {
             < 0 => "Breached",

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalAssignment.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalAssignment.cs
@@ -78,7 +78,7 @@ public class AppraisalAssignment : Entity<Guid>
         PreviousAssignmentId = previousAssignmentId;
         ReassignmentNumber = reassignmentNumber;
         AssignmentStatus = AssignmentStatus.Pending;
-        AssignedAt = DateTime.UtcNow;
+        AssignedAt = DateTime.Now;
         AssignedBy = assignedBy;
         ProgressPercent = 0;
     }
@@ -143,7 +143,7 @@ public class AppraisalAssignment : Entity<Guid>
         AssignedBy = assignedBy;
 
         AssignmentStatus = AssignmentStatus.Assigned;
-        AssignedAt = DateTime.UtcNow;
+        AssignedAt = DateTime.Now;
     }
 
     /// <summary>
@@ -154,7 +154,7 @@ public class AppraisalAssignment : Entity<Guid>
         ValidateStatus(AssignmentStatus.Assigned, "start work");
 
         AssignmentStatus = AssignmentStatus.InProgress;
-        StartedAt = DateTime.UtcNow;
+        StartedAt = DateTime.Now;
     }
 
     /// <summary>
@@ -169,7 +169,7 @@ public class AppraisalAssignment : Entity<Guid>
             throw new InvalidOperationException("Can only update progress for in-progress assignments");
 
         ProgressPercent = percent;
-        LastProgressUpdate = DateTime.UtcNow;
+        LastProgressUpdate = DateTime.Now;
     }
 
     /// <summary>
@@ -181,7 +181,7 @@ public class AppraisalAssignment : Entity<Guid>
 
         AssignmentStatus = AssignmentStatus.Completed;
         ProgressPercent = 100;
-        CompletedAt = DateTime.UtcNow;
+        CompletedAt = DateTime.Now;
     }
 
     /// <summary>

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalFeeItem.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalFeeItem.cs
@@ -58,7 +58,7 @@ public class AppraisalFeeItem : Entity<Guid>
 
         ApprovalStatus = "Approved";
         ApprovedBy = approvedBy;
-        ApprovedAt = DateTime.UtcNow;
+        ApprovedAt = DateTime.Now;
     }
 
     public void Reject(Guid rejectedBy, string reason)
@@ -68,7 +68,7 @@ public class AppraisalFeeItem : Entity<Guid>
 
         ApprovalStatus = "Rejected";
         ApprovedBy = rejectedBy;
-        ApprovedAt = DateTime.UtcNow;
+        ApprovedAt = DateTime.Now;
         RejectionReason = reason;
     }
 }

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalGallery.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalGallery.cs
@@ -63,7 +63,7 @@ public class AppraisalGallery : Entity<Guid>
             PhotoNumber = photoNumber,
             PhotoType = photoType,
             IsInUse = false,
-            UploadedAt = DateTime.UtcNow,
+            UploadedAt = DateTime.Now,
             UploadedBy = uploadedBy,
             FileName = fileName,
             FilePath = filePath,

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalReview.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalReview.cs
@@ -58,7 +58,7 @@ public class AppraisalReview : Entity<Guid>
     public void AssignTo(Guid userId, Guid assignedBy, Guid? teamId = null, string? teamName = null)
     {
         AssignedTo = userId;
-        AssignedAt = DateTime.UtcNow;
+        AssignedAt = DateTime.Now;
         AssignedBy = assignedBy;
         TeamId = teamId;
         TeamName = teamName;
@@ -75,7 +75,7 @@ public class AppraisalReview : Entity<Guid>
     public void Approve(Guid reviewedBy, string? comments = null)
     {
         Status = ReviewStatus.Approved;
-        ReviewedAt = DateTime.UtcNow;
+        ReviewedAt = DateTime.Now;
         ReviewedBy = reviewedBy;
         ReviewComments = comments;
     }
@@ -86,7 +86,7 @@ public class AppraisalReview : Entity<Guid>
             throw new ArgumentException("Return reason is required");
 
         Status = ReviewStatus.Returned;
-        ReviewedAt = DateTime.UtcNow;
+        ReviewedAt = DateTime.Now;
         ReviewedBy = reviewedBy;
         ReturnReason = reason;
         ReviewComments = comments;

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/CondoUnitUpload.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/CondoUnitUpload.cs
@@ -19,7 +19,7 @@ public class CondoUnitUpload : Entity<Guid>
             Id = Guid.CreateVersion7(),
             AppraisalId = appraisalId,
             FileName = fileName,
-            UploadedAt = DateTime.UtcNow,
+            UploadedAt = DateTime.Now,
             IsUsed = false,
             DocumentId = documentId
         };

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/PropertyPhotoMapping.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/PropertyPhotoMapping.cs
@@ -38,7 +38,7 @@ public class PropertyPhotoMapping : Entity<Guid>
             PhotoPurpose = photoPurpose,
             SequenceNumber = 1,
             LinkedBy = linkedBy,
-            LinkedAt = DateTime.UtcNow
+            LinkedAt = DateTime.Now
         };
     }
 

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/SoftDelete.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/SoftDelete.cs
@@ -23,7 +23,7 @@ public class SoftDelete : ValueObject
 
     public static SoftDelete Deleted(Guid? deletedBy)
     {
-        return new SoftDelete(true, DateTime.UtcNow, deletedBy);
+        return new SoftDelete(true, DateTime.Now, deletedBy);
     }
 
     public override string ToString()

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/VillageUnitUpload.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/VillageUnitUpload.cs
@@ -19,7 +19,7 @@ public class VillageUnitUpload : Entity<Guid>
             Id = Guid.CreateVersion7(),
             AppraisalId = appraisalId,
             FileName = fileName,
-            UploadedAt = DateTime.UtcNow,
+            UploadedAt = DateTime.Now,
             IsUsed = false,
             DocumentId = documentId
         };

--- a/Modules/Appraisal/Appraisal/Domain/Committees/CommitteeVote.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Committees/CommitteeVote.cs
@@ -35,7 +35,7 @@ public class CommitteeVote : Entity<Guid>
             MemberName = memberName,
             MemberRole = memberRole,
             Vote = vote,
-            VotedAt = DateTime.UtcNow,
+            VotedAt = DateTime.Now,
             Comments = comments
         };
     }

--- a/Modules/Appraisal/Appraisal/Domain/Quotations/CompanyQuotation.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Quotations/CompanyQuotation.cs
@@ -60,7 +60,7 @@ public class CompanyQuotation : Entity<Guid>
             InvitationId = invitationId,
             CompanyId = companyId,
             QuotationNumber = quotationNumber,
-            SubmittedAt = DateTime.UtcNow,
+            SubmittedAt = DateTime.Now,
             EstimatedDays = estimatedDays,
             Status = "Submitted",
             TotalQuotedPrice = 0

--- a/Modules/Appraisal/Appraisal/Domain/Quotations/QuotationInvitation.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Quotations/QuotationInvitation.cs
@@ -28,7 +28,7 @@ public class QuotationInvitation : Entity<Guid>
             Id = Guid.CreateVersion7(),
             QuotationRequestId = quotationRequestId,
             CompanyId = companyId,
-            InvitedAt = DateTime.UtcNow,
+            InvitedAt = DateTime.Now,
             Status = "Pending",
             NotificationSent = false
         };
@@ -37,12 +37,12 @@ public class QuotationInvitation : Entity<Guid>
     public void MarkNotificationSent()
     {
         NotificationSent = true;
-        NotificationSentAt = DateTime.UtcNow;
+        NotificationSentAt = DateTime.Now;
     }
 
     public void MarkViewed()
     {
-        ViewedAt ??= DateTime.UtcNow;
+        ViewedAt ??= DateTime.Now;
     }
 
     public void MarkSubmitted()

--- a/Modules/Appraisal/Appraisal/Domain/Quotations/QuotationNegotiation.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Quotations/QuotationNegotiation.cs
@@ -54,7 +54,7 @@ public class QuotationNegotiation : Entity<Guid>
             NegotiationRound = negotiationRound,
             InitiatedBy = initiatedBy,
             InitiatedByUserId = initiatedByUserId,
-            InitiatedAt = DateTime.UtcNow,
+            InitiatedAt = DateTime.Now,
             Message = message,
             CounterPrice = counterPrice,
             CounterTimeline = counterTimeline,
@@ -69,7 +69,7 @@ public class QuotationNegotiation : Entity<Guid>
 
         Status = "Accepted";
         RespondedBy = respondedBy;
-        RespondedAt = DateTime.UtcNow;
+        RespondedAt = DateTime.Now;
         ResponseMessage = responseMessage;
     }
 
@@ -80,7 +80,7 @@ public class QuotationNegotiation : Entity<Guid>
 
         Status = "Rejected";
         RespondedBy = respondedBy;
-        RespondedAt = DateTime.UtcNow;
+        RespondedAt = DateTime.Now;
         ResponseMessage = responseMessage;
     }
 
@@ -91,7 +91,7 @@ public class QuotationNegotiation : Entity<Guid>
 
         Status = "Countered";
         RespondedBy = respondedBy;
-        RespondedAt = DateTime.UtcNow;
+        RespondedAt = DateTime.Now;
         ResponseMessage = responseMessage;
     }
 }

--- a/Modules/Appraisal/Appraisal/Domain/Quotations/QuotationRequest.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Quotations/QuotationRequest.cs
@@ -52,7 +52,7 @@ public class QuotationRequest : Aggregate<Guid>
         return new QuotationRequest
         {
             Id = Guid.CreateVersion7(),
-            RequestDate = DateTime.UtcNow,
+            RequestDate = DateTime.Now,
             DueDate = dueDate,
             RequestedBy = requestedBy,
             RequestedByName = requestedByName,
@@ -117,7 +117,7 @@ public class QuotationRequest : Aggregate<Guid>
 
         SelectedCompanyId = companyId;
         SelectedQuotationId = quotationId;
-        SelectedAt = DateTime.UtcNow;
+        SelectedAt = DateTime.Now;
         SelectionReason = reason;
         Status = "Closed";
 

--- a/Modules/Auth/Auth/Domain/Companies/Company.cs
+++ b/Modules/Auth/Auth/Domain/Companies/Company.cs
@@ -81,7 +81,7 @@ public class Company : Entity<Guid>
     public void Delete(Guid? deletedBy)
     {
         IsDeleted = true;
-        DeletedOn = DateTime.UtcNow;
+        DeletedOn = DateTime.Now;
         DeletedBy = deletedBy;
     }
 }

--- a/Modules/Auth/Auth/Domain/Groups/Group.cs
+++ b/Modules/Auth/Auth/Domain/Groups/Group.cs
@@ -40,7 +40,7 @@ public class Group : Entity<Guid>
     public void Delete(Guid? deletedBy)
     {
         IsDeleted = true;
-        DeletedOn = DateTime.UtcNow;
+        DeletedOn = DateTime.Now;
         DeletedBy = deletedBy;
     }
 }

--- a/Modules/Common/Common/Domain/Notes/DashboardNote.cs
+++ b/Modules/Common/Common/Domain/Notes/DashboardNote.cs
@@ -36,7 +36,7 @@ public class DashboardNote
     {
         ValidateContent(content);
 
-        var now = DateTimeOffset.UtcNow;
+        var now = DateTimeOffset.Now;
         return new DashboardNote
         {
             Id = Guid.CreateVersion7(),
@@ -54,7 +54,7 @@ public class DashboardNote
     {
         ValidateContent(content);
         Content = content.Trim();
-        UpdatedAt = DateTimeOffset.UtcNow;
+        UpdatedAt = DateTimeOffset.Now;
     }
 
     private static void ValidateContent(string content)

--- a/Modules/Common/Common/Domain/SavedSearches/SavedSearch.cs
+++ b/Modules/Common/Common/Domain/SavedSearches/SavedSearch.cs
@@ -84,7 +84,7 @@ public class SavedSearch
                 $"FiltersJson exceeds the maximum allowed length of {MaxFiltersJsonLength} characters.",
                 nameof(filtersJson));
 
-        var now = DateTimeOffset.UtcNow;
+        var now = DateTimeOffset.Now;
         return new SavedSearch
         {
             Id = Guid.CreateVersion7(),

--- a/Modules/Document/Document/Domain/Documents/Document.cs
+++ b/Modules/Document/Document/Domain/Documents/Document.cs
@@ -191,7 +191,7 @@ public class Document : Aggregate<Guid>
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(deletedBy);
         IsDeleted = true;
-        DeletedAt = DateTime.UtcNow;
+        DeletedAt = DateTime.Now;
         DeletedBy = deletedBy;
         IsActive = false;
     }

--- a/Modules/Integration/Integration/Domain/IdempotencyRecords/IdempotencyRecord.cs
+++ b/Modules/Integration/Integration/Domain/IdempotencyRecords/IdempotencyRecord.cs
@@ -36,7 +36,7 @@ public class IdempotencyRecord : Entity<Guid>
         ArgumentException.ThrowIfNullOrWhiteSpace(idempotencyKey);
         ArgumentException.ThrowIfNullOrWhiteSpace(operationType);
 
-        var expiresAt = DateTime.UtcNow.Add(expiresIn ?? TimeSpan.FromHours(24));
+        var expiresAt = DateTime.Now.Add(expiresIn ?? TimeSpan.FromHours(24));
 
         return new IdempotencyRecord(idempotencyKey, operationType, requestHash, expiresAt);
     }
@@ -47,5 +47,5 @@ public class IdempotencyRecord : Entity<Guid>
         StatusCode = statusCode;
     }
 
-    public bool IsExpired() => DateTime.UtcNow >= ExpiresAt;
+    public bool IsExpired() => DateTime.Now >= ExpiresAt;
 }

--- a/Modules/Integration/Integration/Domain/WebhookDeliveries/WebhookDelivery.cs
+++ b/Modules/Integration/Integration/Domain/WebhookDeliveries/WebhookDelivery.cs
@@ -49,7 +49,7 @@ public class WebhookDelivery : Entity<Guid>
         if (statusCode >= 200 && statusCode < 300)
         {
             Status = DeliveryStatus.Delivered;
-            DeliveredAt = DateTime.UtcNow;
+            DeliveredAt = DateTime.Now;
             NextRetryAt = null;
         }
         else if (AttemptCount >= 3)
@@ -60,7 +60,7 @@ public class WebhookDelivery : Entity<Guid>
         else
         {
             Status = DeliveryStatus.Retrying;
-            NextRetryAt = DateTime.UtcNow.Add(GetRetryDelay(AttemptCount));
+            NextRetryAt = DateTime.Now.Add(GetRetryDelay(AttemptCount));
         }
     }
 

--- a/Modules/Workflow/Workflow/Data/Entities/ActivityProcessConfiguration.cs
+++ b/Modules/Workflow/Workflow/Data/Entities/ActivityProcessConfiguration.cs
@@ -98,8 +98,8 @@ public class ActivityProcessConfiguration : Entity<Guid>
             RunIfExpression = runIfExpression,
             IsActive = true,
             Version = 1,
-            CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.Now,
+            UpdatedAt = DateTime.Now,
             CreatedBy = createdBy,
             UpdatedBy = createdBy
         };
@@ -129,7 +129,7 @@ public class ActivityProcessConfiguration : Entity<Guid>
         RunIfExpression = runIfExpression;
         IsActive = isActive;
         Version++;
-        UpdatedAt = DateTime.UtcNow;
+        UpdatedAt = DateTime.Now;
         UpdatedBy = updatedBy;
     }
 
@@ -137,7 +137,7 @@ public class ActivityProcessConfiguration : Entity<Guid>
     {
         IsActive = isActive;
         Version++;
-        UpdatedAt = DateTime.UtcNow;
+        UpdatedAt = DateTime.Now;
         UpdatedBy = updatedBy;
     }
 }

--- a/Modules/Workflow/Workflow/Data/Entities/ActivityProcessExecution.cs
+++ b/Modules/Workflow/Workflow/Data/Entities/ActivityProcessExecution.cs
@@ -103,7 +103,7 @@ public class ActivityProcessExecution
             SkipReason = skipReason,
             DurationMs = durationMs,
             ErrorMessage = errorMessage,
-            CreatedOn = DateTime.UtcNow
+            CreatedOn = DateTime.Now
         };
     }
 }

--- a/Modules/Workflow/Workflow/Data/Entities/TaskAssignmentConfiguration.cs
+++ b/Modules/Workflow/Workflow/Data/Entities/TaskAssignmentConfiguration.cs
@@ -108,8 +108,8 @@ public class TaskAssignmentConfiguration : Entity<Guid>
             AssigneeGroup = assigneeGroup,
             AdditionalConfiguration = additionalConfiguration,
             IsActive = true,
-            CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.Now,
+            UpdatedAt = DateTime.Now,
             CreatedBy = createdBy,
             UpdatedBy = createdBy
         };
@@ -137,21 +137,21 @@ public class TaskAssignmentConfiguration : Entity<Guid>
             EscalateToAdminPool = escalateToAdminPool.Value;
             
         AdditionalConfiguration = additionalConfiguration;
-        UpdatedAt = DateTime.UtcNow;
+        UpdatedAt = DateTime.Now;
         UpdatedBy = updatedBy;
     }
 
     public void Activate(string updatedBy)
     {
         IsActive = true;
-        UpdatedAt = DateTime.UtcNow;
+        UpdatedAt = DateTime.Now;
         UpdatedBy = updatedBy;
     }
 
     public void Deactivate(string updatedBy)
     {
         IsActive = false;
-        UpdatedAt = DateTime.UtcNow;
+        UpdatedAt = DateTime.Now;
         UpdatedBy = updatedBy;
     }
 }

--- a/Modules/Workflow/Workflow/Data/Repository/AssignmentRepository.cs
+++ b/Modules/Workflow/Workflow/Data/Repository/AssignmentRepository.cs
@@ -137,7 +137,7 @@ public class AssignmentRepository(WorkflowDbContext dbContext, ISqlConnectionFac
                         GroupsList = groupsList,
                         UserId = userId,
                         AssignmentCount = 0,
-                        LastAssignedAt = DateTime.UtcNow,
+                        LastAssignedAt = DateTime.Now,
                         IsActive = true
                     });
             }
@@ -165,7 +165,7 @@ public class AssignmentRepository(WorkflowDbContext dbContext, ISqlConnectionFac
         // Select user with minimum count
         var selectedUser = counters.First();
         selectedUser.AssignmentCount++;
-        selectedUser.LastAssignedAt = DateTime.UtcNow;
+        selectedUser.LastAssignedAt = DateTime.Now;
 
         // Check if the round is complete (no active users have count = 0)
         var usersWithZero = counters.Count(x => x.AssignmentCount == 0);

--- a/Modules/Workflow/Workflow/DocumentFollowups/Domain/DocumentFollowup.cs
+++ b/Modules/Workflow/Workflow/DocumentFollowups/Domain/DocumentFollowup.cs
@@ -55,7 +55,7 @@ public class DocumentFollowup : Aggregate<Guid>
             RaisingActivityId = raisingActivityId,
             RaisingUserId = raisingUserId,
             Status = DocumentFollowupStatus.Open,
-            RaisedAt = DateTime.UtcNow
+            RaisedAt = DateTime.Now
         };
 
         foreach (var (type, notes) in items)
@@ -120,7 +120,7 @@ public class DocumentFollowup : Aggregate<Guid>
             throw new InvalidOperationException("All line items must be Uploaded or Declined before submitting");
 
         Status = DocumentFollowupStatus.Resolved;
-        ResolvedAt = DateTime.UtcNow;
+        ResolvedAt = DateTime.Now;
         AddDomainEvent(new DocumentFollowupResolvedDomainEvent(Id, RaisingPendingTaskId));
     }
 
@@ -155,7 +155,7 @@ public class DocumentFollowup : Aggregate<Guid>
 
         Status = DocumentFollowupStatus.Cancelled;
         CancellationReason = reason;
-        ResolvedAt = DateTime.UtcNow;
+        ResolvedAt = DateTime.Now;
         AddDomainEvent(new DocumentFollowupCancelledDomainEvent(Id, RaisingPendingTaskId, reason));
     }
 

--- a/Modules/Workflow/Workflow/DocumentFollowups/Domain/DocumentFollowupLineItem.cs
+++ b/Modules/Workflow/Workflow/DocumentFollowups/Domain/DocumentFollowupLineItem.cs
@@ -28,21 +28,21 @@ public class DocumentFollowupLineItem
     {
         Status = DocumentFollowupLineItemStatus.Uploaded;
         DocumentId = documentId;
-        ResolvedAt = DateTime.UtcNow;
+        ResolvedAt = DateTime.Now;
     }
 
     internal void MarkDeclined(string reason)
     {
         Status = DocumentFollowupLineItemStatus.Declined;
         Reason = reason;
-        ResolvedAt = DateTime.UtcNow;
+        ResolvedAt = DateTime.Now;
     }
 
     internal void MarkCancelled(string reason)
     {
         Status = DocumentFollowupLineItemStatus.Cancelled;
         Reason = reason;
-        ResolvedAt = DateTime.UtcNow;
+        ResolvedAt = DateTime.Now;
     }
 }
 

--- a/Modules/Workflow/Workflow/Domain/ApprovalVote.cs
+++ b/Modules/Workflow/Workflow/Domain/ApprovalVote.cs
@@ -30,7 +30,7 @@ public class ApprovalVote : Entity<Guid>
             MemberRole = memberRole,
             Vote = vote,
             Comments = comments,
-            VotedAt = DateTime.UtcNow
+            VotedAt = DateTime.Now
         };
     }
 }

--- a/Modules/Workflow/Workflow/Meetings/Domain/Meeting.cs
+++ b/Modules/Workflow/Workflow/Meetings/Domain/Meeting.cs
@@ -366,7 +366,7 @@ public class Meeting : Aggregate<Guid>
 
         Status = MeetingStatus.Cancelled;
         CancelReason = reason;
-        CancelledAt = DateTime.UtcNow;
+        CancelledAt = DateTime.Now;
 
         var cancelledDecisionItems = _items
             .Where(i => i.Kind == MeetingItemKind.Decision)

--- a/Modules/Workflow/Workflow/Meetings/Domain/MeetingItem.cs
+++ b/Modules/Workflow/Workflow/Meetings/Domain/MeetingItem.cs
@@ -62,7 +62,7 @@ public class MeetingItem : Entity<Guid>
             FacilityLimit = facilityLimit,
             WorkflowInstanceId = workflowInstanceId,
             ActivityId = activityId,
-            AddedAt = DateTime.UtcNow,
+            AddedAt = DateTime.Now,
             Kind = MeetingItemKind.Decision,
             AppraisalType = appraisalType,
             ItemDecision = ItemDecision.Pending
@@ -92,7 +92,7 @@ public class MeetingItem : Entity<Guid>
             FacilityLimit = facilityLimit,
             WorkflowInstanceId = null,
             ActivityId = null,
-            AddedAt = DateTime.UtcNow,
+            AddedAt = DateTime.Now,
             Kind = MeetingItemKind.Acknowledgement,
             AppraisalType = appraisalType,
             AcknowledgementGroup = acknowledgementGroup,

--- a/Modules/Workflow/Workflow/Meetings/Domain/MeetingMember.cs
+++ b/Modules/Workflow/Workflow/Meetings/Domain/MeetingMember.cs
@@ -42,7 +42,7 @@ public class MeetingMember : Entity<Guid>
             MemberName = committeeMember.MemberName,
             Position = committeeMember.Position,
             SourceCommitteeMemberId = committeeMember.Id,
-            AddedAt = DateTime.UtcNow
+            AddedAt = DateTime.Now
         };
     }
 
@@ -66,7 +66,7 @@ public class MeetingMember : Entity<Guid>
             MemberName = memberName.Trim(),
             Position = position,
             SourceCommitteeMemberId = null,
-            AddedAt = DateTime.UtcNow
+            AddedAt = DateTime.Now
         };
     }
 

--- a/Modules/Workflow/Workflow/Meetings/ReadModels/AppraisalAcknowledgementQueueItem.cs
+++ b/Modules/Workflow/Workflow/Meetings/ReadModels/AppraisalAcknowledgementQueueItem.cs
@@ -56,7 +56,7 @@ public class AppraisalAcknowledgementQueueItem : Entity<Guid>
             CommitteeCode = committeeCode,
             AcknowledgementGroup = acknowledgementGroup,
             Status = AcknowledgementStatus.PendingAcknowledgement,
-            EnqueuedAt = DateTime.UtcNow
+            EnqueuedAt = DateTime.Now
         };
     }
 

--- a/Modules/Workflow/Workflow/Meetings/ReadModels/MeetingQueueItem.cs
+++ b/Modules/Workflow/Workflow/Meetings/ReadModels/MeetingQueueItem.cs
@@ -38,7 +38,7 @@ public class MeetingQueueItem : Entity<Guid>
             WorkflowInstanceId = workflowInstanceId,
             ActivityId = activityId,
             Status = MeetingQueueItemStatus.Queued,
-            EnqueuedAt = DateTime.UtcNow
+            EnqueuedAt = DateTime.Now
         };
     }
 

--- a/Modules/Workflow/Workflow/Tasks/Models/PendingTask.cs
+++ b/Modules/Workflow/Workflow/Tasks/Models/PendingTask.cs
@@ -77,7 +77,7 @@ public class PendingTask : Aggregate<Guid>
             throw new InvalidOperationException($"Task is already locked by {WorkingBy}");
 
         WorkingBy = username;
-        LockedAt = DateTime.UtcNow;
+        LockedAt = DateTime.Now;
     }
 
     public void ReleaseLock()
@@ -90,7 +90,7 @@ public class PendingTask : Aggregate<Guid>
         string.Equals(WorkingBy, username, StringComparison.OrdinalIgnoreCase);
 
     public bool IsLockExpired(TimeSpan timeout) =>
-        LockedAt.HasValue && LockedAt.Value.Add(timeout) < DateTime.UtcNow;
+        LockedAt.HasValue && LockedAt.Value.Add(timeout) < DateTime.Now;
 
     public void MarkAtRisk()
     {

--- a/Modules/Workflow/Workflow/Telemetry/WorkflowTracing.cs
+++ b/Modules/Workflow/Workflow/Telemetry/WorkflowTracing.cs
@@ -218,7 +218,7 @@ internal class WorkflowSpan : IWorkflowSpan
                 eventTags[WorkflowTelemetryConstants.SemanticAttributes.WorkflowErrorStackTrace] = exception.StackTrace;
             }
             
-            Activity.AddEvent(new ActivityEvent("exception", DateTimeOffset.UtcNow, eventTags));
+            Activity.AddEvent(new ActivityEvent("exception", DateTimeOffset.Now, eventTags));
         }
         
         return this;
@@ -238,7 +238,7 @@ internal class WorkflowSpan : IWorkflowSpan
                 ? new ActivityTagsCollection(attributes.Select(kv => new KeyValuePair<string, object?>(kv.Key, kv.Value)))
                 : new ActivityTagsCollection();
                 
-            Activity.AddEvent(new ActivityEvent(name, DateTimeOffset.UtcNow, tags));
+            Activity.AddEvent(new ActivityEvent(name, DateTimeOffset.Now, tags));
         }
         
         return this;

--- a/Modules/Workflow/Workflow/Telemetry/WorkflowTracingUsageExamples.cs
+++ b/Modules/Workflow/Workflow/Telemetry/WorkflowTracingUsageExamples.cs
@@ -64,7 +64,7 @@ public static class WorkflowTracingUsageExamples
                 {
                     // Add activity context
                     span.SetAttribute("assignee_id", "approver123")
-                        .SetAttribute("due_date", DateTime.UtcNow.AddDays(1))
+                        .SetAttribute("due_date", DateTime.Now.AddDays(1))
                         .SetAttribute("task_priority", "medium");
 
                     // Record activity milestone

--- a/Modules/Workflow/Workflow/Workflow/Actions/PublishEventAction.cs
+++ b/Modules/Workflow/Workflow/Workflow/Actions/PublishEventAction.cs
@@ -292,7 +292,7 @@ public class EventPublishResult
             EventId = eventId,
             MessageId = messageId,
             PublishDetails = publishDetails ?? new Dictionary<string, object>(),
-            PublishedAt = DateTime.UtcNow
+            PublishedAt = DateTime.Now
         };
     
     public static EventPublishResult Failed(string errorMessage)
@@ -300,6 +300,6 @@ public class EventPublishResult
         {
             IsSuccess = false,
             ErrorMessage = errorMessage,
-            PublishedAt = DateTime.UtcNow
+            PublishedAt = DateTime.Now
         };
 }

--- a/Modules/Workflow/Workflow/Workflow/Actions/SendNotificationAction.cs
+++ b/Modules/Workflow/Workflow/Workflow/Actions/SendNotificationAction.cs
@@ -243,7 +243,7 @@ public class SendNotificationAction : WorkflowActionBase
         templateData.TryAdd("workflowInstanceId", context.WorkflowInstanceId);
         templateData.TryAdd("activityId", context.ActivityId);
         templateData.TryAdd("assignee", context.CurrentAssignee ?? "");
-        templateData.TryAdd("timestamp", DateTime.UtcNow);
+        templateData.TryAdd("timestamp", DateTime.Now);
         
         // Add workflow variables (be careful with sensitive data)
         foreach (var variable in context.Variables)
@@ -335,7 +335,7 @@ public class NotificationResult
             IsSuccess = true,
             NotificationId = notificationId,
             DeliveryDetails = deliveryDetails ?? new Dictionary<string, object>(),
-            SentAt = DateTime.UtcNow
+            SentAt = DateTime.Now
         };
     
     public static NotificationResult Failed(string errorMessage)
@@ -343,6 +343,6 @@ public class NotificationResult
         {
             IsSuccess = false,
             ErrorMessage = errorMessage,
-            SentAt = DateTime.UtcNow
+            SentAt = DateTime.Now
         };
 }

--- a/Modules/Workflow/Workflow/Workflow/Actions/UpdateEntityStatusAction.cs
+++ b/Modules/Workflow/Workflow/Workflow/Actions/UpdateEntityStatusAction.cs
@@ -233,7 +233,7 @@ public class EntityStatusUpdateResult
             IsSuccess = true,
             NewStatus = newStatus,
             PreviousStatus = previousStatus,
-            UpdatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.Now,
             AdditionalData = additionalData ?? new Dictionary<string, object>()
         };
     
@@ -243,6 +243,6 @@ public class EntityStatusUpdateResult
             IsSuccess = false,
             ErrorMessage = errorMessage,
             NewStatus = "",
-            UpdatedAt = DateTime.UtcNow
+            UpdatedAt = DateTime.Now
         };
 }

--- a/Modules/Workflow/Workflow/Workflow/Activities/Core/ActivityErrorBuilder.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/Core/ActivityErrorBuilder.cs
@@ -44,7 +44,7 @@ public static class ActivityErrorBuilder
             ["errorMessage"] = message,
             ["activityId"] = activityId,
             ["errorType"] = "ExecutionError",
-            ["occurredAt"] = DateTime.UtcNow
+            ["occurredAt"] = DateTime.Now
         };
 
         if (exception != null)
@@ -95,7 +95,7 @@ public static class ActivityErrorBuilder
             ["activityId"] = activityId,
             ["errorType"] = "ExpressionError",
             ["expression"] = expression,
-            ["evaluatedAt"] = DateTime.UtcNow
+            ["evaluatedAt"] = DateTime.Now
         };
     }
 

--- a/Modules/Workflow/Workflow/Workflow/Activities/Core/RuntimeOverride.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/Core/RuntimeOverride.cs
@@ -39,7 +39,7 @@ public class RuntimeOverride
     /// <summary>
     /// Timestamp when the override was created
     /// </summary>
-    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime CreatedAt { get; set; } = DateTime.Now;
 
     /// <summary>
     /// Checks if this override has any assignment specifications

--- a/Modules/Workflow/Workflow/Workflow/Activities/ForkActivity.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/ForkActivity.cs
@@ -39,7 +39,7 @@ public class ForkActivity : WorkflowActivityBase
             Branches = branches,
             ForkType = forkType,
             MaxConcurrency = maxConcurrency,
-            CreatedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.Now,
             Status = ForkStatus.Active
         };
 

--- a/Modules/Workflow/Workflow/Workflow/Activities/JoinActivity.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/JoinActivity.cs
@@ -60,7 +60,7 @@ public class JoinActivity : WorkflowActivityBase
             ["completedBranches"] = branchResults.Count(br => br.Value.Status == BranchStatus.Completed),
             ["totalBranches"] = forkContext.Branches.Count,
             ["mergedData"] = mergedData,
-            ["joinCompletedAt"] = DateTime.UtcNow
+            ["joinCompletedAt"] = DateTime.Now
         };
 
         // Add cleanup variables to output data
@@ -118,7 +118,7 @@ public class JoinActivity : WorkflowActivityBase
 
         // Check timeout
         var isTimeout = timeoutMinutes > 0 && 
-                       DateTime.UtcNow > forkContext.CreatedAt.AddMinutes(timeoutMinutes);
+                       DateTime.Now > forkContext.CreatedAt.AddMinutes(timeoutMinutes);
 
         var result = joinType switch
         {
@@ -250,7 +250,7 @@ public class JoinActivity : WorkflowActivityBase
             ["completedBranches"] = branchResults.Count(br => br.Value.Status == BranchStatus.Completed),
             ["totalBranches"] = forkContext.Branches.Count,
             ["timeoutAction"] = timeoutAction,
-            ["timeoutAt"] = DateTime.UtcNow
+            ["timeoutAt"] = DateTime.Now
         };
 
         return timeoutAction switch

--- a/Modules/Workflow/Workflow/Workflow/Degradation/IWorkflowDegradationService.cs
+++ b/Modules/Workflow/Workflow/Workflow/Degradation/IWorkflowDegradationService.cs
@@ -274,7 +274,7 @@ public class DegradationStatus
         ServiceName = serviceName,
         IsDegraded = false,
         CurrentLevel = ServiceLevel.Full,
-        LastCheck = DateTime.UtcNow
+        LastCheck = DateTime.Now
     };
 
     public static DegradationStatus Degraded(
@@ -287,9 +287,9 @@ public class DegradationStatus
         IsDegraded = true,
         CurrentLevel = level,
         Reason = reason,
-        DegradedSince = DateTime.UtcNow,
+        DegradedSince = DateTime.Now,
         AdditionalInfo = additionalInfo,
-        LastCheck = DateTime.UtcNow
+        LastCheck = DateTime.Now
     };
 }
 
@@ -325,7 +325,7 @@ public class WorkflowContinuationResult
 public class DegradationMetrics
 {
     public Dictionary<string, ServiceDegradationMetrics> ServiceMetrics { get; set; } = new();
-    public DateTime CollectionTime { get; set; } = DateTime.UtcNow;
+    public DateTime CollectionTime { get; set; } = DateTime.Now;
     public ServiceLevel OverallServiceLevel { get; set; }
     public int TotalServices { get; set; }
     public int HealthyServices { get; set; }

--- a/Modules/Workflow/Workflow/Workflow/Degradation/WorkflowDegradationService.cs
+++ b/Modules/Workflow/Workflow/Workflow/Degradation/WorkflowDegradationService.cs
@@ -477,8 +477,8 @@ public class WorkflowDegradationService : IWorkflowDegradationService
         var cachedResult = new CachedResult
         {
             Result = result,
-            CachedAt = DateTime.UtcNow,
-            ExpiresAt = DateTime.UtcNow.Add(expiry)
+            CachedAt = DateTime.Now,
+            ExpiresAt = DateTime.Now.Add(expiry)
         };
         
         cache.Enqueue(cachedResult);
@@ -633,7 +633,7 @@ public class WorkflowDegradationService : IWorkflowDegradationService
             // Clean up expired cache entries
             foreach (var cache in _resultCache.Values)
             {
-                var now = DateTime.UtcNow;
+                var now = DateTime.Now;
                 var itemsToKeep = new List<CachedResult>();
 
                 while (cache.TryDequeue(out var item))

--- a/Modules/Workflow/Workflow/Workflow/Engine/Core/WorkflowExecutionContext.cs
+++ b/Modules/Workflow/Workflow/Workflow/Engine/Core/WorkflowExecutionContext.cs
@@ -135,7 +135,7 @@ public class WorkflowExecutionContext
             ActivityId = activityId,
             Status = status,
             Duration = duration,
-            Timestamp = DateTime.UtcNow
+            Timestamp = DateTime.Now
         });
     }
 
@@ -160,7 +160,7 @@ public class WorkflowExecutionContext
 /// </summary>
 public class WorkflowExecutionMetadata
 {
-    public DateTime StartTime { get; set; } = DateTime.UtcNow;
+    public DateTime StartTime { get; set; } = DateTime.Now;
     public List<ExecutionStep> ExecutionSteps { get; set; } = new();
     public Dictionary<string, object> AdditionalData { get; set; } = new();
 

--- a/Modules/Workflow/Workflow/Workflow/Engine/Core/WorkflowOperationResult.cs
+++ b/Modules/Workflow/Workflow/Workflow/Engine/Core/WorkflowOperationResult.cs
@@ -10,7 +10,7 @@ public class WorkflowOperationResult<T>
     public T? Result { get; init; }
     public string? ErrorMessage { get; init; }
     public Exception? Exception { get; init; }
-    public DateTime OperationTime { get; init; } = DateTime.UtcNow;
+    public DateTime OperationTime { get; init; } = DateTime.Now;
     public Dictionary<string, object> Metadata { get; init; } = new();
 
     /// <summary>
@@ -137,7 +137,7 @@ public class WorkflowOperationResult
     public bool IsSuccess { get; init; }
     public string? ErrorMessage { get; init; }
     public Exception? Exception { get; init; }
-    public DateTime OperationTime { get; init; } = DateTime.UtcNow;
+    public DateTime OperationTime { get; init; } = DateTime.Now;
     public Dictionary<string, object> Metadata { get; init; } = new();
 
     /// <summary>

--- a/Modules/Workflow/Workflow/Workflow/Expressions/ExpressionContext.cs
+++ b/Modules/Workflow/Workflow/Workflow/Expressions/ExpressionContext.cs
@@ -28,7 +28,7 @@ public class ExpressionContext
     /// <summary>
     /// Execution timestamp
     /// </summary>
-    public DateTime ExecutionTime { get; set; } = DateTime.UtcNow;
+    public DateTime ExecutionTime { get; set; } = DateTime.Now;
 
     /// <summary>
     /// Global functions and helpers available in expressions
@@ -65,12 +65,12 @@ public class ExpressionContext
         {
             WorkflowInstanceId = workflowInstanceId,
             CurrentUser = currentUser,
-            ExecutionTime = DateTime.UtcNow
+            ExecutionTime = DateTime.Now
         };
 
         // Add common workflow functions
-        context.AddFunction("Now", () => DateTime.UtcNow);
-        context.AddFunction("Today", () => DateTime.UtcNow.Date);
+        context.AddFunction("Now", () => DateTime.Now);
+        context.AddFunction("Today", () => DateTime.Now.Date);
         context.AddFunction("NewGuid", () => Guid.NewGuid());
         context.AddFunction("Random", () => new Random().NextDouble());
 

--- a/Modules/Workflow/Workflow/Workflow/ImportExport/WorkflowExportResult.cs
+++ b/Modules/Workflow/Workflow/Workflow/ImportExport/WorkflowExportResult.cs
@@ -78,7 +78,7 @@ public class WorkflowExportResult
     /// <summary>
     /// When the export was completed
     /// </summary>
-    public DateTime ExportedAt { get; set; } = DateTime.UtcNow;
+    public DateTime ExportedAt { get; set; } = DateTime.Now;
 
     /// <summary>
     /// Create a successful export result
@@ -93,7 +93,7 @@ public class WorkflowExportResult
             DataSizeBytes = System.Text.Encoding.UTF8.GetByteCount(data),
             ExecutionTime = executionTime,
             ContentType = GetContentType(format),
-            FileName = $"workflow_export_{DateTime.UtcNow:yyyyMMdd_HHmmss}{GetFileExtension(format)}"
+            FileName = $"workflow_export_{DateTime.Now:yyyyMMdd_HHmmss}{GetFileExtension(format)}"
         };
     }
 
@@ -110,7 +110,7 @@ public class WorkflowExportResult
             DataSizeBytes = data.Length,
             ExecutionTime = executionTime,
             ContentType = GetContentType(format),
-            FileName = $"workflow_export_{DateTime.UtcNow:yyyyMMdd_HHmmss}{GetFileExtension(format)}"
+            FileName = $"workflow_export_{DateTime.Now:yyyyMMdd_HHmmss}{GetFileExtension(format)}"
         };
     }
 

--- a/Modules/Workflow/Workflow/Workflow/ImportExport/WorkflowImportResult.cs
+++ b/Modules/Workflow/Workflow/Workflow/ImportExport/WorkflowImportResult.cs
@@ -63,7 +63,7 @@ public class WorkflowImportResult
     /// <summary>
     /// When the import was completed
     /// </summary>
-    public DateTime ImportedAt { get; set; } = DateTime.UtcNow;
+    public DateTime ImportedAt { get; set; } = DateTime.Now;
 
     /// <summary>
     /// Create a successful import result

--- a/Modules/Workflow/Workflow/Workflow/Models/WorkflowActivityExecution.cs
+++ b/Modules/Workflow/Workflow/Workflow/Models/WorkflowActivityExecution.cs
@@ -49,7 +49,7 @@ public class WorkflowActivityExecution : Entity<Guid>
             ActivityType = activityType,
             Status = ActivityExecutionStatus.Pending,
             AssignedTo = assignedTo,
-            StartedOn = DateTime.UtcNow,
+            StartedOn = DateTime.Now,
             InputData = inputData ?? new Dictionary<string, object>()
         };
     }
@@ -57,7 +57,7 @@ public class WorkflowActivityExecution : Entity<Guid>
     public void Start()
     {
         Status = ActivityExecutionStatus.InProgress;
-        StartedOn = DateTime.UtcNow;
+        StartedOn = DateTime.Now;
     }
 
     public void Complete(
@@ -66,7 +66,7 @@ public class WorkflowActivityExecution : Entity<Guid>
         string? comments = null)
     {
         Status = ActivityExecutionStatus.Completed;
-        CompletedOn = DateTime.UtcNow;
+        CompletedOn = DateTime.Now;
         CompletedBy = completedBy;
         OutputData = outputData ?? new Dictionary<string, object>();
         Comments = comments;
@@ -75,21 +75,21 @@ public class WorkflowActivityExecution : Entity<Guid>
     public void Fail(string errorMessage)
     {
         Status = ActivityExecutionStatus.Failed;
-        CompletedOn = DateTime.UtcNow;
+        CompletedOn = DateTime.Now;
         ErrorMessage = errorMessage;
     }
 
     public void Skip(string reason)
     {
         Status = ActivityExecutionStatus.Skipped;
-        CompletedOn = DateTime.UtcNow;
+        CompletedOn = DateTime.Now;
         Comments = reason;
     }
 
     public void Cancel(string reason)
     {
         Status = ActivityExecutionStatus.Cancelled;
-        CompletedOn = DateTime.UtcNow;
+        CompletedOn = DateTime.Now;
         Comments = reason;
     }
 

--- a/Modules/Workflow/Workflow/Workflow/Models/WorkflowBookmark.cs
+++ b/Modules/Workflow/Workflow/Workflow/Models/WorkflowBookmark.cs
@@ -50,7 +50,7 @@ public class WorkflowBookmark : Entity<Guid>
             Payload = payload,
             IsConsumed = false,
             DueAt = dueAt,
-            CreatedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.Now,
             ClaimedBy = null,
             ClaimedAt = null,
             LeaseExpiresAt = null
@@ -63,19 +63,19 @@ public class WorkflowBookmark : Entity<Guid>
             throw new InvalidOperationException("Bookmark has already been consumed");
 
         IsConsumed = true;
-        ConsumedAt = DateTime.UtcNow;
+        ConsumedAt = DateTime.Now;
         ConsumedBy = consumedBy;
     }
 
     public bool IsDue()
     {
-        return DueAt.HasValue && DueAt.Value <= DateTime.UtcNow;
+        return DueAt.HasValue && DueAt.Value <= DateTime.Now;
     }
 
     public bool IsExpired(TimeSpan? expiration = null)
     {
         if (!expiration.HasValue) return false;
-        return CreatedAt.Add(expiration.Value) <= DateTime.UtcNow;
+        return CreatedAt.Add(expiration.Value) <= DateTime.Now;
     }
 
     public void Claim(string claimedBy, TimeSpan leaseDuration)
@@ -87,8 +87,8 @@ public class WorkflowBookmark : Entity<Guid>
             throw new InvalidOperationException($"Bookmark is already claimed by {ClaimedBy}");
 
         ClaimedBy = claimedBy;
-        ClaimedAt = DateTime.UtcNow;
-        LeaseExpiresAt = DateTime.UtcNow.Add(leaseDuration);
+        ClaimedAt = DateTime.Now;
+        LeaseExpiresAt = DateTime.Now.Add(leaseDuration);
     }
 
     public void ReleaseClaim()
@@ -100,7 +100,7 @@ public class WorkflowBookmark : Entity<Guid>
 
     public bool IsLeaseExpired()
     {
-        return LeaseExpiresAt.HasValue && LeaseExpiresAt.Value <= DateTime.UtcNow;
+        return LeaseExpiresAt.HasValue && LeaseExpiresAt.Value <= DateTime.Now;
     }
 
     public bool IsAvailableForClaim()

--- a/Modules/Workflow/Workflow/Workflow/Models/WorkflowDefinitionVersion.cs
+++ b/Modules/Workflow/Workflow/Workflow/Models/WorkflowDefinitionVersion.cs
@@ -49,7 +49,7 @@ public class WorkflowDefinitionVersion : Entity<Guid>
             Status = VersionStatus.Draft,
             Category = category,
             Metadata = metadata ?? new Dictionary<string, object>(),
-            CreatedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.Now,
             CreatedBy = createdBy
         };
     }
@@ -71,7 +71,7 @@ public class WorkflowDefinitionVersion : Entity<Guid>
             throw new InvalidOperationException("Version is already published");
 
         Status = VersionStatus.Published;
-        PublishedAt = DateTime.UtcNow;
+        PublishedAt = DateTime.Now;
         PublishedBy = publishedBy;
         BreakingChanges = breakingChanges ?? new List<BreakingChange>();
         MigrationInstructions = migrationInstructions;
@@ -83,7 +83,7 @@ public class WorkflowDefinitionVersion : Entity<Guid>
             throw new InvalidOperationException("Only published versions can be deprecated");
 
         Status = VersionStatus.Deprecated;
-        DeprecatedAt = DateTime.UtcNow;
+        DeprecatedAt = DateTime.Now;
         DeprecatedBy = deprecatedBy;
 
         if (!string.IsNullOrEmpty(reason)) Metadata["DeprecationReason"] = reason;
@@ -92,7 +92,7 @@ public class WorkflowDefinitionVersion : Entity<Guid>
     public void Archive(string archivedBy)
     {
         Status = VersionStatus.Archived;
-        Metadata["ArchivedAt"] = DateTime.UtcNow;
+        Metadata["ArchivedAt"] = DateTime.Now;
         Metadata["ArchivedBy"] = archivedBy;
     }
 
@@ -102,7 +102,7 @@ public class WorkflowDefinitionVersion : Entity<Guid>
             throw new InvalidOperationException("Cannot modify published version schema");
 
         JsonSchema = jsonSchema;
-        UpdatedAt = DateTime.UtcNow;
+        UpdatedAt = DateTime.Now;
         UpdatedBy = updatedBy;
     }
 
@@ -111,7 +111,7 @@ public class WorkflowDefinitionVersion : Entity<Guid>
         Name = name;
         Description = description;
         if (metadata != null) Metadata = metadata;
-        UpdatedAt = DateTime.UtcNow;
+        UpdatedAt = DateTime.Now;
         UpdatedBy = updatedBy;
     }
 

--- a/Modules/Workflow/Workflow/Workflow/Models/WorkflowExecutionLog.cs
+++ b/Modules/Workflow/Workflow/Workflow/Models/WorkflowExecutionLog.cs
@@ -39,7 +39,7 @@ public class WorkflowExecutionLog : Entity<Guid>
             WorkflowInstanceId = workflowInstanceId,
             ActivityId = activityId,
             Event = eventType,
-            OccurredAt = DateTime.UtcNow,
+            OccurredAt = DateTime.Now,
             Details = details,
             ActorId = actorId,
             CorrelationId = correlationId,

--- a/Modules/Workflow/Workflow/Workflow/Models/WorkflowExternalCall.cs
+++ b/Modules/Workflow/Workflow/Workflow/Models/WorkflowExternalCall.cs
@@ -50,7 +50,7 @@ public class WorkflowExternalCall : Entity<Guid>
             Headers = headers ?? new Dictionary<string, string>(),
             IdempotencyKey = $"{workflowInstanceId}:{activityId}:{Guid.NewGuid()}",
             Status = ExternalCallStatus.Pending,
-            CreatedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.Now,
             AttemptCount = 0
         };
     }
@@ -58,14 +58,14 @@ public class WorkflowExternalCall : Entity<Guid>
     public void MarkAsStarted()
     {
         Status = ExternalCallStatus.InProgress;
-        StartedAt = DateTime.UtcNow;
+        StartedAt = DateTime.Now;
         AttemptCount++;
     }
 
     public void MarkAsCompleted(string responsePayload, TimeSpan duration)
     {
         Status = ExternalCallStatus.Completed;
-        CompletedAt = DateTime.UtcNow;
+        CompletedAt = DateTime.Now;
         ResponsePayload = responsePayload;
         Duration = duration;
         ErrorMessage = null;
@@ -74,7 +74,7 @@ public class WorkflowExternalCall : Entity<Guid>
     public void MarkAsFailed(string errorMessage, TimeSpan duration)
     {
         Status = ExternalCallStatus.Failed;
-        CompletedAt = DateTime.UtcNow;
+        CompletedAt = DateTime.Now;
         ErrorMessage = errorMessage;
         Duration = duration;
     }
@@ -82,7 +82,7 @@ public class WorkflowExternalCall : Entity<Guid>
     public void MarkAsTimedOut(TimeSpan duration)
     {
         Status = ExternalCallStatus.TimedOut;
-        CompletedAt = DateTime.UtcNow;
+        CompletedAt = DateTime.Now;
         ErrorMessage = "Request timed out";
         Duration = duration;
     }

--- a/Modules/Workflow/Workflow/Workflow/Models/WorkflowInstance.cs
+++ b/Modules/Workflow/Workflow/Workflow/Models/WorkflowInstance.cs
@@ -64,7 +64,7 @@ public class WorkflowInstance : Entity<Guid>
             CorrelationId = correlationId,
             Status = WorkflowStatus.Running,
             CurrentActivityId = string.Empty,
-            StartedOn = DateTime.UtcNow,
+            StartedOn = DateTime.Now,
             StartedBy = startedBy,
             Variables = initialVariables ?? new Dictionary<string, object>(),
             RuntimeOverrides = runtimeOverrides ?? new Dictionary<string, RuntimeOverride>()
@@ -108,7 +108,7 @@ public class WorkflowInstance : Entity<Guid>
         
         if (status == WorkflowStatus.Completed || status == WorkflowStatus.Failed || status == WorkflowStatus.Cancelled)
         {
-            CompletedOn = DateTime.UtcNow;
+            CompletedOn = DateTime.Now;
         }
 
         if (!string.IsNullOrEmpty(errorMessage))

--- a/Modules/Workflow/Workflow/Workflow/Models/WorkflowOutbox.cs
+++ b/Modules/Workflow/Workflow/Workflow/Models/WorkflowOutbox.cs
@@ -36,7 +36,7 @@ public class WorkflowOutbox : Entity<Guid>
         return new WorkflowOutbox
         {
             Id = Guid.CreateVersion7(),
-            OccurredAt = DateTime.UtcNow,
+            OccurredAt = DateTime.Now,
             Type = eventType,
             Payload = payload,
             Headers = headers ?? new Dictionary<string, string>(),
@@ -58,7 +58,7 @@ public class WorkflowOutbox : Entity<Guid>
     public void MarkAsProcessed()
     {
         Status = OutboxStatus.Processed;
-        ProcessedAt = DateTime.UtcNow;
+        ProcessedAt = DateTime.Now;
         NextAttemptAt = null;
         ErrorMessage = null;
     }
@@ -70,7 +70,7 @@ public class WorkflowOutbox : Entity<Guid>
         
         if (retryDelay.HasValue)
         {
-            NextAttemptAt = DateTime.UtcNow.Add(retryDelay.Value);
+            NextAttemptAt = DateTime.Now.Add(retryDelay.Value);
         }
     }
 
@@ -79,13 +79,13 @@ public class WorkflowOutbox : Entity<Guid>
         Attempts++;
         Status = OutboxStatus.Failed;
         ErrorMessage = errorMessage;
-        NextAttemptAt = DateTime.UtcNow.Add(CalculateRetryDelay());
+        NextAttemptAt = DateTime.Now.Add(CalculateRetryDelay());
     }
 
     public void ScheduleRetry(TimeSpan delay)
     {
         Status = OutboxStatus.Pending;
-        NextAttemptAt = DateTime.UtcNow.Add(delay);
+        NextAttemptAt = DateTime.Now.Add(delay);
     }
 
     public void MarkAsDeadLetter(string reason)
@@ -98,7 +98,7 @@ public class WorkflowOutbox : Entity<Guid>
     public bool IsReadyForProcessing()
     {
         return Status == OutboxStatus.Pending && 
-               (NextAttemptAt == null || NextAttemptAt <= DateTime.UtcNow);
+               (NextAttemptAt == null || NextAttemptAt <= DateTime.Now);
     }
 
     public bool ShouldRetry(int maxRetries)

--- a/Modules/Workflow/Workflow/Workflow/Resilience/IWorkflowResilienceService.cs
+++ b/Modules/Workflow/Workflow/Workflow/Resilience/IWorkflowResilienceService.cs
@@ -402,7 +402,7 @@ public class OperationValidationResult
 public class ResilienceMetrics
 {
     public Dictionary<string, OperationMetrics> OperationMetrics { get; init; } = new();
-    public DateTime CollectionTime { get; init; } = DateTime.UtcNow;
+    public DateTime CollectionTime { get; init; } = DateTime.Now;
     public TimeSpan CollectionPeriod { get; init; }
 }
 

--- a/Modules/Workflow/Workflow/Workflow/Resilience/WorkflowResilienceService.cs
+++ b/Modules/Workflow/Workflow/Workflow/Resilience/WorkflowResilienceService.cs
@@ -595,7 +595,7 @@ internal class CircuitBreakerInstance
     {
         lock (_lock)
         {
-            var now = DateTime.UtcNow;
+            var now = DateTime.Now;
             _successHistory.Enqueue(now);
             CleanupHistory(_successHistory, now);
             
@@ -616,7 +616,7 @@ internal class CircuitBreakerInstance
     {
         lock (_lock)
         {
-            var now = DateTime.UtcNow;
+            var now = DateTime.Now;
             _failureHistory.Enqueue(now);
             CleanupHistory(_failureHistory, now);
             
@@ -640,7 +640,7 @@ internal class CircuitBreakerInstance
         lock (_lock)
         {
             State = CircuitBreakerState.Open;
-            OpenUntil = DateTime.UtcNow.Add(duration);
+            OpenUntil = DateTime.Now.Add(duration);
         }
     }
 
@@ -655,7 +655,7 @@ internal class CircuitBreakerInstance
 
     private bool ShouldOpen()
     {
-        var now = DateTime.UtcNow;
+        var now = DateTime.Now;
         var totalRequests = _failureHistory.Count + _successHistory.Count;
         
         return totalRequests >= _policy.MinimumThroughput &&

--- a/Modules/Workflow/Workflow/Workflow/Services/IWorkflowAuditService.cs
+++ b/Modules/Workflow/Workflow/Workflow/Services/IWorkflowAuditService.cs
@@ -196,7 +196,7 @@ public enum AuditTrailCategory
 public class WorkflowAuditEvent
 {
     public Guid Id { get; init; } = Guid.CreateVersion7();
-    public DateTime Timestamp { get; init; } = DateTime.UtcNow;
+    public DateTime Timestamp { get; init; } = DateTime.Now;
     public Guid WorkflowInstanceId { get; init; }
     public string? ActivityId { get; init; }
     public string EventType { get; init; } = default!;

--- a/Modules/Workflow/Workflow/Workflow/Services/WorkflowNotificationService.cs
+++ b/Modules/Workflow/Workflow/Workflow/Services/WorkflowNotificationService.cs
@@ -22,7 +22,7 @@ public class WorkflowNotificationService : IWorkflowNotificationService
             WorkflowInstanceId = workflowInstanceId,
             InstanceName = instanceName,
             StartedBy = startedBy,
-            Timestamp = DateTime.UtcNow
+            Timestamp = DateTime.Now
         };
 
         await _hubContext.Clients.Group($"workflow-{workflowInstanceId}")
@@ -39,7 +39,7 @@ public class WorkflowNotificationService : IWorkflowNotificationService
             ActivityId = activityId,
             CompletedBy = completedBy,
             OutputData = outputData,
-            Timestamp = DateTime.UtcNow
+            Timestamp = DateTime.Now
         };
 
         await _hubContext.Clients.Group($"workflow-{workflowInstanceId}")
@@ -56,7 +56,7 @@ public class WorkflowNotificationService : IWorkflowNotificationService
             ActivityId = activityId,
             AssignedTo = assignedTo,
             ActivityName = activityName,
-            Timestamp = DateTime.UtcNow
+            Timestamp = DateTime.Now
         };
 
         await _hubContext.Clients.Group($"workflow-{workflowInstanceId}")
@@ -74,7 +74,7 @@ public class WorkflowNotificationService : IWorkflowNotificationService
             Type = "WorkflowCompleted",
             WorkflowInstanceId = workflowInstanceId,
             CompletedBy = completedBy,
-            Timestamp = DateTime.UtcNow
+            Timestamp = DateTime.Now
         };
 
         await _hubContext.Clients.Group($"workflow-{workflowInstanceId}")
@@ -88,7 +88,7 @@ public class WorkflowNotificationService : IWorkflowNotificationService
             Type = "WorkflowFailed",
             WorkflowInstanceId = workflowInstanceId,
             ErrorMessage = errorMessage,
-            Timestamp = DateTime.UtcNow
+            Timestamp = DateTime.Now
         };
 
         await _hubContext.Clients.Group($"workflow-{workflowInstanceId}")
@@ -103,7 +103,7 @@ public class WorkflowNotificationService : IWorkflowNotificationService
             WorkflowInstanceId = workflowInstanceId,
             CancelledBy = cancelledBy,
             Reason = reason,
-            Timestamp = DateTime.UtcNow
+            Timestamp = DateTime.Now
         };
 
         await _hubContext.Clients.Group($"workflow-{workflowInstanceId}")
@@ -118,7 +118,7 @@ public class WorkflowNotificationService : IWorkflowNotificationService
             WorkflowInstanceId = workflowInstanceId,
             TaskName = taskName,
             ActivityId = activityId,
-            Timestamp = DateTime.UtcNow
+            Timestamp = DateTime.Now
         };
 
         await _hubContext.Clients.Group($"user-{userId}")

--- a/Modules/Workflow/Workflow/Workflow/Services/WorkflowService.cs
+++ b/Modules/Workflow/Workflow/Workflow/Services/WorkflowService.cs
@@ -199,13 +199,13 @@ public class WorkflowService : IWorkflowService
                 throw new InvalidOperationException("WorkflowEngine returned null instance");
 
             await _eventPublisher.PublishActivityCompletedAsync(
-                workflowInstanceId, activityId, completedBy, DateTime.UtcNow, input,
+                workflowInstanceId, activityId, completedBy, DateTime.Now, input,
                 input?.TryGetValue("comments", out var commentsValue) == true ? commentsValue?.ToString() : null,
                 cancellationToken);
 
             if (executionResult.Status == WorkflowExecutionStatus.Completed)
                 await _eventPublisher.PublishWorkflowCompletedAsync(
-                    workflowInstanceId, completedBy, DateTime.UtcNow, cancellationToken);
+                    workflowInstanceId, completedBy, DateTime.Now, cancellationToken);
 
             _logger.LogInformation("SERVICE: Successfully resumed workflow {WorkflowInstanceId} with status {Status}",
                 workflowInstanceId, executionResult.Status);
@@ -263,7 +263,7 @@ public class WorkflowService : IWorkflowService
         await _eventPublisher.PublishWorkflowCancelledAsync(
             workflowInstanceId,
             cancelledBy,
-            DateTime.UtcNow,
+            DateTime.Now,
             reason,
             cancellationToken);
 

--- a/Modules/Workflow/Workflow/Workflow/Versioning/VersionComparisonResult.cs
+++ b/Modules/Workflow/Workflow/Workflow/Versioning/VersionComparisonResult.cs
@@ -12,5 +12,5 @@ public class VersionComparisonResult
     public List<string> AddedActivities { get; set; } = new();
     public List<string> RemovedActivities { get; set; } = new();
     public List<string> ModifiedActivities { get; set; } = new();
-    public DateTime ComparedAt { get; set; } = DateTime.UtcNow;
+    public DateTime ComparedAt { get; set; } = DateTime.Now;
 }

--- a/Modules/Workflow/Workflow/Workflow/Versioning/VersionMigrationResult.cs
+++ b/Modules/Workflow/Workflow/Workflow/Versioning/VersionMigrationResult.cs
@@ -14,7 +14,7 @@ public class VersionMigrationResult
     public TimeSpan Duration { get; set; }
     public List<MigrationError> Errors { get; set; } = new();
     public Dictionary<string, object> Statistics { get; set; } = new();
-    public DateTime MigratedAt { get; set; } = DateTime.UtcNow;
+    public DateTime MigratedAt { get; set; } = DateTime.Now;
 }
 
 /// <summary>

--- a/Shared/Shared.Messaging/Events/IntegrationEvent.cs
+++ b/Shared/Shared.Messaging/Events/IntegrationEvent.cs
@@ -4,6 +4,6 @@ public record IntegrationEvent
 {
     // Computed once at construction — expression-bodied would generate a new value on every access
     public Guid EventId { get; } = Guid.CreateVersion7();
-    public DateTime OccurredOn { get; } = DateTime.UtcNow;
+    public DateTime OccurredOn { get; } = DateTime.Now;
     public string EventType => GetType().AssemblyQualifiedName!;
 }

--- a/Shared/Shared.Messaging/Filters/InboxGuard.cs
+++ b/Shared/Shared.Messaging/Filters/InboxGuard.cs
@@ -51,7 +51,7 @@ public class InboxGuard<TDbContext>(
         }
 
         // Status is Processing — check if stale
-        if (existing.StartedAt < DateTime.UtcNow.AddMinutes(-StaleThresholdMinutes))
+        if (existing.StartedAt < DateTime.Now.AddMinutes(-StaleThresholdMinutes))
         {
             // Stale Processing — another instance crashed. Delete and re-claim.
             logger.LogWarning("[INBOX] Stale Processing message {MessageId} by {Consumer} (started {StartedAt}), reclaiming",
@@ -96,6 +96,6 @@ public class InboxGuard<TDbContext>(
             "UPDATE [" + schema + "].[InboxMessage] " +
             "SET Status = 'Processed', ProcessedAt = {0} " +
             "WHERE MessageId = {1} AND ConsumerType = {2}",
-            new object[] { DateTime.UtcNow, messageId.Value, consumerType }, ct);
+            new object[] { DateTime.Now, messageId.Value, consumerType }, ct);
     }
 }

--- a/Shared/Shared.Messaging/Services/IntegrationEventDeliveryService.cs
+++ b/Shared/Shared.Messaging/Services/IntegrationEventDeliveryService.cs
@@ -80,7 +80,7 @@ public class IntegrationEventDeliveryService<TDbContext>(
 
     private async Task<bool> TryAcquireLeaseAsync(TDbContext dbContext, CancellationToken ct)
     {
-        var now = DateTime.UtcNow;
+        var now = DateTime.Now;
         var leasedUntil = now.Add(LeaseDuration);
         var schema = dbContext.Model.GetDefaultSchema() ?? "dbo";
 
@@ -120,7 +120,7 @@ public class IntegrationEventDeliveryService<TDbContext>(
             "UPDATE [" + schema + "].[OutboxDeliveryLock] " +
             "SET LeasedUntil = {0} " +
             "WHERE Id = {1} AND InstanceId = {2}",
-            new object[] { DateTime.UtcNow, _lockId, _instanceId }, ct);
+            new object[] { DateTime.Now, _lockId, _instanceId }, ct);
     }
 
     private async Task<int> ProcessBatchAsync(TDbContext dbContext, IBus bus, CancellationToken stoppingToken)

--- a/Shared/Shared/Data/Outbox/InboxMessage.cs
+++ b/Shared/Shared/Data/Outbox/InboxMessage.cs
@@ -17,14 +17,14 @@ public class InboxMessage
             MessageId = messageId,
             ConsumerType = consumerType,
             Status = InboxMessageStatus.Processing,
-            StartedAt = DateTime.UtcNow
+            StartedAt = DateTime.Now
         };
     }
 
     public void MarkAsProcessed()
     {
         Status = InboxMessageStatus.Processed;
-        ProcessedAt = DateTime.UtcNow;
+        ProcessedAt = DateTime.Now;
     }
 }
 

--- a/Shared/Shared/Data/Outbox/IntegrationEventOutboxMessage.cs
+++ b/Shared/Shared/Data/Outbox/IntegrationEventOutboxMessage.cs
@@ -28,7 +28,7 @@ public class IntegrationEventOutboxMessage
             Payload = payload,
             CorrelationId = correlationId,
             Headers = headers ?? new Dictionary<string, string>(),
-            OccurredAt = DateTime.UtcNow,
+            OccurredAt = DateTime.Now,
             Status = OutboxMessageStatus.Pending,
             RetryCount = 0
         };
@@ -42,7 +42,7 @@ public class IntegrationEventOutboxMessage
     public void MarkAsProcessed()
     {
         Status = OutboxMessageStatus.Processed;
-        ProcessedAt = DateTime.UtcNow;
+        ProcessedAt = DateTime.Now;
         Error = null;
     }
 

--- a/Shared/Shared/Data/Outbox/OutboxCleanupJob.cs
+++ b/Shared/Shared/Data/Outbox/OutboxCleanupJob.cs
@@ -13,7 +13,7 @@ public class OutboxCleanupJob<TDbContext>(
 
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        var cutoff = DateTime.UtcNow.AddDays(-RetentionDays);
+        var cutoff = DateTime.Now.AddDays(-RetentionDays);
         var schema = dbContext.Model.GetDefaultSchema() ?? "dbo";
         var totalDeleted = 0;
 
@@ -21,7 +21,7 @@ public class OutboxCleanupJob<TDbContext>(
             typeof(TDbContext).Name, cutoff);
 
         // Reset stuck Processing messages (instance crashed mid-batch) back to Pending
-        var stuckCutoff = DateTime.UtcNow.AddMinutes(-5);
+        var stuckCutoff = DateTime.Now.AddMinutes(-5);
         var reset = await dbContext.Database.ExecuteSqlRawAsync(
             "UPDATE [" + schema + "].[IntegrationEventOutbox] " +
             "SET Status = 'Pending' " +


### PR DESCRIPTION
## Summary

Replaces `DateTime.UtcNow` / `DateTimeOffset.UtcNow` with `.Now` in domain entities, application handlers, and Shared infrastructure.

- 60 files, 151 replacements, confined to timestamp expressions.
- Storage types (`datetime2`, `datetimeoffset`) unchanged; no TZ conversion at edges.

## Rationale

All downstream consumers (Thai market, UTC+7) render timestamps as local wall clock. Storing UTC required round-trip conversion at every read site and introduced inconsistencies where some layers skipped conversion. Standardising on server local time simplifies the read path.

> Reviewers: this is a deliberate policy shift. If you prefer to keep UTC at persistence and convert at the edge instead, please say so and this PR can be inverted (restore UtcNow and add a presentation-layer converter).

## Dependencies

- **Merge LAST.** The other six PRs (#164, #165, #166, #167, #168, #169) carry theme changes that were intentionally stripped of `DateTime.Now` to keep them thematically clean. Landing those first means the sed in this PR lands on a consistent base.
- Rebase on updated `main` before merging; re-run `sed` (or accept the diff as-is \u2014 `.UtcNow` remaining in any touched file is the target for the change).

## Test plan

- [ ] `dotnet build` \u2014 solution (verified locally, 0 errors)
- [ ] Grep check: `git grep -n "DateTime\\.UtcNow" -- 'Modules/**' Shared` \u2014 should return only files that genuinely still warrant UTC (if any) after this PR lands
- [ ] Smoke: create a new request, attach a document, complete an appraisal \u2014 verify created/updated timestamps match `getdate()` on the SQL server

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)