### PR TITLE
refactor(workflow) and feat(auth): events and enhance user-group update endpoint

### DIFF
--- a/Modules/Appraisal/Appraisal/Application/EventHandlers/InternalFollowupAssignedIntegrationEventHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/EventHandlers/InternalFollowupAssignedIntegrationEventHandler.cs
@@ -7,14 +7,14 @@ using Shared.Messaging.Filters;
 
 namespace Appraisal.Application.EventHandlers;
 
-public class CompanyAssignedIntegrationEventHandler(
+public class InternalFollowupAssignedIntegrationEventHandler(
     IAppraisalRepository appraisalRepository,
     IAppraisalUnitOfWork unitOfWork,
-    ILogger<CompanyAssignedIntegrationEventHandler> logger,
+    ILogger<InternalFollowupAssignedIntegrationEventHandler> logger,
     InboxGuard<AppraisalDbContext> inboxGuard
-) : IConsumer<CompanyAssignedIntegrationEvent>
+) : IConsumer<InternalFollowupAssignedIntegrationEvent>
 {
-    public async Task Consume(ConsumeContext<CompanyAssignedIntegrationEvent> context)
+    public async Task Consume(ConsumeContext<InternalFollowupAssignedIntegrationEvent> context)
     {
         if (await inboxGuard.TryClaimAsync(context.MessageId, GetType().Name, context.CancellationToken))
             return;
@@ -23,15 +23,15 @@ public class CompanyAssignedIntegrationEventHandler(
         var ct = context.CancellationToken;
 
         logger.LogInformation(
-            "Integration Event received: {IntegrationEvent} for AppraisalId: {AppraisalId}, CompanyId: {CompanyId}",
-            nameof(CompanyAssignedIntegrationEvent), message.AppraisalId, message.CompanyId);
+            "Integration Event received: {IntegrationEvent} for AppraisalId: {AppraisalId}, InternalAppraiserId: {InternalAppraiserId}",
+            nameof(InternalFollowupAssignedIntegrationEvent), message.AppraisalId, message.InternalAppraiserId);
 
         var appraisal = await appraisalRepository.GetByIdWithAllDataAsync(message.AppraisalId, ct);
 
         if (appraisal is null)
         {
             logger.LogWarning(
-                "Appraisal {AppraisalId} not found for company assignment", message.AppraisalId);
+                "Appraisal {AppraisalId} not found for internal followup assignment", message.AppraisalId);
             await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
             return;
         }
@@ -44,28 +44,22 @@ public class CompanyAssignedIntegrationEventHandler(
         if (assignment is null)
         {
             logger.LogWarning(
-                "No active assignment found for Appraisal {AppraisalId}", message.AppraisalId);
+                "No active assignment found for Appraisal {AppraisalId} when attaching internal followup",
+                message.AppraisalId);
             await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
             return;
         }
 
-        // Preserve internal-followup fields: Assign() defaults them to null, so without
-        // passing them back we'd clobber values set by InternalFollowupAssignedIntegrationEventHandler
-        // if that event was processed first (consumer delivery order is not guaranteed).
-        assignment.Assign(
-            assignmentType: "External",
-            assigneeCompanyId: message.CompanyId.ToString(),
-            assignmentMethod: message.AssignmentMethod,
-            internalAppraiserId: assignment.InternalAppraiserId,
-            internalFollowupMethod: assignment.InternalFollowupAssignmentMethod,
-            assignedBy: "System");
+        assignment.AssignInternalFollowup(
+            message.InternalAppraiserId,
+            message.InternalFollowupAssignmentMethod);
 
         await appraisalRepository.UpdateAsync(appraisal, ct);
         await unitOfWork.SaveChangesAsync(ct);
         await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
 
         logger.LogInformation(
-            "Updated AppraisalAssignment for AppraisalId {AppraisalId}: CompanyId={CompanyId}, Method={Method}",
-            message.AppraisalId, message.CompanyId, message.AssignmentMethod);
+            "Attached internal followup to AppraisalAssignment for AppraisalId {AppraisalId}: StaffId={StaffId}, Method={Method}",
+            message.AppraisalId, message.InternalAppraiserId, message.InternalFollowupAssignmentMethod);
     }
 }

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalAssignment.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalAssignment.cs
@@ -147,6 +147,15 @@ public class AppraisalAssignment : Entity<Guid>
     }
 
     /// <summary>
+    /// Attach internal followup staff after the company has been assigned.
+    /// </summary>
+    public void AssignInternalFollowup(string internalAppraiserId, string internalFollowupMethod)
+    {
+        InternalAppraiserId = internalAppraiserId;
+        InternalFollowupAssignmentMethod = internalFollowupMethod;
+    }
+
+    /// <summary>
     /// Start work on this assignment
     /// </summary>
     public void StartWork()

--- a/Modules/Auth/Auth/Application/Features/Groups/GetGroupById/GetGroupByIdQueryHandler.cs
+++ b/Modules/Auth/Auth/Application/Features/Groups/GetGroupById/GetGroupByIdQueryHandler.cs
@@ -1,22 +1,28 @@
 using Auth.Application.Services;
+using Auth.Infrastructure;
 
 namespace Auth.Application.Features.Groups.GetGroupById;
 
