### PR TITLE
fix: add EstimatedDays to quotation valuers and fee items

### DIFF
--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/SaveDraftQuotation/SaveDraftQuotationCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/SaveDraftQuotation/SaveDraftQuotationCommand.cs
@@ -17,7 +17,6 @@ public record SaveDraftQuotationCommand(
     Guid QuotationRequestId,
     Guid CompanyId,
     string QuotationNumber,
-    int EstimatedDays,
     List<SaveDraftQuotationItem> Items,
     DateTime? ValidUntil = null,
     DateTime? ProposedStartDate = null,

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/SaveDraftQuotation/SaveDraftQuotationCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/SaveDraftQuotation/SaveDraftQuotationCommandHandler.cs
@@ -49,8 +49,7 @@ public class SaveDraftQuotationCommandHandler(
                 command.QuotationRequestId,
                 invitation.Id,
                 command.CompanyId,
-                command.QuotationNumber,
-                command.EstimatedDays);
+                command.QuotationNumber);
 
             ApplyScalarFields(companyQuotation, command);
             AddItems(companyQuotation, command.Items);

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/SaveDraftQuotation/SaveDraftQuotationEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/SaveDraftQuotation/SaveDraftQuotationEndpoint.cs
@@ -36,7 +36,6 @@ public class SaveDraftQuotationEndpoint : ICarterModule
                         QuotationRequestId: id,
                         CompanyId: companyId,
                         QuotationNumber: request.QuotationNumber,
