### PR TITLE
fix(quotation): resolve child workflow by CorrelationId on cutoff

### DIFF
--- a/Modules/Workflow/Workflow/EventHandlers/QuotationDueDatePassedIntegrationEventConsumer.cs
+++ b/Modules/Workflow/Workflow/EventHandlers/QuotationDueDatePassedIntegrationEventConsumer.cs
@@ -29,6 +29,7 @@ public class QuotationDueDatePassedIntegrationEventConsumer(
     : IConsumer<QuotationDueDatePassedIntegrationEvent>
 {
     private const string DefaultActivityId = "ext-collect-submissions";
+    private const string QuotationWorkflowDefinitionName = "Quotation Workflow";
 
     public async Task Consume(ConsumeContext<QuotationDueDatePassedIntegrationEvent> context)
     {
@@ -45,9 +46,13 @@ public class QuotationDueDatePassedIntegrationEventConsumer(
         // Resolve the child workflow by CorrelationId (set at spawn in
         // QuotationStartedIntegrationEventConsumer to QuotationRequestId.ToString()).
         // QuotationRequest.QuotationWorkflowInstanceId is never written, so we cannot
-        // trust the value on the incoming message.
-        var instance = await instanceRepository.GetByCorrelationId(
-            message.QuotationRequestId.ToString(), ct);
+        // trust the value on the incoming message. Scope by workflow definition name
+        // because (CorrelationId, WorkflowDefinitionId) is the DB uniqueness key —
+        // other workflow types could share the same CorrelationId value.
+        var instance = await instanceRepository.GetByCorrelationIdAsync(
+            message.QuotationRequestId.ToString(),
+            QuotationWorkflowDefinitionName,
+            ct);
 
         if (instance is null)
         {

--- a/Modules/Workflow/Workflow/EventHandlers/QuotationDueDatePassedIntegrationEventConsumer.cs
+++ b/Modules/Workflow/Workflow/EventHandlers/QuotationDueDatePassedIntegrationEventConsumer.cs
@@ -4,6 +4,8 @@ using Shared.Messaging.Events;
 using Shared.Messaging.Filters;
 using Workflow.Data;
 using Workflow.Tasks.Features.ExpireOverdueFanOutTasks;
+using Workflow.Workflow.Models;
+using Workflow.Workflow.Repositories;
 
 namespace Workflow.EventHandlers;
 
@@ -21,6 +23,7 @@ namespace Workflow.EventHandlers;
 public class QuotationDueDatePassedIntegrationEventConsumer(
     ISender mediator,
     IPublishEndpoint publishEndpoint,
+    IWorkflowInstanceRepository instanceRepository,
     InboxGuard<WorkflowDbContext> inboxGuard,
     ILogger<QuotationDueDatePassedIntegrationEventConsumer> logger)
     : IConsumer<QuotationDueDatePassedIntegrationEvent>
@@ -36,27 +39,45 @@ public class QuotationDueDatePassedIntegrationEventConsumer(
         var ct = context.CancellationToken;
 
         logger.LogInformation(
-            "QuotationDueDatePassedConsumer: processing QuotationRequestId={QuotationRequestId} WorkflowInstanceId={WorkflowInstanceId}",
-            message.QuotationRequestId, message.QuotationWorkflowInstanceId);
+            "QuotationDueDatePassedConsumer: processing QuotationRequestId={QuotationRequestId}",
+            message.QuotationRequestId);
 
-        if (message.QuotationWorkflowInstanceId is null)
+        // Resolve the child workflow by CorrelationId (set at spawn in
+        // QuotationStartedIntegrationEventConsumer to QuotationRequestId.ToString()).
+        // QuotationRequest.QuotationWorkflowInstanceId is never written, so we cannot
+        // trust the value on the incoming message.
+        var instance = await instanceRepository.GetByCorrelationId(
+            message.QuotationRequestId.ToString(), ct);
+
+        if (instance is null)
         {
             logger.LogWarning(
-                "QuotationDueDatePassedConsumer: QuotationRequestId={QuotationRequestId} has no QuotationWorkflowInstanceId — skipping fan-out expiry",
+                "QuotationDueDatePassedConsumer: no workflow instance found by CorrelationId for QuotationRequestId={QuotationRequestId} — skipping fan-out expiry",
                 message.QuotationRequestId);
+            await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
+            return;
+        }
+
+        if (instance.Status is WorkflowStatus.Completed
+                               or WorkflowStatus.Cancelled
+                               or WorkflowStatus.Failed)
+        {
+            logger.LogInformation(
+                "QuotationDueDatePassedConsumer: workflow {InstanceId} already terminal ({Status}) — skipping",
+                instance.Id, instance.Status);
             await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
             return;
         }
 
         var result = await mediator.Send(
             new ExpireOverdueFanOutTasksCommand(
-                message.QuotationWorkflowInstanceId.Value,
+                instance.Id,
                 DefaultActivityId),
             ct);
 
         logger.LogInformation(
             "QuotationDueDatePassedConsumer: archived {ArchivedCount} overdue task(s) for workflow {WorkflowInstanceId}",
-            result.ArchivedCount, message.QuotationWorkflowInstanceId.Value);
+            result.ArchivedCount, instance.Id);
 
         // Notify Appraisal module to auto-decline companies that never responded
         if (result.ExpiredCompanyIds.Count > 0)


### PR DESCRIPTION
## Summary
- Quotation auto-close was flipping status to `UnderAdminReview` but leaving the workflow stuck on `ext-collect-submissions`.
- Root cause: `QuotationRequest.QuotationWorkflowInstanceId` is never written (the setter has zero callers), so the cutoff consumer hit its null-skip branch and never expired the fan-out tasks.
- Fix: resolve the child workflow on demand by `CorrelationId = QuotationRequestId.ToString()` in `QuotationDueDatePassedIntegrationEventConsumer` — same pattern already used by `QuotationWorkflowResumeIntegrationEventConsumer`. Adds a terminal-status guard for races with manual Cancel/Finalize. No new event, no consumer, no backfill needed.
- Companion UAT hotfix: same change committed directly to `release/uat/v3.0.0-2026-05-11` (commit `bc11c5b7`).

## Test plan
- [ ] Send a quotation with `DueDate = now + 2m`, invite 2+ companies; leave at least one non-responding.
- [ ] After cutoff (~70s past `DueDate`), confirm `workflow.ActivityExecutions` shows `ext-collect-submissions = Completed` and `admin-review-submissions = InProgress`.
- [ ] Confirm remaining `PendingTask` rows are archived to `CompletedTasks` with `ActionTaken = "Declined"`.
- [ ] Regression: forward paths (`SendShortlistToRm`, `Finalize`, `Cancel`) still drive the workflow via `QuotationWorkflowResumeIntegrationEventConsumer` (untouched).
- [ ] Regression: all-respond-before-cutoff path advances on the last submission via `SubmitQuotationCommandHandler` (untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)