-public class GetGroupByIdQueryHandler(IGroupService groupService)
+public class GetGroupByIdQueryHandler(IGroupService groupService, AuthDbContext dbContext)
     : IQueryHandler<GetGroupByIdQuery, GetGroupByIdResult>
 {
     public async Task<GetGroupByIdResult> Handle(GetGroupByIdQuery query, CancellationToken cancellationToken)
     {
-        var group = await groupService.GetGroupById(query.Id, cancellationToken);
-        if (group is null) throw new KeyNotFoundException($"Group {query.Id} not found.");
+        var grp = await groupService.GetGroupById(query.Id, cancellationToken);
+        if (grp is null) throw new KeyNotFoundException($"Group {query.Id} not found.");
 
-        var users = group.Users.Select(u => new GroupUserDto(u.UserId)).ToList();
-        var monitoredGroups = group.MonitoredGroups
+        var users = await dbContext.GroupUsers
+            .Where(gu => gu.GroupId == grp.Id)
+            .Join(dbContext.Users, gu => gu.UserId, u => u.Id,
+                (gu, u) => new GroupUserDto(u.Id, u.UserName!, u.FirstName, u.LastName))
+            .ToListAsync(cancellationToken);
+
+        var monitoredGroups = grp.MonitoredGroups
             .Select(mg => new GroupMonitoringDto(mg.MonitoredGroupId, mg.MonitoredGroup.Name))
             .ToList();
 
         return new GetGroupByIdResult(
-            group.Id, group.Name, group.Description, group.Scope, group.CompanyId,
+            grp.Id, grp.Name, grp.Description, grp.Scope, grp.CompanyId,
             users, monitoredGroups);
     }
 }

--- a/Modules/Auth/Auth/Application/Features/Groups/GetGroupById/GetGroupByIdResult.cs
+++ b/Modules/Auth/Auth/Application/Features/Groups/GetGroupById/GetGroupByIdResult.cs
@@ -1,8 +1,8 @@
 namespace Auth.Application.Features.Groups.GetGroupById;
 
-public record GroupUserDto(Guid UserId);
+public record GroupUserDto(Guid UserId, string UserName, string FirstName, string LastName);
 
-public record GroupMonitoringDto(Guid MonitoredGroupId, string MonitoredGroupName);
+public record GroupMonitoringDto(Guid GroupId, string GroupName);
 
 public record GetGroupByIdResult(
     Guid Id,

--- a/Modules/Auth/Auth/Application/Features/Users/GetUserById/GetUserByIdResult.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/GetUserById/GetUserByIdResult.cs
@@ -1,6 +1,6 @@
 namespace Auth.Application.Features.Users.GetUserById;
 
-public record UserGroupDto(Guid GroupId, string GroupName, string Scope);
+public record UserGroupDto(Guid Id, string Name, string Scope);
 
 public record UserPermissionDto(Guid PermissionId, string PermissionCode, bool IsGranted);
 

--- a/Modules/Auth/Auth/Application/Features/Users/UpdateUserGroups/UpdateUserGroupsCommand.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/UpdateUserGroups/UpdateUserGroupsCommand.cs
@@ -1,0 +1,3 @@
+namespace Auth.Application.Features.Users.UpdateUserGroups;
+
+public record UpdateUserGroupsCommand(Guid UserId, List<Guid> GroupIds) : ICommand;

--- a/Modules/Auth/Auth/Application/Features/Users/UpdateUserGroups/UpdateUserGroupsCommandHandler.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/UpdateUserGroups/UpdateUserGroupsCommandHandler.cs
@@ -1,0 +1,45 @@
+using Auth.Domain.Groups;
+using Auth.Infrastructure;
+using Microsoft.AspNetCore.Identity;
+using Shared.Exceptions;
+
+namespace Auth.Application.Features.Users.UpdateUserGroups;
+
+public class UpdateUserGroupsCommandHandler(
+    UserManager<ApplicationUser> userManager,
+    AuthDbContext dbContext)
+    : ICommandHandler<UpdateUserGroupsCommand>
+{
+    public async Task<Unit> Handle(UpdateUserGroupsCommand command, CancellationToken cancellationToken)
+    {
+        var user = await userManager.FindByIdAsync(command.UserId.ToString())
+            ?? throw new NotFoundException("User", command.UserId);
+
+        var requestedGroupIds = (command.GroupIds ?? []).Distinct().ToList();
+
+        var existingGroupIds = await dbContext.Groups
+            .Where(g => requestedGroupIds.Contains(g.Id))
+            .Select(g => g.Id)
+            .ToListAsync(cancellationToken);
+
+        var missing = requestedGroupIds.Except(existingGroupIds).ToList();
+        if (missing.Count > 0)
+            throw new NotFoundException("Group", missing[0]);
+
+        var currentLinks = await dbContext.GroupUsers
+            .Where(gu => gu.UserId == command.UserId)
+            .ToListAsync(cancellationToken);
+
+        var currentGroupIds = currentLinks.Select(l => l.GroupId).ToList();
+
+        var toRemove = currentLinks.Where(l => !requestedGroupIds.Contains(l.GroupId)).ToList();
+        if (toRemove.Count > 0)
+            dbContext.GroupUsers.RemoveRange(toRemove);
+
+        foreach (var groupId in requestedGroupIds.Except(currentGroupIds))
+            dbContext.GroupUsers.Add(new GroupUser { GroupId = groupId, UserId = command.UserId });
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return Unit.Value;
+    }
+}

--- a/Modules/Auth/Auth/Application/Features/Users/UpdateUserGroups/UpdateUserGroupsEndpoint.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/UpdateUserGroups/UpdateUserGroupsEndpoint.cs
@@ -1,0 +1,24 @@
+namespace Auth.Application.Features.Users.UpdateUserGroups;
+
+public class UpdateUserGroupsEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPut(
+                "/auth/users/{id:guid}/groups",
+                async (Guid id, UpdateUserGroupsRequest request, ISender sender, CancellationToken cancellationToken) =>
+                {
+                    var command = new UpdateUserGroupsCommand(id, request.GroupIds);
+                    await sender.Send(command, cancellationToken);
+                    return Results.NoContent();
+                })
+            .WithName("UpdateUserGroups")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Update user groups (admin)")
+            .WithDescription("Replace all group memberships for a user.")
+            .WithTags("User")
+            .RequireAuthorization("CanManageUsers");
+    }
+}

