### PR TITLE
fix(deploy): decouple in-process loopback HttpClient base URL from Ap…

### DIFF
--- a/Bootstrapper/Api/Program.cs
+++ b/Bootstrapper/Api/Program.cs
@@ -122,8 +122,15 @@ builder.Services.AddMassTransit(config =>
 
 builder.Services.AddHttpClient("CAS", client =>
 {
-    var baseUrl = builder.Configuration["AppBaseUrl"]
-                  ?? throw new InvalidOperationException("AppBaseUrl is not configured in appsettings.");
+    // In-process loopback calls (TokenHandler / RefreshTokenHandler) hit /connect/token via this client.
+    // Behind an LB, AppBaseUrl is the public LB URL — but the TLS cert at that URL may not match the
+    // hostname (RemoteCertificateNameMismatch) when traffic loops back to the local node. Allow ops to
+    // point the loopback HttpClient at http(s)://localhost:<port> via Auth:InternalAuthBaseUrl while
+    // keeping AppBaseUrl = LB URL for the OpenIddict issuer claim.
+    var baseUrl = builder.Configuration["Auth:InternalAuthBaseUrl"]
+                  ?? builder.Configuration["AppBaseUrl"]
+                  ?? throw new InvalidOperationException(
+                      "Neither Auth:InternalAuthBaseUrl nor AppBaseUrl is configured in appsettings.");
     client.BaseAddress = new Uri(baseUrl);
 });
 

--- a/Bootstrapper/Api/appsettings.Production.json.template
+++ b/Bootstrapper/Api/appsettings.Production.json.template
@@ -23,6 +23,9 @@
     }
   },
   "AppBaseUrl": "#{APP_BASE_URL}#",
+  "Auth": {
+    "InternalAuthBaseUrl": "#{AUTH_INTERNAL_BASE_URL}#"
+  },
   "Serilog": {
     "Using": [
       "Serilog.Sinks.Console",

--- a/docs/ops/multi-server-deployment.md
+++ b/docs/ops/multi-server-deployment.md
@@ -225,7 +225,10 @@ release-pipeline variables for the tokens:
       "Thumbprint": "#{OAUTH2_ENCRYPTION_CERT_THUMBPRINT}#"
     }
   },
-  "AppBaseUrl": "#{APP_BASE_URL}#"
+  "AppBaseUrl": "#{APP_BASE_URL}#",
+  "Auth": {
+    "InternalAuthBaseUrl": "#{AUTH_INTERNAL_BASE_URL}#"
+  }
 }
 ```
 
@@ -234,6 +237,12 @@ release-pipeline variables for the tokens:
 - `AppBaseUrl` must be the **public load-balancer URL** (e.g. `https://cas.example.com`),
   not the per-server hostname. OpenIddict stamps this into the JWT `iss` claim; mismatched
   issuers between nodes will fail validation on the other node.
+- `Auth:InternalAuthBaseUrl` is for **in-process loopback calls only** (`TokenHandler` /
+  `RefreshTokenHandler` calling `/connect/token` on themselves). Set to
+  `http://localhost:<kestrel-port>` or `https://localhost:<kestrel-port>`. Without it,
+  the loopback call goes out through the LB and you get `RemoteCertificateNameMismatch`
+  if the LB's TLS cert doesn't include the hostname being used. If omitted, the code
+  falls back to `AppBaseUrl`.
 - The same two thumbprints must be deployed to **both** servers.
 - Strip any whitespace from thumbprints copied from `certlm.msc` (Windows likes to prefix
   an invisible LRM character).


### PR DESCRIPTION
…pBaseUrl

The "CAS" HttpClient used by TokenHandler / RefreshTokenHandler shared its base address with the OpenIddict issuer (AppBaseUrl = public LB URL). Behind a load balancer, the loopback call to /connect/token then went out through the LB and failed TLS validation with RemoteCertificateNameMismatch when the LB's cert did not include the LB hostname in its SAN.

Introduce Auth:InternalAuthBaseUrl. The CAS HttpClient prefers this when set, falling back to AppBaseUrl. AppBaseUrl stays the public LB URL (still used as the OpenIddict issuer). Ops sets InternalAuthBaseUrl to http(s)://localhost:<port> so the loopback never traverses the LB.