### PR TITLE
feat(integration): emit QUOTATION_FINALIZED webhook on quotation finalize

### DIFF
--- a/Modules/Integration/Integration/Application/EventHandlers/Outbound/QuotationFinalizedWebhookConsumer.cs
+++ b/Modules/Integration/Integration/Application/EventHandlers/Outbound/QuotationFinalizedWebhookConsumer.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using Integration.Application.Services;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using Shared.Messaging.Events;
+
+namespace Integration.Application.EventHandlers.Outbound;
+
+public class QuotationFinalizedWebhookConsumer(
+    IWebhookService webhookService,
+    IAppraisalLookupService appraisalLookup,
+    IQuotationFinalizeLookupService finalizeLookup,
+    ILogger<QuotationFinalizedWebhookConsumer> logger)
+    : IConsumer<QuotationFinalizedIntegrationEvent>
+{
+    private static readonly JsonSerializerOptions ReasonJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public async Task Consume(ConsumeContext<QuotationFinalizedIntegrationEvent> context)
+    {
+        var msg = context.Message;
+
+        if (msg.AppraisalIds.Length == 0)
+        {
+            logger.LogWarning("QuotationFinalizedWebhookConsumer: no AppraisalIds on QuotationRequestId {QuotationRequestId}, skipping", msg.QuotationRequestId);
+            return;
+        }
+
+        AppraisalKeys? keys = null;
+        foreach (var appraisalId in msg.AppraisalIds)
+        {
+            var candidate = await appraisalLookup.GetKeysAsync(appraisalId, context.CancellationToken);
+            if (candidate is not null
+                && !string.IsNullOrEmpty(candidate.ExternalCaseKey)
+                && !string.IsNullOrEmpty(candidate.ExternalSystem))
+            {
+                keys = candidate;
+                break;
+            }
+        }
+
+        if (keys is null)
+        {
+            logger.LogWarning("QuotationFinalizedWebhookConsumer: no appraisal with ExternalSystem found on QuotationRequestId {QuotationRequestId}, skipping", msg.QuotationRequestId);
+            return;
+        }
+
+        var snapshot = await finalizeLookup.GetSnapshotAsync(
+            msg.QuotationRequestId, msg.WinningQuotationId, context.CancellationToken);
+
+        if (snapshot is null)
+        {
+            logger.LogWarning("QuotationFinalizedWebhookConsumer: no quotation snapshot for WinningQuotationId {WinningQuotationId} (QuotationRequestId {QuotationRequestId}), skipping", msg.WinningQuotationId, msg.QuotationRequestId);
+            return;
+        }
+
+        // The external contract embeds the finalized-quotation detail as an escaped JSON
+        // string inside data.reason, mirroring the QUOTATION_CANCELLED payload shape.
+        var reason = JsonSerializer.Serialize(snapshot, ReasonJsonOptions);
+
+        await webhookService.SendAsync(
+            eventId: msg.EventId,
+            systemCode: keys.ExternalSystem!,
+            eventType: "QUOTATION_FINALIZED",
+            externalCaseKey: keys.ExternalCaseKey!,
+            occurredAt: msg.OccurredOn,
+            data: new
+            {
+                quotationId = msg.QuotationRequestId,
+                reason
+            },
+            cancellationToken: context.CancellationToken);
+    }
+}

--- a/Modules/Integration/Integration/Application/Services/IQuotationFinalizeLookupService.cs
+++ b/Modules/Integration/Integration/Application/Services/IQuotationFinalizeLookupService.cs
@@ -1,0 +1,27 @@
+namespace Integration.Application.Services;
+
+/// <summary>
+/// Snapshot of a finalized quotation used to build the QUOTATION_FINALIZED webhook payload.
+/// Property names serialize (camelCase) to the agreed external contract embedded in data.reason.
+/// </summary>
+public record QuotationFinalizeSnapshot(
+    string? QuotationNumber,
+    Guid CompanyQuotationId,
+    string? ValuerName,
+    decimal TotalAppraisalFee,
+    int EstimatedDays,
+    IReadOnlyList<QuotationFinalizeItem> Items);
+
+public record QuotationFinalizeItem(
+    string AppraisalNumber,
+    decimal QuotedPrice,
+    string? PropertyType,
+    int EstimatedDays);
+
+public interface IQuotationFinalizeLookupService
+{
+    Task<QuotationFinalizeSnapshot?> GetSnapshotAsync(
+        Guid quotationRequestId,
+        Guid winningQuotationId,
+        CancellationToken ct = default);
+}