--- a/Modules/Auth/Auth/Application/Features/Users/UpdateUserGroups/UpdateUserGroupsRequest.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/UpdateUserGroups/UpdateUserGroupsRequest.cs
@@ -1,0 +1,3 @@
+namespace Auth.Application.Features.Users.UpdateUserGroups;
+
+public record UpdateUserGroupsRequest(List<Guid> GroupIds);

--- a/Modules/Workflow/Workflow/Workflow/Activities/CompanySelectionActivity.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/CompanySelectionActivity.cs
@@ -1,3 +1,5 @@
+using Shared.Data.Outbox;
+using Shared.Messaging.Events;
 using Workflow.AssigneeSelection.Services;
 using Workflow.Workflow.Activities.Core;
 using Workflow.Workflow.Models;
@@ -13,15 +15,18 @@ public class CompanySelectionActivity : WorkflowActivityBase
 {
     private readonly ICompanyRoundRobinService _companyRoundRobinService;
     private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly IIntegrationEventOutbox _outbox;
     private readonly ILogger<CompanySelectionActivity> _logger;
 
     public CompanySelectionActivity(
         ICompanyRoundRobinService companyRoundRobinService,
         IDateTimeProvider dateTimeProvider,
+        IIntegrationEventOutbox outbox,
         ILogger<CompanySelectionActivity> logger)
     {
         _companyRoundRobinService = companyRoundRobinService;
         _dateTimeProvider = dateTimeProvider;
+        _outbox = outbox;
         _logger = logger;
     }
 
@@ -64,6 +69,7 @@ public class CompanySelectionActivity : WorkflowActivityBase
                 "CompanySelectionActivity {ActivityId}: manually selected company {CompanyName} ({CompanyId})",
                 context.ActivityId, companyName, companyId);
 
+            PublishCompanyAssignedEvent(context, companyId, companyName, "Manual");
             return ActivityResult.Success(outputData);
         }
 
@@ -83,7 +89,7 @@ public class CompanySelectionActivity : WorkflowActivityBase
             _logger.LogInformation(
                 "CompanySelectionActivity {ActivityId}: replaying — reusing previously selected company {CompanyName} ({CompanyId})",
                 context.ActivityId, existingCompanyName, existingCompanyId);
-
+            
             return ActivityResult.Success(outputData);
         }
 
@@ -104,6 +110,7 @@ public class CompanySelectionActivity : WorkflowActivityBase
                 "CompanySelectionActivity {ActivityId}: round-robin selected company {CompanyName} ({CompanyId})",
                 context.ActivityId, result.CompanyName, result.CompanyId);
 
+            PublishCompanyAssignedEvent(context, result.CompanyId!.Value.ToString(), result.CompanyName!, "RoundRobin");
             return ActivityResult.Success(outputData);
         }
 
@@ -127,5 +134,45 @@ public class CompanySelectionActivity : WorkflowActivityBase
             ActivityType,
             "SYSTEM",
             context.Variables);
+    }
+
+    private void PublishCompanyAssignedEvent(
+        ActivityContext context,
+        string companyIdRaw,
+        string companyName,
+        string assignmentMethod)
+    {
+        var appraisalId = WorkflowVariables.TryGetAppraisalId(context.Variables);
+        if (appraisalId is null)
+        {
+            _logger.LogWarning(
+                "CompanySelectionActivity {ActivityId}: appraisalId not in variables; skipping CompanyAssignedIntegrationEvent publish",
+                context.ActivityId);
+            return;
+        }
+
+        if (!Guid.TryParse(companyIdRaw, out var companyId))
+        {
+            _logger.LogWarning(
+                "CompanySelectionActivity {ActivityId}: assignedCompanyId '{Raw}' is not a Guid; skipping publish",
+                context.ActivityId, companyIdRaw);
+            return;
+        }
+
+        var appraisalNumber = GetVariable<string>(context, "appraisalNumber", "");
+
+        _outbox.Publish(new CompanyAssignedIntegrationEvent
+        {
+            AppraisalId = appraisalId.Value,
+            CompanyId = companyId,
+            CompanyName = companyName,
+            AssignmentMethod = assignmentMethod,
+            CompletedBy = context.WorkflowInstance.LastCompletedBy,
+            AppraisalNumber = string.IsNullOrEmpty(appraisalNumber) ? null : appraisalNumber
+        }, correlationId: appraisalId.Value.ToString());
+
+        _logger.LogInformation(
+            "CompanySelectionActivity {ActivityId}: published CompanyAssignedIntegrationEvent for AppraisalId={AppraisalId}, CompanyId={CompanyId}",
+            context.ActivityId, appraisalId.Value, companyId);
     }
 }

--- a/Modules/Workflow/Workflow/Workflow/Activities/InternalFollowupSelectionActivity.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/InternalFollowupSelectionActivity.cs
@@ -1,3 +1,5 @@
+using Shared.Data.Outbox;
+using Shared.Messaging.Events;
 using Workflow.AssigneeSelection.Services;
 using Workflow.Workflow.Activities.Core;
 using Workflow.Workflow.Models;
