### PR TITLE
fix: include QuotationNumber in GetQuotationValuers result

### DIFF
--- a/Modules/Integration/Integration/Application/Features/Quotations/GetQuotationValuers/GetQuotationValuersQuery.cs
+++ b/Modules/Integration/Integration/Application/Features/Quotations/GetQuotationValuers/GetQuotationValuersQuery.cs
@@ -6,6 +6,7 @@ public record GetQuotationValuersQuery(Guid QuotationId) : IQuery<GetQuotationVa
 
 public record GetQuotationValuersResult(
     Guid QuotationId,
+    string? QuotationNumber,
     List<QuotationAppraisalItem> Appraisals,
     List<QuotationValuerItem> Valuers);
 

--- a/Modules/Integration/Integration/Application/Features/Quotations/GetQuotationValuers/GetQuotationValuersQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/Quotations/GetQuotationValuers/GetQuotationValuersQueryHandler.cs
@@ -1,6 +1,5 @@
 using Dapper;
 using Shared.CQRS;
-using Shared.Data;
 
 namespace Integration.Application.Features.Quotations.GetQuotationValuers;
 
@@ -8,6 +7,12 @@ public class GetQuotationValuersQueryHandler(
     ISqlConnectionFactory connectionFactory
 ) : IQueryHandler<GetQuotationValuersQuery, GetQuotationValuersResult>
 {
+    private const string SqlQuotationNumber = """
+                                              SELECT QuotationNumber
+                                              FROM appraisal.QuotationRequests
+                                              WHERE Id = @QuotationId
+                                              """;
+
     private const string SqlAppraisals = """
                                          SELECT qi.AppraisalNumber, qi.PropertyType, qi.PropertyLocation
                                          FROM appraisal.QuotationRequestItems qi
@@ -16,7 +21,7 @@ public class GetQuotationValuersQueryHandler(
                                          """;
 
     private const string SqlShortlistedCompanies = """
-                                                   SELECT cq.Id AS CompanyQuotationId, c.Name AS CompanyName, cq.TotalQuotedPrice, cq.EstimatedDays
+                                                   SELECT cq.Id AS CompanyQuotationId, c.Name AS CompanyName, cq.TotalQuotedPrice, cq.EstimatedDays 
                                                    FROM appraisal.CompanyQuotations cq
                                                    JOIN auth.Companies c ON c.Id = cq.CompanyId
                                                    WHERE cq.QuotationRequestId = @QuotationId AND cq.IsShortlisted = 1
@@ -30,7 +35,6 @@ public class GetQuotationValuersQueryHandler(
                                               cqi.EstimatedDays
                                        FROM appraisal.CompanyQuotationItems cqi
                                        JOIN appraisal.Appraisals a ON a.Id = cqi.AppraisalId
-                                       --JOIN appraisal.QuotationRequestItems qi ON qi.Id = cqi.QuotationRequestItemId
                                        WHERE cqi.CompanyQuotationId IN @CompanyQuotationIds
                                        """;
 
@@ -42,6 +46,9 @@ public class GetQuotationValuersQueryHandler(
 
         var appraisalParams = new DynamicParameters();
         appraisalParams.Add("QuotationId", query.QuotationId);
+
+        var quotationNumber = await conn.QuerySingleOrDefaultAsync<string?>(
+            new CommandDefinition(SqlQuotationNumber, appraisalParams, cancellationToken: cancellationToken));
 
         var appraisalRows = await conn.QueryAsync<AppraisalRow>(
             new CommandDefinition(SqlAppraisals, appraisalParams, cancellationToken: cancellationToken));
@@ -58,7 +65,8 @@ public class GetQuotationValuersQueryHandler(
 
         var companies = companyRows.ToList();
 
-        if (companies.Count == 0) return new GetQuotationValuersResult(query.QuotationId, appraisals, []);
+        if (companies.Count == 0)
+            return new GetQuotationValuersResult(query.QuotationId, quotationNumber, appraisals, []);
 
         var shortlistedIds = companies.Select(c => c.CompanyQuotationId).ToList();
 
@@ -84,7 +92,7 @@ public class GetQuotationValuersQueryHandler(
                     : []))
             .ToList();
 
-        return new GetQuotationValuersResult(query.QuotationId, appraisals, valuers);
+        return new GetQuotationValuersResult(query.QuotationId, quotationNumber, appraisals, valuers);
     }
 
     private sealed record AppraisalRow(string AppraisalNumber, string? PropertyType, string? PropertyLocation);


### PR DESCRIPTION
## Summary
- Add `QuotationNumber` (nullable string) to `GetQuotationValuersResult`.
- Handler now fetches `QuotationNumber` from `appraisal.QuotationRequests` and threads it through both return paths (empty-companies and full).

Lifted out of `feature/invoice-fsd-alignment` as an urgent fix so it can ship independently of the in-progress invoice work.

## Test plan
- [ ] `dotnet build` passes.
- [ ] `GET /api/v1/quotations/{quotationId}/valuers` returns `quotationNumber` populated for an existing quotation.
- [ ] Returns `null` for an unknown quotationId (current behaviour preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)