### PR TITLE
Use lease  land area to calculate Leasehold table

### DIFF
--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveLeaseholdAnalysis/SaveLeaseholdAnalysisCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveLeaseholdAnalysis/SaveLeaseholdAnalysisCommandHandler.cs
@@ -40,6 +40,18 @@ public class SaveLeaseholdAnalysisCommandHandler(
             analysis = LeaseholdAnalysis.Create(method.Id);
             method.SetLeaseholdAnalysis(analysis);
         }
+        
+        // Update partial usage (lease land area) to calculate leashold table first
+        if (command.IsPartialUsage)
+        {
+            analysis.SetPartialUsage(true,
+                  command.PartialRai, command.PartialNgan, command.PartialWa,
+                  (command.PartialRai ?? 0) * 400m + (command.PartialNgan ?? 0) * 100m + (command.PartialWa ?? 0), command.PricePerSqWa,
+                  null, null, null
+                  );
+        } else {
+            analysis.SetPartialUsage(false, null, null, null, null, null, null, null, null );
+        }
 
         // Update input fields
         analysis.Update(

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveLeaseholdAnalysis/SaveLeaseholdAnalysisCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveLeaseholdAnalysis/SaveLeaseholdAnalysisCommandHandler.cs
@@ -108,7 +108,7 @@ public class SaveLeaseholdAnalysisCommandHandler(
                 LeaseholdCalculationService.CalculatePartialUsage(
                     calcResult.FinalValueRounded,
                     command.PartialRai, command.PartialNgan, command.PartialWa,
-                    command.PricePerSqWa);
+                    command.LandValuePerSqWa, propertyData.TotalLandAreaInSqWa);
 
             computedEstimatePriceRounded = estimatePriceRounded;
 
@@ -117,7 +117,7 @@ public class SaveLeaseholdAnalysisCommandHandler(
 
             analysis.SetPartialUsage(true,
                 command.PartialRai, command.PartialNgan, command.PartialWa,
-                partialLandArea, command.PricePerSqWa,
+                partialLandArea, command.LandValuePerSqWa,
                 partialLandPrice, estimateNetPrice, finalEstimate);
         }
         else

--- a/Modules/Appraisal/Appraisal/Domain/Services/LeaseholdCalculationService.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Services/LeaseholdCalculationService.cs
@@ -51,7 +51,8 @@ public class LeaseholdCalculationService
         var costIndex = analysis.ConstructionCostIndex / 100m;
         var depRate = analysis.DepreciationRate / 100m;
         var depInterval = analysis.DepreciationIntervalYears > 0 ? analysis.DepreciationIntervalYears : 1;
-        var baseLandValue = analysis.LandValuePerSqWa * totalLandAreaInSqWa;
+        
+        var baseLandValue = analysis.LandValuePerSqWa * (analysis.IsPartialUsage ? (analysis.PartialRai ?? 0) * 400m + (analysis.PartialNgan ?? 0) * 100m + (analysis.PartialWa ?? 0) : totalLandAreaInSqWa);
         var initialBuildingValue = analysis.InitialBuildingValue;
 
         var tableRows = new List<TableRowResult>();
@@ -149,17 +150,20 @@ public class LeaseholdCalculationService
             decimal? partialRai,
             decimal? partialNgan,
             decimal? partialWa,
-            decimal? pricePerSqWa)
+            decimal? pricePerSqWa,
+            decimal? totalLandAreaInSqWa
+            )
     {
         var partialLandArea = (partialRai ?? 0) * 400m + (partialNgan ?? 0) * 100m + (partialWa ?? 0);
         if (partialLandArea == 0 || !pricePerSqWa.HasValue)
             return (partialLandArea > 0 ? partialLandArea : null, null, null, null);
 
-        var partialLandPrice = pricePerSqWa.Value * partialLandArea;
-        var estimateNetPrice = finalValueRounded + partialLandPrice;
+        var remainingLandArea = (totalLandAreaInSqWa ?? 0) - partialLandArea;
+        var remainingLandPrice = pricePerSqWa.Value * remainingLandArea;
+        var estimateNetPrice = finalValueRounded + remainingLandPrice;
         var estimatePriceRounded = Math.Round(estimateNetPrice / 1000m, MidpointRounding.AwayFromZero) * 1000m;
 
-        return (partialLandArea, Math.Round(partialLandPrice, 2), Math.Round(estimateNetPrice, 2), estimatePriceRounded);
+        return (partialLandArea, pricePerSqWa, Math.Round(estimateNetPrice, 2), estimatePriceRounded);
     }
 
     private static decimal CalculatePvFactor(decimal discountRate, decimal year)


### PR DESCRIPTION
Update leasehold partial-usage logic to compute estimates using the total land area and land value per sq.wa. The LeaseholdCalculationService.CalculatePartialUsage signature now accepts totalLandAreaInSqWa and computes the estimate based on remaining land (total - partial) rather than using only the partial-land price. baseLandValue now respects analysis.IsPartialUsage by using the converted partial area when applicable. SaveLeaseholdAnalysisCommandHandler was updated to pass LandValuePerSqWa and TotalLandAreaInSqWa and to use LandValuePerSqWa in SetPartialUsage. These changes correct net price calculations for partial-usage scenarios.