@@ -14,15 +16,18 @@ public class InternalFollowupSelectionActivity : WorkflowActivityBase
 {
     private readonly IInternalStaffRoundRobinService _staffRoundRobinService;
     private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly IIntegrationEventOutbox _outbox;
     private readonly ILogger<InternalFollowupSelectionActivity> _logger;
 
     public InternalFollowupSelectionActivity(
         IInternalStaffRoundRobinService staffRoundRobinService,
         IDateTimeProvider dateTimeProvider,
+        IIntegrationEventOutbox outbox,
         ILogger<InternalFollowupSelectionActivity> logger)
     {
         _staffRoundRobinService = staffRoundRobinService;
         _dateTimeProvider = dateTimeProvider;
+        _outbox = outbox;
         _logger = logger;
     }
 
@@ -45,14 +50,16 @@ public class InternalFollowupSelectionActivity : WorkflowActivityBase
         // If admin already selected a followup staff, use it
         if (!string.IsNullOrEmpty(existingStaffId))
         {
+            var method = string.IsNullOrEmpty(existingMethod) ? "Manual" : existingMethod;
             outputData["internalFollowupStaffId"] = existingStaffId;
-            outputData["internalFollowupMethod"] = string.IsNullOrEmpty(existingMethod) ? "Manual" : existingMethod;
+            outputData["internalFollowupMethod"] = method;
             outputData["decision"] = "staff_selected";
 
             _logger.LogInformation(
                 "InternalFollowupSelectionActivity {ActivityId}: using admin-selected staff {StaffId}",
                 context.ActivityId, existingStaffId);
 
+            PublishFollowupAssignedEvent(context, existingStaffId, method);
             return ActivityResult.Success(outputData);
         }
 
@@ -69,6 +76,7 @@ public class InternalFollowupSelectionActivity : WorkflowActivityBase
                 "InternalFollowupSelectionActivity {ActivityId}: round-robin selected staff {StaffId}",
                 context.ActivityId, result.UserId);
 
+            PublishFollowupAssignedEvent(context, result.UserId!, "RoundRobin");
             return ActivityResult.Success(outputData);
         }
 
@@ -92,5 +100,32 @@ public class InternalFollowupSelectionActivity : WorkflowActivityBase
             ActivityType,
             "SYSTEM",
             context.Variables);
+    }
+
+    private void PublishFollowupAssignedEvent(
+        ActivityContext context,
+        string internalAppraiserId,
+        string internalFollowupMethod)
+    {
+        var appraisalId = WorkflowVariables.TryGetAppraisalId(context.Variables);
+        if (appraisalId is null)
+        {
+            _logger.LogWarning(
+                "InternalFollowupSelectionActivity {ActivityId}: appraisalId not in variables; skipping InternalFollowupAssignedIntegrationEvent publish",
+                context.ActivityId);
+            return;
+        }
+
+        _outbox.Publish(new InternalFollowupAssignedIntegrationEvent
+        {
+            AppraisalId = appraisalId.Value,
+            InternalAppraiserId = internalAppraiserId,
+            InternalFollowupAssignmentMethod = internalFollowupMethod,
+            CompletedBy = context.WorkflowInstance.LastCompletedBy
+        }, correlationId: appraisalId.Value.ToString());
+
+        _logger.LogInformation(
+            "InternalFollowupSelectionActivity {ActivityId}: published InternalFollowupAssignedIntegrationEvent for AppraisalId={AppraisalId}, StaffId={StaffId}",
+            context.ActivityId, appraisalId.Value, internalAppraiserId);
     }
 }

--- a/Modules/Workflow/Workflow/Workflow/Models/WorkflowVariables.cs
+++ b/Modules/Workflow/Workflow/Workflow/Models/WorkflowVariables.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+
+namespace Workflow.Workflow.Models;
+
+/// <summary>
+/// Typed accessors over the loose <see cref="WorkflowInstance.Variables"/> dictionary.
+/// </summary>
+public static class WorkflowVariables
+{
+    /// <summary>
+    /// Resolve the "appraisalId" variable to a <see cref="Guid"/>, tolerating Guid / string / JsonElement
+    /// representations produced by JSON round-trips through the persistence layer.
+    /// </summary>
+    public static Guid? TryGetAppraisalId(IReadOnlyDictionary<string, object> variables)
+    {
+        if (!variables.TryGetValue("appraisalId", out var raw) || raw is null)
+            return null;
+
+        return raw switch
+        {
+            Guid g => g,
+            string s when Guid.TryParse(s, out var parsed) => parsed,
+            JsonElement je when je.ValueKind == JsonValueKind.String
+                && Guid.TryParse(je.GetString(), out var jp) => jp,
+            _ => null
+        };
+    }
+}

--- a/Modules/Workflow/Workflow/Workflow/Services/WorkflowService.cs
+++ b/Modules/Workflow/Workflow/Workflow/Services/WorkflowService.cs
@@ -306,13 +306,15 @@ public class WorkflowService : IWorkflowService
     }
 
     /// <summary>