--- a/Modules/Integration/Integration/Application/Services/QuotationFinalizeLookupService.cs
+++ b/Modules/Integration/Integration/Application/Services/QuotationFinalizeLookupService.cs
@@ -1,0 +1,98 @@
+using Dapper;
+using Microsoft.Extensions.Logging;
+using Shared.Data;
+
+namespace Integration.Application.Services;
+
+public class QuotationFinalizeLookupService(
+    ISqlConnectionFactory connectionFactory,
+    ILogger<QuotationFinalizeLookupService> logger) : IQuotationFinalizeLookupService
+{
+    private const string SqlHeader = """
+        SELECT
+            cq.QuotationNumber AS QuotationNumber,
+            cq.Id AS CompanyQuotationId,
+            c.Name AS ValuerName,
+            COALESCE(cq.CurrentNegotiatedPrice, cq.TotalQuotedPrice) AS TotalAppraisalFee,
+            cq.EstimatedDays AS EstimatedDays
+        FROM appraisal.CompanyQuotations cq
+        JOIN auth.Companies c ON c.Id = cq.CompanyId
+        WHERE cq.Id = @WinningQuotationId
+        """;
+
+    // QuotedPrice mirrors how CompanyQuotation.TotalQuotedPrice is built (VAT-inclusive net
+    // after discounts, falling back to the legacy QuotedPrice when FeeAmount is unset), so the
+    // per-item values sum to the header totalAppraisalFee. PropertyType is resolved via a TOP 1
+    // subquery — joining QuotationRequestItems directly would fan out duplicate rows since there
+    // is no unique constraint on (QuotationRequestId, AppraisalId).
+    private const string SqlItems = """
+        SELECT
+            a.AppraisalNumber AS AppraisalNumber,
+            CASE WHEN cqi.FeeAmount > 0
+                 THEN (cqi.FeeAmount - cqi.Discount - ISNULL(cqi.NegotiatedDiscount, 0))
+                      * (1.0 + cqi.VatPercent / 100.0)
+                 ELSE cqi.QuotedPrice
+            END AS QuotedPrice,
+            (SELECT TOP 1 qri.PropertyType
+             FROM appraisal.QuotationRequestItems qri
+             WHERE qri.QuotationRequestId = @QuotationRequestId
+               AND qri.AppraisalId = cqi.AppraisalId
+             ORDER BY qri.ItemNumber) AS PropertyType,
+            cqi.EstimatedDays AS EstimatedDays
+        FROM appraisal.CompanyQuotationItems cqi
+        JOIN appraisal.Appraisals a ON a.Id = cqi.AppraisalId
+        WHERE cqi.CompanyQuotationId = @WinningQuotationId
+        ORDER BY cqi.ItemNumber
+        """;
+
+    public async Task<QuotationFinalizeSnapshot?> GetSnapshotAsync(
+        Guid quotationRequestId,
+        Guid winningQuotationId,
+        CancellationToken ct = default)
+    {
+        var connection = connectionFactory.GetOpenConnection();
+
+        var parameters = new DynamicParameters();
+        parameters.Add("QuotationRequestId", quotationRequestId);
+        parameters.Add("WinningQuotationId", winningQuotationId);
+
+        var header = await connection.QuerySingleOrDefaultAsync<HeaderRow>(
+            new CommandDefinition(SqlHeader, parameters, cancellationToken: ct));
+
+        if (header is null)
+        {
+            logger.LogWarning(
+                "QuotationFinalizeLookupService: no CompanyQuotation found for WinningQuotationId {WinningQuotationId} (QuotationRequestId {QuotationRequestId})",
+                winningQuotationId, quotationRequestId);
+            return null;
+        }
+
+        var itemRows = await connection.QueryAsync<ItemRow>(
+            new CommandDefinition(SqlItems, parameters, cancellationToken: ct));
+
+        var items = itemRows
+            .Select(r => new QuotationFinalizeItem(r.AppraisalNumber, r.QuotedPrice, r.PropertyType, r.EstimatedDays))
+            .ToList();
+
+        return new QuotationFinalizeSnapshot(
+            header.QuotationNumber,
+            header.CompanyQuotationId,
+            header.ValuerName,
+            header.TotalAppraisalFee,
+            header.EstimatedDays,
+            items);
+    }
+
+    private sealed record HeaderRow(
+        string? QuotationNumber,
+        Guid CompanyQuotationId,
+        string? ValuerName,
+        decimal TotalAppraisalFee,
+        int EstimatedDays);
+
+    private sealed record ItemRow(
+        string AppraisalNumber,
+        decimal QuotedPrice,
+        string? PropertyType,
+        int EstimatedDays);
+}

