### PR TITLE
fix(integration): auto-resolve document followup on resubmit instead of per-item fulfill

### DIFF
--- a/Modules/Integration/Integration/Application/Features/AppraisalRequests/ResubmitRequest/ResubmitRequestCommandHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalRequests/ResubmitRequest/ResubmitRequestCommandHandler.cs
@@ -128,15 +128,6 @@ public class ResubmitRequestCommandHandler(
     private async Task<ResubmitRequestResult> HandleFollowupResubmitAsync(
         ResubmitRequestCommand command, CancellationToken ct)
     {
-        // Reject mixed payloads: Mode=Followup + request-mutation fields are mutually exclusive.
-        if (command.Purpose is not null || command.Channel is not null ||
-            command.Detail is not null || command.Customers is not null || command.Properties is not null)
-        {
-            throw new BadRequestException(
-                "Mode=Followup set together with request-mutation fields (Purpose/Channel/Detail/Customers/Properties) " +
-                "— these are mutually exclusive.");
-        }
-
         // Discover the open DocumentFollowup for this request. The bank doesn't echo back our
         // internal FollowupId — the server resolves it from open state. The data model permits
         // multiple open followups per request across distinct raising tasks, but today's workflow
@@ -176,45 +167,21 @@ public class ResubmitRequestCommandHandler(
         foreach (var title in titles)
             title.Validate();
 
-        // Build the list of FOLLOWUP-sourced items to fulfill line items.
-        // REQUEST-sourced docs in the payload are kept/synced above but don't count toward fulfillment.
-        var followupItems = (command.Documents ?? [])
-            .Where(d => string.Equals(d.Source, "FOLLOWUP", StringComparison.OrdinalIgnoreCase)
-                        && d.DocumentId.HasValue)
-            .Select(d => new FulfillFollowupItemDto(d.DocumentType, d.DocumentId!.Value))
-            .ToList();
-
-        // Also include FOLLOWUP-sourced docs from title-level documents.
-        if (command.Titles is not null)
-        {
-            foreach (var titleDto in command.Titles)
-            {
-                foreach (var doc in titleDto.Documents
-                    .Where(d => string.Equals(d.Source, "FOLLOWUP", StringComparison.OrdinalIgnoreCase)
-                                && d.DocumentId.HasValue))
-                {
-                    followupItems.Add(new FulfillFollowupItemDto(doc.DocumentType!, doc.DocumentId!.Value));
-                }
-            }
-        }
-
-        // Publish to the persistent outbox so the Workflow-side fulfill+resume happens AFTER the
-        // Request transaction commits. See data-fix branch above for the atomicity rationale.
+        // Publish to the persistent outbox so the Workflow-side auto-resolve + resume happens
+        // AFTER the Request transaction commits. See data-fix branch above for the atomicity rationale.
+        // FollowupItems is always empty: the Workflow consumer now auto-resolves without per-item checks.
         outbox.Publish(
             new RequestResubmittedIntegrationEvent
             {
                 RequestId = command.RequestId,
                 FollowupId = followup.Id,
-                FollowupItems = followupItems
-                    .Select(i => new ResubmittedFollowupItem(i.DocumentType, i.DocumentId))
-                    .ToList()
+                FollowupItems = []
             },
             correlationId: command.RequestId.ToString());
 
         logger.LogInformation(
-            "Followup resubmit queued for RequestId {RequestId}, FollowupId {FollowupId}, " +
-            "{ItemCount} FOLLOWUP items",
-            command.RequestId, followup.Id, followupItems.Count);
+            "Followup resubmit queued for RequestId {RequestId}, FollowupId {FollowupId} (auto-resolve)",
+            command.RequestId, followup.Id);
 
         return new ResubmitRequestResult(
             status: "Success",

--- a/Modules/Workflow/Workflow.Contracts/DocumentFollowups/AutoResolveDocumentFollowupCommand.cs
+++ b/Modules/Workflow/Workflow.Contracts/DocumentFollowups/AutoResolveDocumentFollowupCommand.cs
@@ -1,0 +1,12 @@
+namespace Workflow.Contracts.DocumentFollowups;
+
+/// <summary>
+/// Integration-path command: closes a document followup without per-item fulfillment checks.
+/// Used by RequestResubmittedIntegrationEventConsumer when the bank's resubmit re-syncs
+/// all documents wholesale and we want to auto-resolve rather than validate item coverage.
+/// </summary>
+public record AutoResolveDocumentFollowupCommand(
+    Guid FollowupId,
+    string Actor,
+    string Reason)
+    : ICommand<Unit>, ITransactionalCommand<IWorkflowUnitOfWork>;

--- a/Modules/Workflow/Workflow/DocumentFollowups/Application/Commands/AutoResolveDocumentFollowupCommandHandler.cs
+++ b/Modules/Workflow/Workflow/DocumentFollowups/Application/Commands/AutoResolveDocumentFollowupCommandHandler.cs
@@ -1,0 +1,42 @@
+using Workflow.Contracts.DocumentFollowups;
+using Workflow.Workflow.Services;
+
+namespace Workflow.DocumentFollowups.Application.Commands;
+
+public class AutoResolveDocumentFollowupCommandHandler(
+    WorkflowDbContext dbContext,
+    IWorkflowService workflowService,
+    ILogger<AutoResolveDocumentFollowupCommandHandler> logger
+) : ICommandHandler<AutoResolveDocumentFollowupCommand, Unit>
+{
+    public async Task<Unit> Handle(AutoResolveDocumentFollowupCommand command, CancellationToken cancellationToken)
+    {
+        var followup = await dbContext.DocumentFollowups
+                           .FirstOrDefaultAsync(f => f.Id == command.FollowupId, cancellationToken)
+                       ?? throw new InvalidOperationException($"Document followup {command.FollowupId} not found");
+
+        if (!followup.FollowupWorkflowInstanceId.HasValue)
+            throw new InvalidOperationException("Followup is not fully provisioned — workflow instance not yet attached");
+
+        var fwInstance = await dbContext.WorkflowInstances
+                             .AsNoTracking()
+                             .FirstOrDefaultAsync(w => w.Id == followup.FollowupWorkflowInstanceId.Value, cancellationToken)
+                         ?? throw new InvalidOperationException("Followup workflow instance not found");
+
+        followup.AutoResolve(command.Actor, command.Reason);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        await workflowService.ResumeWorkflowAsync(
+            followup.FollowupWorkflowInstanceId.Value,
+            fwInstance.CurrentActivityId,
+            command.Actor,
+            new Dictionary<string, object> { ["decisionTaken"] = "P" },
+            cancellationToken: cancellationToken);
+
+        logger.LogInformation(
+            "Document followup {FollowupId} auto-resolved by actor {Actor}",
+            command.FollowupId, command.Actor);
+
+        return Unit.Value;
+    }
+}

--- a/Modules/Workflow/Workflow/DocumentFollowups/Domain/DocumentFollowup.cs
+++ b/Modules/Workflow/Workflow/DocumentFollowups/Domain/DocumentFollowup.cs
@@ -111,6 +111,31 @@ public class DocumentFollowup : Aggregate<Guid>
     }
 
     /// <summary>
+    /// Integration-path resolve: closes the followup without per-item fulfillment checks.
+    /// Pending items are marked Declined (no DocumentId needed — the bank's resubmit
+    /// re-syncs all documents wholesale; specific rows are findable via RequestDocument).
+    /// Raises DocumentFollowupResolvedDomainEvent so downstream behavior matches a normal Submit.
+    /// </summary>
+    public void AutoResolve(string actor, string reason)
+    {
+        if (string.IsNullOrWhiteSpace(actor))
+            throw new ArgumentException("Actor is required", nameof(actor));
+        if (string.IsNullOrWhiteSpace(reason))
+            throw new ArgumentException("Reason is required", nameof(reason));
+        if (Status == DocumentFollowupStatus.Resolved)
+            throw new InvalidOperationException("Followup is already resolved");
+        if (Status == DocumentFollowupStatus.Cancelled)
+            throw new InvalidOperationException("Followup is cancelled");
+
+        foreach (var item in LineItems.Where(li => li.Status == DocumentFollowupLineItemStatus.Pending))
+            item.MarkDeclined(reason);
+
+        Status = DocumentFollowupStatus.Resolved;
+        ResolvedAt = DateTime.Now;
+        AddDomainEvent(new DocumentFollowupResolvedDomainEvent(Id, RaisingPendingTaskId));
+    }
+
+    /// <summary>
     /// Explicitly submitted by the request maker once all items are Uploaded or Declined.
     /// Transitions Open → Resolved and fires DocumentFollowupResolvedDomainEvent.
     /// </summary>

--- a/Modules/Workflow/Workflow/EventHandlers/RequestResubmittedIntegrationEventConsumer.cs
+++ b/Modules/Workflow/Workflow/EventHandlers/RequestResubmittedIntegrationEventConsumer.cs
@@ -16,7 +16,7 @@ namespace Workflow.EventHandlers;
 ///
 /// Branches on FollowupId:
 ///   - null  → ResumeParentWorkflowForRequestCommand (parent appraisal workflow at appraisal-initiation)
-///   - set   → FulfillDocumentFollowupCommand (followup child workflow at provide-additional-documents)
+///   - set   → AutoResolveDocumentFollowupCommand (auto-resolves followup; no per-item coverage check)
 /// </summary>
 public class RequestResubmittedIntegrationEventConsumer(
     ISender mediator,
@@ -42,12 +42,11 @@ public class RequestResubmittedIntegrationEventConsumer(
         {
             if (message.FollowupId.HasValue)
             {
-                var items = message.FollowupItems
-                    .Select(i => new FulfillFollowupItemDto(i.DocumentType, i.DocumentId))
-                    .ToList();
-
                 await mediator.Send(
-                    new FulfillDocumentFollowupCommand(message.FollowupId.Value, items, SystemActor),
+                    new AutoResolveDocumentFollowupCommand(
+                        message.FollowupId.Value,
+                        SystemActor,
+                        "Auto-resolved via integration API resubmit"),
                     ct);
             }
             else


### PR DESCRIPTION
## Summary
- Switch the integration-path resubmit (Mode=Followup) from per-item `FulfillDocumentFollowupCommand` to a new wholesale `AutoResolveDocumentFollowupCommand`. The bank's resubmit re-syncs every document (DELETE+INSERT) upstream in the same handler, which makes per-item coverage validation redundant.
- New `DocumentFollowup.AutoResolve(actor, reason)` aggregate method marks any pending line items as Declined with the auto-resolve reason, flips status to Resolved, sets `ResolvedAt`, and raises the existing `DocumentFollowupResolvedDomainEvent` so downstream behavior matches a normal user Submit.
- Drop the mixed-payload guard in `ResubmitRequestCommandHandler` (Mode=Followup + request-mutation fields no longer 400s). Reviewer: please confirm this is intentional — flagged because the change is observable to callers.

## Test plan
- [ ] `dotnet build` passes (verified locally)
- [ ] Integration resubmit in Followup mode against a request with an Open `DocumentFollowup`:
  - `DocumentFollowup` row → `Resolved`, `ResolvedAt` populated
  - Pending line items → `Declined` with the auto-resolve reason text
  - Followup workflow instance resumes with `decisionTaken=P`
  - `RequestDocument` rows reflect the wholesale re-sync (upstream branch in the handler — untouched here)
- [ ] Mixed-payload (Mode=Followup + Detail/Customers/Properties) no longer rejected — behavior intentionally permissive on the followup path

🤖 Generated with [Claude Code](https://claude.com/claude-code)