-    /// Publishes integration events AFTER the transaction has committed.
-    /// Publishes CompanyAssignedIntegrationEvent for external path and
-    /// InternalAssignedIntegrationEvent for internal path.
+    /// Publishes post-commit integration events for activity landings that don't have
+    /// a natural owning activity to emit from. Currently only the internal path
+    /// (int-appraisal-execution) — the external path emits CompanyAssignedIntegrationEvent
+    /// and InternalFollowupAssignedIntegrationEvent directly from CompanySelectionActivity
+    /// and InternalFollowupSelectionActivity, which are bypassed on routeback.
     /// </summary>
     private async Task PublishPostCommitEventsAsync(WorkflowInstance instance, CancellationToken cancellationToken)
     {
-        var appraisalId = ResolveAppraisalIdFromVariables(instance);
+        var appraisalId = WorkflowVariables.TryGetAppraisalId(instance.Variables);
         if (appraisalId is null)
         {
             _logger.LogWarning(
@@ -321,48 +323,10 @@ public class WorkflowService : IWorkflowService
             return;
         }
 
-        if (instance.CurrentActivityId == "ext-appraisal-assignment")
-        {
-            PublishCompanyAssignedEvent(instance, appraisalId.Value);
-        }
-        else if (instance.CurrentActivityId == "int-appraisal-execution")
+        if (instance.CurrentActivityId == "int-appraisal-execution")
         {
             PublishInternalAssignedEvent(instance, appraisalId.Value);
         }
-    }
-
-    private void PublishCompanyAssignedEvent(WorkflowInstance instance, Guid correlationId)
-    {
-        if (!instance.Variables.TryGetValue("assignedCompanyId", out var cid)
-            || !Guid.TryParse(cid?.ToString(), out var companyId))
-            return;
-
-        var companyName = instance.Variables.TryGetValue("assignedCompanyName", out var cn)
-            ? cn?.ToString() ?? "" : "";
-        var method = instance.Variables.TryGetValue("assignmentMethod", out var am)
-            ? am?.ToString() ?? "Manual" : "Manual";
-        var internalStaffId = instance.Variables.TryGetValue("internalFollowupStaffId", out var ifs)
-            ? ifs?.ToString() : null;
-        var internalFollowupMethod = instance.Variables.TryGetValue("internalFollowupMethod", out var ifm)
-            ? ifm?.ToString() : null;
-
-        var appraisalNumber = instance.Variables.TryGetValue("appraisalNumber", out var an) ? an?.ToString() : null;
-
-        _outbox.Publish(new CompanyAssignedIntegrationEvent
-        {
-            AppraisalId = correlationId,
-            CompanyId = companyId,
-            CompanyName = companyName,
-            AssignmentMethod = method,
-            InternalAppraiserId = string.IsNullOrEmpty(internalStaffId) ? null : internalStaffId,
-            InternalFollowupAssignmentMethod = string.IsNullOrEmpty(internalFollowupMethod) ? null : internalFollowupMethod,
-            CompletedBy = instance.LastCompletedBy,
-            AppraisalNumber = appraisalNumber
-        }, correlationId: correlationId.ToString());
-
-        _logger.LogInformation(
-            "Published CompanyAssignedIntegrationEvent after commit: AppraisalId={AppraisalId}, CompanyId={CompanyId}, InternalStaff={InternalStaffId}",
-            correlationId, companyId, internalStaffId);
     }
 
     private void PublishInternalAssignedEvent(WorkflowInstance instance, Guid correlationId)
@@ -401,18 +365,4 @@ public class WorkflowService : IWorkflowService
             correlationId, assigneeUserId, method);
     }
 
-    private static Guid? ResolveAppraisalIdFromVariables(WorkflowInstance instance)
-    {
-        if (!instance.Variables.TryGetValue("appraisalId", out var aidObj))
-            return null;
-
-        return aidObj switch
-        {
-            Guid g => g,
-            string s when Guid.TryParse(s, out var parsed) => parsed,
-            JsonElement je when je.ValueKind == JsonValueKind.String
-                && Guid.TryParse(je.GetString(), out var jp) => jp,
-            _ => null
-        };
-    }
 }

--- a/Shared/Shared.Messaging/Events/CompanyAssignedIntegrationEvent.cs
+++ b/Shared/Shared.Messaging/Events/CompanyAssignedIntegrationEvent.cs
@@ -6,8 +6,6 @@ public record CompanyAssignedIntegrationEvent : IntegrationEvent
     public Guid CompanyId { get; init; }
     public string CompanyName { get; init; } = default!;
     public string AssignmentMethod { get; init; } = default!;
-    public string? InternalAppraiserId { get; init; }
-    public string? InternalFollowupAssignmentMethod { get; init; }
     public string? CompletedBy { get; init; }
     public string? AppraisalNumber { get; init; }
 }

--- a/Shared/Shared.Messaging/Events/InternalFollowupAssignedIntegrationEvent.cs
+++ b/Shared/Shared.Messaging/Events/InternalFollowupAssignedIntegrationEvent.cs
@@ -1,0 +1,9 @@
+namespace Shared.Messaging.Events;
+
+public record InternalFollowupAssignedIntegrationEvent : IntegrationEvent
+{
+    public Guid AppraisalId { get; init; }
+    public string InternalAppraiserId { get; init; } = default!;
+    public string InternalFollowupAssignmentMethod { get; init; } = default!;
+    public string? CompletedBy { get; init; }
+}

--- a/Tests/Unit/Workflow.Tests/Workflow/CompanySelectionActivityTests.cs
+++ b/Tests/Unit/Workflow.Tests/Workflow/CompanySelectionActivityTests.cs
@@ -2,6 +2,8 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using Shared.Data.Outbox;
+using Shared.Messaging.Events;
 using Shared.Time;
 using Workflow.AssigneeSelection.Services;
 using Workflow.Workflow.Activities;
@@ -14,6 +16,7 @@ namespace Workflow.Tests.Workflow;
 public class CompanySelectionActivityTests
 {
     private readonly ICompanyRoundRobinService _roundRobinService;
+    private readonly IIntegrationEventOutbox _outbox;
     private readonly CompanySelectionActivity _sut;
 
     public CompanySelectionActivityTests()
@@ -22,8 +25,9 @@ public class CompanySelectionActivityTests
         var dateTimeProvider = Substitute.For<IDateTimeProvider>();
         dateTimeProvider.ApplicationNow.Returns(new DateTime(2026, 4, 19, 12, 0, 0));
         dateTimeProvider.Now.Returns(new DateTime(2026, 4, 19, 12, 0, 0));
+        _outbox = Substitute.For<IIntegrationEventOutbox>();
         var logger = Substitute.For<ILogger<CompanySelectionActivity>>();
-        _sut = new CompanySelectionActivity(_roundRobinService, dateTimeProvider, logger);
+        _sut = new CompanySelectionActivity(_roundRobinService, dateTimeProvider, _outbox, logger);
     }
 
     private static ActivityContext CreateContext(Dictionary<string, object>? variables = null)