--- a/Modules/Integration/Integration/IntegrationModule.cs
+++ b/Modules/Integration/Integration/IntegrationModule.cs
@@ -33,6 +33,7 @@ public static class IntegrationModule
         // Register services
         services.AddScoped<IWebhookService, WebhookService>();
         services.AddScoped<IAppraisalLookupService, AppraisalLookupService>();
+        services.AddScoped<IQuotationFinalizeLookupService, QuotationFinalizeLookupService>();
         services.AddTransient<IUpdateRequestService, UpdateRequestService>();
         services.AddTransient<WebhookAttemptCounterHandler>();
         var webhookClientBuilder = services.AddHttpClient("Webhook");


### PR DESCRIPTION
## Summary
Adds a `QUOTATION_FINALIZED` outbound webhook so the originating external bank system is notified when an admin finalizes a quotation. The `QuotationFinalizedIntegrationEvent` was already published by `FinalizeQuotationCommandHandler` (consumed only by Notification before); this adds an Integration-module consumer that translates it into a webhook, mirroring the existing `QUOTATION_CANCELLED` flow.

## Changes (Integration module only)
- **`QuotationFinalizeLookupService`** (Dapper read) — builds the finalized-quotation snapshot: `quotationNumber`, `valuerName`, `totalAppraisalFee` (`COALESCE(CurrentNegotiatedPrice, TotalQuotedPrice)`, matching the handler's fee rule), `estimatedDays`, and per-item details.
  - Per-item `quotedPrice` uses the VAT-inclusive net expression (same as `GetQuotationValuersQueryHandler`) so items sum to the header total.
  - Items join via the `Appraisals` PK (1:1); `propertyType` resolved through a `TOP 1` subquery to avoid row fan-out.
- **`QuotationFinalizedWebhookConsumer`** — resolves `externalCaseKey`/`externalSystem` via `IAppraisalLookupService`, packs the snapshot as an escaped JSON string into `data.reason`, and POSTs via `IWebhookService`. Skips silently (logged) for purely internal cases.
- **`IntegrationModule`** — registers the lookup service. Consumer auto-registers via MassTransit `AddConsumers` + `ConfigureEndpoints`.

No changes to the shared integration event or the Appraisal handler.

## Payload shape
\`\`\`json
{
  "eventType": "QUOTATION_FINALIZED",
  "externalCaseKey": "119-CA023539-2568",
  "data": {
    "quotationId": "...",
    "reason": "{\"quotationNumber\":\"QTN-...\",\"valuerName\":\"...\",\"totalAppraisalFee\":1070.00,\"estimatedDays\":3,\"items\":[...]}"
  }
}
\`\`\`

## Testing
- `dotnet build` — passes (0 errors).
- Manual end-to-end: seed a `WebhookSubscription`, finalize a quotation on a request with `ExternalCaseKey`/`ExternalSystem`, confirm the `WebhookDelivery` row + listener payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)