-                        EstimatedDays: request.EstimatedDays,
                         Items: items,
                         ValidUntil: request.ValidUntil,
                         ProposedStartDate: request.ProposedStartDate,

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/SaveDraftQuotation/SaveDraftQuotationRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/SaveDraftQuotation/SaveDraftQuotationRequest.cs
@@ -13,7 +13,6 @@ public record SaveDraftQuotationItemBody(
 
 public record SaveDraftQuotationRequest(
     string QuotationNumber,
-    int EstimatedDays,
     List<SaveDraftQuotationItemBody> Items,
     DateTime? ValidUntil = null,
     DateTime? ProposedStartDate = null,

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/SubmitQuotation/SubmitQuotationCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/SubmitQuotation/SubmitQuotationCommand.cs
@@ -20,7 +20,6 @@ public record SubmitQuotationCommand(
     Guid QuotationRequestId,
     Guid CompanyId,
     string QuotationNumber,
-    int EstimatedDays,
     List<SubmitQuotationItemRequest> Items,
     DateTime? ValidUntil = null,
     DateTime? ProposedStartDate = null,

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/SubmitQuotation/SubmitQuotationCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/SubmitQuotation/SubmitQuotationCommandHandler.cs
@@ -71,7 +71,6 @@ public class SubmitQuotationCommandHandler(
                 invitationId: invitation.Id,
                 companyId: command.CompanyId,
                 quotationNumber: command.QuotationNumber,
-                estimatedDays: command.EstimatedDays,
                 submittedAt: dateTimeProvider.ApplicationNow);
 
             ApplyScalarFields(companyQuotation, command);

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/SubmitQuotation/SubmitQuotationEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/SubmitQuotation/SubmitQuotationEndpoint.cs
@@ -38,7 +38,6 @@ public class SubmitQuotationEndpoint : ICarterModule
                         QuotationRequestId: id,
                         CompanyId: companyId,
                         QuotationNumber: request.QuotationNumber,
-                        EstimatedDays: request.EstimatedDays,
                         Items: items,
                         ValidUntil: request.ValidUntil,
                         ProposedStartDate: request.ProposedStartDate,

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/SubmitQuotation/SubmitQuotationRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/SubmitQuotation/SubmitQuotationRequest.cs
@@ -15,7 +15,6 @@ public record SubmitQuotationItemBody(
 
 public record SubmitQuotationRequest(
     string QuotationNumber,
-    int EstimatedDays,
     List<SubmitQuotationItemBody> Items,
     DateTime? ValidUntil = null,
     DateTime? ProposedStartDate = null,

--- a/Modules/Appraisal/Appraisal/Domain/Quotations/CompanyQuotation.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Quotations/CompanyQuotation.cs
@@ -88,7 +88,6 @@ public class CompanyQuotation : Entity<Guid>
         Guid invitationId,
         Guid companyId,
         string quotationNumber,
-        int estimatedDays,
         DateTime submittedAt)
     {
         return new CompanyQuotation
@@ -99,7 +98,6 @@ public class CompanyQuotation : Entity<Guid>
             CompanyId = companyId,
             QuotationNumber = quotationNumber,
             SubmittedAt = submittedAt,
-            EstimatedDays = estimatedDays,
             Status = "Submitted",
             TotalQuotedPrice = 0,
             IsShortlisted = false,
@@ -115,8 +113,7 @@ public class CompanyQuotation : Entity<Guid>
         Guid quotationRequestId,
         Guid invitationId,
         Guid companyId,
-        string quotationNumber,
-        int estimatedDays)
+        string quotationNumber)
     {
         // Id intentionally left at default — matches legacy Create() pattern.
         // Repository uses DbSet.Update() which treats default-key entities as Added
@@ -130,7 +127,6 @@ public class CompanyQuotation : Entity<Guid>
             CompanyId = companyId,
             QuotationNumber = quotationNumber,
             SubmittedAt = default,
-            EstimatedDays = estimatedDays,
             Status = "Draft",
             TotalQuotedPrice = 0,
             Currency = "THB"
@@ -152,6 +148,7 @@ public class CompanyQuotation : Entity<Guid>
             Id, quotationRequestItemId, appraisalId, itemNumber, quotedPrice, estimatedDays);
         _items.Add(item);
         RecalculateTotalPrice();
+        RecalculateEstimatedDays();
         return item;
     }
 
@@ -469,6 +466,8 @@ public class CompanyQuotation : Entity<Guid>
     // Internal helpers
     // ─────────────────────────────────────────────────────────────────────────
 
+    private void RecalculateEstimatedDays() => EstimatedDays = _items.Sum(i => i.EstimatedDays);
+
     private void RecalculateTotalPrice()
     {
         // If any item has a fee breakdown entered, use the derived NetAmount.
@@ -483,6 +482,7 @@ public class CompanyQuotation : Entity<Guid>
     internal void ClearItems()
     {
         _items.Clear();
+        RecalculateEstimatedDays();
     }
 
     internal void AddNegotiation(QuotationNegotiation negotiation)

--- a/Modules/Integration/Integration/Application/Features/Quotations/GetQuotationValuers/GetQuotationValuersQuery.cs
+++ b/Modules/Integration/Integration/Application/Features/Quotations/GetQuotationValuers/GetQuotationValuersQuery.cs
@@ -18,8 +18,10 @@ public record QuotationValuerItem(
     string CompanyQuotationId,
     string ValuerName,
     decimal TotalAppraisalFee,
+    int? EstimatedDays,
     List<ValuerAppraisalFeeItem> Items);
 
 public record ValuerAppraisalFeeItem(
     string AppraisalNumber,
-    decimal QuotedPrice);
+    decimal QuotedPrice,
+    int? EstimatedDays);

--- a/Modules/Integration/Integration/Application/Features/Quotations/GetQuotationValuers/GetQuotationValuersQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/Quotations/GetQuotationValuers/GetQuotationValuersQueryHandler.cs
@@ -9,28 +9,30 @@ public class GetQuotationValuersQueryHandler(
 ) : IQueryHandler<GetQuotationValuersQuery, GetQuotationValuersResult>
 {
     private const string SqlAppraisals = """
-        SELECT qi.AppraisalNumber, qi.PropertyType, qi.PropertyLocation
-        FROM appraisal.QuotationRequestItems qi
-        WHERE qi.QuotationRequestId = @QuotationId
-        ORDER BY qi.ItemNumber
-        """;
+                                         SELECT qi.AppraisalNumber, qi.PropertyType, qi.PropertyLocation
+                                         FROM appraisal.QuotationRequestItems qi
+                                         WHERE qi.QuotationRequestId = @QuotationId
+                                         ORDER BY qi.ItemNumber
+                                         """;
 
     private const string SqlShortlistedCompanies = """
-        SELECT cq.Id AS CompanyQuotationId, c.Name AS CompanyName, cq.TotalQuotedPrice
-        FROM appraisal.CompanyQuotations cq
-        JOIN auth.Companies c ON c.Id = cq.CompanyId
-        WHERE cq.QuotationRequestId = @QuotationId AND cq.IsShortlisted = 1
-        """;
+                                                   SELECT cq.Id AS CompanyQuotationId, c.Name AS CompanyName, cq.TotalQuotedPrice, cq.EstimatedDays
+                                                   FROM appraisal.CompanyQuotations cq
+                                                   JOIN auth.Companies c ON c.Id = cq.CompanyId
+                                                   WHERE cq.QuotationRequestId = @QuotationId AND cq.IsShortlisted = 1
+                                                   """;
 
     private const string SqlFeeItems = """
-        SELECT cqi.CompanyQuotationId,
-               qi.AppraisalNumber,
-               (cqi.FeeAmount - cqi.Discount - ISNULL(cqi.NegotiatedDiscount, 0))
-                 * (1.0 + cqi.VatPercent / 100.0) AS QuotedPrice
-        FROM appraisal.CompanyQuotationItems cqi
-        JOIN appraisal.QuotationRequestItems qi ON qi.Id = cqi.QuotationRequestItemId
-        WHERE cqi.CompanyQuotationId IN @CompanyQuotationIds
-        """;
+                                       SELECT cqi.CompanyQuotationId,
+                                              a.AppraisalNumber,
+                                              (cqi.FeeAmount - cqi.Discount - ISNULL(cqi.NegotiatedDiscount, 0))
+                                                * (1.0 + cqi.VatPercent / 100.0) AS QuotedPrice,
+                                              cqi.EstimatedDays
+                                       FROM appraisal.CompanyQuotationItems cqi
+                                       JOIN appraisal.Appraisals a ON a.Id = cqi.AppraisalId
+                                       --JOIN appraisal.QuotationRequestItems qi ON qi.Id = cqi.QuotationRequestItemId
+                                       WHERE cqi.CompanyQuotationId IN @CompanyQuotationIds
+                                       """;
 
     public async Task<GetQuotationValuersResult> Handle(
         GetQuotationValuersQuery query,
@@ -56,10 +58,7 @@ public class GetQuotationValuersQueryHandler(
 
         var companies = companyRows.ToList();
 
-        if (companies.Count == 0)
-        {
-            return new GetQuotationValuersResult(query.QuotationId, appraisals, []);
-        }
+        if (companies.Count == 0) return new GetQuotationValuersResult(query.QuotationId, appraisals, []);
 
         var shortlistedIds = companies.Select(c => c.CompanyQuotationId).ToList();
 
@@ -75,11 +74,13 @@ public class GetQuotationValuersQueryHandler(
 
         var valuers = companies
             .Select(c => new QuotationValuerItem(
-                CompanyQuotationId: c.CompanyQuotationId.ToString(),
-                ValuerName: c.CompanyName,
-                TotalAppraisalFee: c.TotalQuotedPrice,
-                Items: feesByCompany.TryGetValue(c.CompanyQuotationId, out var items)
-                    ? items.Select(i => new ValuerAppraisalFeeItem(i.AppraisalNumber, i.QuotedPrice)).ToList()
+                c.CompanyQuotationId.ToString(),
+                c.CompanyName,
+                c.TotalQuotedPrice,
+                c.EstimatedDays,
+                feesByCompany.TryGetValue(c.CompanyQuotationId, out var items)
+                    ? items.Select(i => new ValuerAppraisalFeeItem(i.AppraisalNumber, i.QuotedPrice, i.EstimatedDays))
+                        .ToList()
                     : []))
             .ToList();
 
@@ -87,6 +88,16 @@ public class GetQuotationValuersQueryHandler(
     }
 
     private sealed record AppraisalRow(string AppraisalNumber, string? PropertyType, string? PropertyLocation);
-    private sealed record CompanyRow(Guid CompanyQuotationId, string CompanyName, decimal TotalQuotedPrice);
-    private sealed record FeeRow(Guid CompanyQuotationId, string AppraisalNumber, decimal QuotedPrice);
+
+    private sealed record CompanyRow(
+        Guid CompanyQuotationId,
+        string CompanyName,
+        decimal TotalQuotedPrice,
+        int? EstimatedDays);
+
+    private sealed record FeeRow(
+        Guid CompanyQuotationId,
+        string AppraisalNumber,
+        decimal QuotedPrice,
+        int? EstimatedDays);
 }


### PR DESCRIPTION
This pull request enhances the quotation valuer feature by including estimated days for both company quotations and individual appraisal items throughout the data flow. The changes ensure that the estimated completion time is available in API responses and internal representations, improving the transparency and usefulness of the quotations.

**Enhancements to Quotation Valuer Data Structures and Queries:**

* Added `EstimatedDays` as an optional (`int?`) property to the `QuotationValuerItem` and `ValuerAppraisalFeeItem` records, so that both company-level and item-level estimated completion times can be tracked and returned.
* Updated SQL queries in `GetQuotationValuersQueryHandler.cs` to select `EstimatedDays` from both `CompanyQuotations` and `CompanyQuotationItems`, ensuring this data is retrieved from the database.
* Modified the mapping logic in the handler to populate the new `EstimatedDays` fields in both company and fee item records, and updated internal `CompanyRow` and `FeeRow` types accordingly.
* Minor code style update: condensed the early return when no companies are found for clarity.