@@ -34,12 +38,15 @@ public class CompanySelectionActivityTests
             null,
             "test-user");
 
+        var vars = variables ?? new Dictionary<string, object>();
+        vars.TryAdd("appraisalId", Guid.NewGuid());
+
         return new ActivityContext
         {
             WorkflowInstanceId = workflowInstance.Id,
             ActivityId = "company-selection",
             Properties = new Dictionary<string, object>(),
-            Variables = variables ?? new Dictionary<string, object>(),
+            Variables = vars,
             WorkflowInstance = workflowInstance
         };
     }
@@ -168,5 +175,76 @@ public class CompanySelectionActivityTests
         result.Status.Should().Be(ActivityResultStatus.Completed);
         result.OutputData["assignmentMethod"].Should().Be("RoundRobin");
         await _roundRobinService.Received(1).SelectCompanyAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RoundRobin_PublishesCompanyAssignedEvent()
+    {
+        var appraisalId = Guid.NewGuid();
+        var companyId = Guid.NewGuid();
+        _roundRobinService.SelectCompanyAsync(Arg.Any<CancellationToken>())
+            .Returns(CompanySelectionResult.Success(companyId, "RR Corp"));
+
+        var context = CreateContext(new Dictionary<string, object>
+        {
+            ["appraisalId"] = appraisalId
+        });
+
+        await _sut.ExecuteAsync(context);
+
+        _outbox.Received(1).Publish(
+            Arg.Is<CompanyAssignedIntegrationEvent>(e =>
+                e.AppraisalId == appraisalId
+                && e.CompanyId == companyId
+                && e.AssignmentMethod == "RoundRobin"),
+            appraisalId.ToString(),
+            Arg.Any<Dictionary<string, string>?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReplayBranch_DoesNotPublish()
+    {
+        // Replay: same loanType as previously assigned company — the activity
+        // reuses the prior selection and must NOT republish (would double-count).
+        var context = CreateContext(new Dictionary<string, object>
+        {
+            ["loanType"] = "HomeEquity",
+            ["assignedCompanyId"] = Guid.NewGuid().ToString(),
+            ["assignedCompanyName"] = "Prior Corp",
+            ["assignedCompanyLoanType"] = "HomeEquity"
+        });
+
+        var result = await _sut.ExecuteAsync(context);
+
+        result.OutputData["decision"].Should().Be("company_selected");
+        _outbox.DidNotReceiveWithAnyArgs().Publish<CompanyAssignedIntegrationEvent>(default!);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoMatch_DoesNotPublish()
+    {
+        _roundRobinService.SelectCompanyAsync(Arg.Any<CancellationToken>())
+            .Returns(CompanySelectionResult.Failure("No active companies"));
+
+        var context = CreateContext();
+
+        var result = await _sut.ExecuteAsync(context);
+
+        result.OutputData["decision"].Should().Be("no_match");
+        _outbox.DidNotReceiveWithAnyArgs().Publish<CompanyAssignedIntegrationEvent>(default!);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ManualSelectionFailure_DoesNotPublish()
+    {
+        var context = CreateContext(new Dictionary<string, object>
+        {
+            ["selectionMethod"] = "manual"
+            // no selectedCompanyId
+        });
+
+        await _sut.ExecuteAsync(context);
+
+        _outbox.DidNotReceiveWithAnyArgs().Publish<CompanyAssignedIntegrationEvent>(default!);
     }
 }

--- a/Tests/Unit/Workflow.Tests/Workflow/InternalFollowupSelectionActivityTests.cs
+++ b/Tests/Unit/Workflow.Tests/Workflow/InternalFollowupSelectionActivityTests.cs
@@ -1,0 +1,136 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shared.Data.Outbox;
+using Shared.Messaging.Events;
+using Shared.Time;
+using Workflow.AssigneeSelection.Services;
+using Workflow.Workflow.Activities;
+using Workflow.Workflow.Activities.Core;
+using Workflow.Workflow.Models;
+using Xunit;
+
+namespace Workflow.Tests.Workflow;
+
+public class InternalFollowupSelectionActivityTests
+{
+    private readonly IInternalStaffRoundRobinService _staffRoundRobinService;
+    private readonly IIntegrationEventOutbox _outbox;
+    private readonly InternalFollowupSelectionActivity _sut;
+
+    public InternalFollowupSelectionActivityTests()
+    {
+        _staffRoundRobinService = Substitute.For<IInternalStaffRoundRobinService>();
+        var dateTimeProvider = Substitute.For<IDateTimeProvider>();
+        dateTimeProvider.ApplicationNow.Returns(new DateTime(2026, 4, 19, 12, 0, 0));
+        dateTimeProvider.Now.Returns(new DateTime(2026, 4, 19, 12, 0, 0));
+        _outbox = Substitute.For<IIntegrationEventOutbox>();
+        var logger = Substitute.For<ILogger<InternalFollowupSelectionActivity>>();
+        _sut = new InternalFollowupSelectionActivity(
+            _staffRoundRobinService, dateTimeProvider, _outbox, logger);
+    }
+
+    private static ActivityContext CreateContext(Dictionary<string, object>? variables = null)
+    {
+        var workflowInstance = WorkflowInstance.Create(
+            Guid.NewGuid(), "test-workflow", null, "test-user");
+
+        var vars = variables ?? new Dictionary<string, object>();
+        vars.TryAdd("appraisalId", Guid.NewGuid());
+
+        return new ActivityContext
+        {
+            WorkflowInstanceId = workflowInstance.Id,
+            ActivityId = "internal-followup-selection",
+            Properties = new Dictionary<string, object>(),
+            Variables = vars,
+            WorkflowInstance = workflowInstance
+        };
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AdminPreSelectedStaff_PublishesFollowupEvent()
+    {
+        var appraisalId = Guid.NewGuid();
+        var context = CreateContext(new Dictionary<string, object>
+        {
+            ["appraisalId"] = appraisalId,
+            ["internalFollowupStaffId"] = "user-123",
+            ["internalFollowupMethod"] = "Manual"
+        });
+
+        var result = await _sut.ExecuteAsync(context);
+
+        result.OutputData["decision"].Should().Be("staff_selected");
+        result.OutputData["internalFollowupStaffId"].Should().Be("user-123");
+        result.OutputData["internalFollowupMethod"].Should().Be("Manual");
+
+        _outbox.Received(1).Publish(
+            Arg.Is<InternalFollowupAssignedIntegrationEvent>(e =>
+                e.AppraisalId == appraisalId
+                && e.InternalAppraiserId == "user-123"
+                && e.InternalFollowupAssignmentMethod == "Manual"),
+            appraisalId.ToString(),
+            Arg.Any<Dictionary<string, string>?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AdminPreSelectedStaffNoMethod_DefaultsToManual()
+    {
+        var context = CreateContext(new Dictionary<string, object>
+        {
+            ["internalFollowupStaffId"] = "user-123"
+        });
+
+        var result = await _sut.ExecuteAsync(context);
+
+        result.OutputData["internalFollowupMethod"].Should().Be("Manual");
+        _outbox.Received(1).Publish(
+            Arg.Is<InternalFollowupAssignedIntegrationEvent>(e =>
+                e.InternalFollowupAssignmentMethod == "Manual"),
+            Arg.Any<string?>(),
+            Arg.Any<Dictionary<string, string>?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RoundRobinSuccess_PublishesFollowupEvent()
+    {
+        var appraisalId = Guid.NewGuid();
+        _staffRoundRobinService.SelectStaffAsync(Arg.Any<CancellationToken>())
+            .Returns(StaffSelectionResult.Success("rr-user-456"));
+
+        var context = CreateContext(new Dictionary<string, object>
+        {
+            ["appraisalId"] = appraisalId
+        });
+
+        var result = await _sut.ExecuteAsync(context);
+
+        result.OutputData["decision"].Should().Be("staff_selected");
+        result.OutputData["internalFollowupStaffId"].Should().Be("rr-user-456");
+        result.OutputData["internalFollowupMethod"].Should().Be("RoundRobin");
+
+        _outbox.Received(1).Publish(
+            Arg.Is<InternalFollowupAssignedIntegrationEvent>(e =>
+                e.AppraisalId == appraisalId
+                && e.InternalAppraiserId == "rr-user-456"
+                && e.InternalFollowupAssignmentMethod == "RoundRobin"),
+            appraisalId.ToString(),
+            Arg.Any<Dictionary<string, string>?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoMatch_DoesNotPublish()
+    {
+        _staffRoundRobinService.SelectStaffAsync(Arg.Any<CancellationToken>())
+            .Returns(StaffSelectionResult.Failure("No eligible internal staff"));
+
+        var context = CreateContext();
+
+        var result = await _sut.ExecuteAsync(context);
+
+        result.OutputData["decision"].Should().Be("no_match");
+        result.OutputData["selectionError"].Should().Be("No eligible internal staff");
+        _outbox.DidNotReceiveWithAnyArgs().Publish<InternalFollowupAssignedIntegrationEvent>(default!);
+    }
+}


### PR DESCRIPTION
This pull request introduces several improvements and new features across the Appraisal and Auth modules, focusing on robust event handling, improved user-group management, and enhanced integration between workflow activities and messaging. The most notable changes include the implementation of inbox/outbox patterns for event processing, the addition of endpoints and handlers for updating user group memberships, and updates to data transfer objects for consistency.

**Event Handling and Idempotency Improvements:**

- Added inbox guard logic to `CompanyAssignedIntegrationEventHandler` to ensure idempotent processing of integration events, preventing duplicate handling and marking events as processed. Also, assignment logic now preserves internal follow-up fields to avoid overwriting changes from other handlers. [[1]](diffhunk://#diff-825d782f76891ffed5b0f1ad7e03b8238563e35f5820b7ef2cbae5f147595c2eR6-L33) [[2]](diffhunk://#diff-825d782f76891ffed5b0f1ad7e03b8238563e35f5820b7ef2cbae5f147595c2eR48-R65)
- Introduced `InternalFollowupAssignedIntegrationEventHandler` with inbox guard support, enabling safe, idempotent handling of internal follow-up assignment events.
- Added `AssignInternalFollowup` method to `AppraisalAssignment` domain model to attach internal follow-up staff after company assignment.

**Workflow Activities and Integration Events:**

- Updated `CompanySelectionActivity` and `InternalFollowupSelectionActivity` to publish integration events (`CompanyAssignedIntegrationEvent`, etc.) using the outbox pattern, ensuring reliable event delivery and decoupling workflow execution from messaging. [[1]](diffhunk://#diff-099014f1aa7fb51a184ca49625647c4aa11cedfd1217b983f1c805358a5b53baR1-R2) [[2]](diffhunk://#diff-099014f1aa7fb51a184ca49625647c4aa11cedfd1217b983f1c805358a5b53baR18-R29) [[3]](diffhunk://#diff-099014f1aa7fb51a184ca49625647c4aa11cedfd1217b983f1c805358a5b53baR72) [[4]](diffhunk://#diff-099014f1aa7fb51a184ca49625647c4aa11cedfd1217b983f1c805358a5b53baR113) [[5]](diffhunk://#diff-099014f1aa7fb51a184ca49625647c4aa11cedfd1217b983f1c805358a5b53baR138-R177) [[6]](diffhunk://#diff-9e4aa47d88d90dc8c1e8bb937d42517ee93dd330a7edcf6393ad325111b7fda3R1-R2) [[7]](diffhunk://#diff-9e4aa47d88d90dc8c1e8bb937d42517ee93dd330a7edcf6393ad325111b7fda3R19-R30) [[8]](diffhunk://#diff-9e4aa47d88d90dc8c1e8bb937d42517ee93dd330a7edcf6393ad325111b7fda3R53-R62) [[9]](diffhunk://#diff-9e4aa47d88d90dc8c1e8bb937d42517ee93dd330a7edcf6393ad325111b7fda3R79)

**User and Group Management Enhancements:**

- Added a new endpoint, command, and handler for updating all group memberships for a user, enabling admins to replace a user's group associations in a single operation. [[1]](diffhunk://#diff-5ac9a7b9b4085478f37d45b8319b87078f31b8a9434be85c4e7b1355cb1f8ec0R1-R3) [[2]](diffhunk://#diff-886f84d1d5ce4ca1f690ee918d645e2b7626a2aabe0bb566c7f4c3efd406d1d6R1-R45) [[3]](diffhunk://#diff-8831d4e1b32ba55e71f5c1bb9c3537c33cb5c0f61ac4800787667d3c7704fbe9R1-R24) [[4]](diffhunk://#diff-00a6814efd0c0ea4d799bcec04f446c742622a6bc6915cfe41b170b7c9e511c5R1-R3)
- Improved `GetGroupByIdQueryHandler` to fetch user details from the database, returning complete user information in group queries.
- Updated DTOs for group and user responses to include more detailed and consistent fields, such as user names and group names. [[1]](diffhunk://#diff-db0eee426a1115c84a24ab9d66f7b75a7fc1ecd58880ebfb45f3c14fcc2ca686L3-R5) [[2]](diffhunk://#diff-fdcf53d58fdf0888fcbd1f76d979f22c9c07571051f69b8247be30060552a180L3-R3)

**Summary of Most Important Changes:**

**Event Handling and Idempotency**
- Added inbox guard logic to `CompanyAssignedIntegrationEventHandler` and new `InternalFollowupAssignedIntegrationEventHandler` for safe, idempotent event processing, and updated assignment logic to preserve internal follow-up fields. [[1]](diffhunk://#diff-825d782f76891ffed5b0f1ad7e03b8238563e35f5820b7ef2cbae5f147595c2eR6-L33) [[2]](diffhunk://#diff-825d782f76891ffed5b0f1ad7e03b8238563e35f5820b7ef2cbae5f147595c2eR48-R65) [[3]](diffhunk://#diff-327315bd5b078fc53318875636d134c2033deb4fdf9cce1ce16fd1239b79d2f6R1-R65)
- Added `AssignInternalFollowup` method to `AppraisalAssignment` for attaching internal follow-up staff post company assignment.

**Workflow Integration Events**
- Enhanced `CompanySelectionActivity` and `InternalFollowupSelectionActivity` to publish integration events via the outbox, improving reliability and decoupling workflow from messaging. [[1]](diffhunk://#diff-099014f1aa7fb51a184ca49625647c4aa11cedfd1217b983f1c805358a5b53baR1-R2) [[2]](diffhunk://#diff-099014f1aa7fb51a184ca49625647c4aa11cedfd1217b983f1c805358a5b53baR18-R29) [[3]](diffhunk://#diff-099014f1aa7fb51a184ca49625647c4aa11cedfd1217b983f1c805358a5b53baR72) [[4]](diffhunk://#diff-099014f1aa7fb51a184ca49625647c4aa11cedfd1217b983f1c805358a5b53baR113) [[5]](diffhunk://#diff-099014f1aa7fb51a184ca49625647c4aa11cedfd1217b983f1c805358a5b53baR138-R177) [[6]](diffhunk://#diff-9e4aa47d88d90dc8c1e8bb937d42517ee93dd330a7edcf6393ad325111b7fda3R1-R2) [[7]](diffhunk://#diff-9e4aa47d88d90dc8c1e8bb937d42517ee93dd330a7edcf6393ad325111b7fda3R19-R30) [[8]](diffhunk://#diff-9e4aa47d88d90dc8c1e8bb937d42517ee93dd330a7edcf6393ad325111b7fda3R53-R62) [[9]](diffhunk://#diff-9e4aa47d88d90dc8c1e8bb937d42517ee93dd330a7edcf6393ad325111b7fda3R79)

**User and Group Management**
- Introduced new endpoint (`/auth/users/{id}/groups`), command, and handler to update user group memberships atomically. [[1]](diffhunk://#diff-5ac9a7b9b4085478f37d45b8319b87078f31b8a9434be85c4e7b1355cb1f8ec0R1-R3) [[2]](diffhunk://#diff-886f84d1d5ce4ca1f690ee918d645e2b7626a2aabe0bb566c7f4c3efd406d1d6R1-R45) [[3]](diffhunk://#diff-8831d4e1b32ba55e71f5c1bb9c3537c33cb5c0f61ac4800787667d3c7704fbe9R1-R24) [[4]](diffhunk://#diff-00a6814efd0c0ea4d799bcec04f446c742622a6bc6915cfe41b170b7c9e511c5R1-R3)
- Improved `GetGroupByIdQueryHandler` to return detailed user info for group queries.
- Updated group and user DTOs for consistency and completeness in API responses. [[1]](diffhunk://#diff-db0eee426a1115c84a24ab9d66f7b75a7fc1ecd58880ebfb45f3c14fcc2ca686L3-R5) [[2]](diffhunk://#diff-fdcf53d58fdf0888fcbd1f76d979f22c9c07571051f69b8247be30060552a180L3-R3)