### PR TITLE
fix(integration): source QUOTATION_FINALIZED quotationNumber from QuotationRequest

### DIFF
--- a/Modules/Integration/Integration/Application/Services/QuotationFinalizeLookupService.cs
+++ b/Modules/Integration/Integration/Application/Services/QuotationFinalizeLookupService.cs
@@ -19,7 +19,7 @@ public class QuotationFinalizeLookupService(
             cq.EstimatedDays AS EstimatedDays
         FROM appraisal.CompanyQuotations cq
         JOIN auth.Companies c ON c.Id = cq.CompanyId
-        JOIN appraisal.QuotationRequests qr ON qr.Id = @QuotationRequestId
+        JOIN appraisal.QuotationRequests qr ON qr.Id = cq.QuotationRequestId
         WHERE cq.Id = @WinningQuotationId
         """;
 

--- a/Modules/Integration/Integration/Application/Services/QuotationFinalizeLookupService.cs
+++ b/Modules/Integration/Integration/Application/Services/QuotationFinalizeLookupService.cs
@@ -8,15 +8,18 @@ public class QuotationFinalizeLookupService(
     ISqlConnectionFactory connectionFactory,
     ILogger<QuotationFinalizeLookupService> logger) : IQuotationFinalizeLookupService
 {
+    // QuotationNumber comes from the QuotationRequest (RFQ) — CompanyQuotation.QuotationNumber
+    // is not populated. Same source the get-quotation-valuers API uses.
     private const string SqlHeader = """
         SELECT
-            cq.QuotationNumber AS QuotationNumber,
+            qr.QuotationNumber AS QuotationNumber,
             cq.Id AS CompanyQuotationId,
             c.Name AS ValuerName,
             COALESCE(cq.CurrentNegotiatedPrice, cq.TotalQuotedPrice) AS TotalAppraisalFee,
             cq.EstimatedDays AS EstimatedDays
         FROM appraisal.CompanyQuotations cq
         JOIN auth.Companies c ON c.Id = cq.CompanyId
+        JOIN appraisal.QuotationRequests qr ON qr.Id = @QuotationRequestId
         WHERE cq.Id = @WinningQuotationId
         """;
 


### PR DESCRIPTION
## Problem
The `QUOTATION_FINALIZED` webhook payload emitted an empty `quotationNumber` (`"quotationNumber":""`). The header query read `cq.QuotationNumber` from `appraisal.CompanyQuotations`, but that column is not populated — the real RFQ number (e.g. `QTN-000029-2569`) lives on the `QuotationRequest`.

## Fix
Read `QuotationNumber` from `appraisal.QuotationRequests` (joined via the quotation id) instead — the same source the get-quotation-valuers API uses. One-line query change in `QuotationFinalizeLookupService.SqlHeader`.

Follow-up to #215.

## Testing
- `dotnet build` — passes (0 errors).
- Re-finalize a quotation and confirm the webhook payload's `data.reason` now carries the populated `quotationNumber`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)