### PR TITLE
feat(fee-appointment): actor-code stamping, appointment history, approval workflow

### DIFF
--- a/Modules/Appraisal/Appraisal/Application/EventHandlers/FeeAppointmentApprovalResolvedIntegrationEventHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/EventHandlers/FeeAppointmentApprovalResolvedIntegrationEventHandler.cs
@@ -36,16 +36,16 @@ public class FeeAppointmentApprovalResolvedIntegrationEventHandler(
         foreach (var outcome in msg.LineOutcomes)
         {
             if (outcome.LineType == "Appointment")
-                await ApplyAppointmentOutcomeAsync(outcome, context.CancellationToken);
+                await ApplyAppointmentOutcomeAsync(outcome, msg.ResolvedByCode, context.CancellationToken);
             else if (outcome.LineType == "Fee")
-                await ApplyFeeOutcomeAsync(outcome, context.CancellationToken);
+                await ApplyFeeOutcomeAsync(outcome, msg.ResolvedByCode, context.CancellationToken);
         }
 
         await dbContext.SaveChangesAsync(context.CancellationToken);
         await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, context.CancellationToken);
     }
 
-    private async Task ApplyAppointmentOutcomeAsync(FeeApprovalLineOutcome outcome, CancellationToken ct)
+    private async Task ApplyAppointmentOutcomeAsync(FeeApprovalLineOutcome outcome, string? resolvedByCode, CancellationToken ct)
     {
         var appointment = await dbContext.Appointments
             .Include(a => a.History)
@@ -57,12 +57,16 @@ public class FeeAppointmentApprovalResolvedIntegrationEventHandler(
             return;
         }
 
+        // Stamp the real resolving user's bank code (matches Appointment.ApprovedBy/ChangedBy).
+        // Falls back to the system actor only when the resolution was system-initiated.
+        var actor = resolvedByCode ?? SystemActor;
+
         if (outcome.Decision == "Approved")
         {
             // Idempotent: only call Approve when actually Pending
             if (appointment.Status == "Pending")
             {
-                appointment.Approve(SystemActor);
+                appointment.Approve(actor);
                 logger.LogInformation("Appointment {Id} approved via FeeAppointmentApproval", outcome.TargetId);
             }
             else
@@ -75,21 +79,24 @@ public class FeeAppointmentApprovalResolvedIntegrationEventHandler(
             // Idempotent: only revert when status is Pending (after a Reschedule)
             if (appointment.Status == "Pending")
             {
-                appointment.RejectReschedule(SystemActor, outcome.Reason);
+                appointment.RejectReschedule(actor, outcome.Reason);
                 logger.LogInformation("Appointment {Id} reschedule rejected via FeeAppointmentApproval", outcome.TargetId);
             }
             else
             {
                 logger.LogInformation("Appointment {Id} already in status '{Status}', skipping reject-reschedule", outcome.TargetId, appointment.Status);
             }
-
-            // Clear approval markers on rejection so a new draft can begin.
-            // On approval, Approve() already clears them.
-            appointment.ClearApprovalMarkers();
         }
+
+        // Always clear the approval markers once resolved (approve OR reject), regardless of whether
+        // the status transition was applied. Otherwise an outcome that arrives when the appointment
+        // is no longer Pending (e.g. redelivery, or a status change via another path) would leave
+        // ApprovalSubmittedAt set, permanently blocking cancel/reschedule via the edit-lock guards.
+        // (Approve() already clears them in the Pending case; this makes the two branches symmetric.)
+        appointment.ClearApprovalMarkers();
     }
 
-    private async Task ApplyFeeOutcomeAsync(FeeApprovalLineOutcome outcome, CancellationToken ct)
+    private async Task ApplyFeeOutcomeAsync(FeeApprovalLineOutcome outcome, string? resolvedByCode, CancellationToken ct)
     {
         var feeItem = await dbContext.AppraisalFeeItems
             .FirstOrDefaultAsync(i => i.Id == outcome.TargetId, ct);
@@ -100,12 +107,16 @@ public class FeeAppointmentApprovalResolvedIntegrationEventHandler(
             return;
         }
 
+        // Stamp the real resolving user's bank code. Falls back to the system actor only for
+        // system-initiated resolutions.
+        var approver = resolvedByCode ?? SystemActor;
+
         if (outcome.Decision == "Approved")
         {
             // Idempotent: only Approve when still Pending
             if (feeItem.ApprovalStatus == "Pending")
             {
-                feeItem.Approve(Guid.Empty);
+                feeItem.Approve(approver);
                 logger.LogInformation("FeeItem {Id} approved via FeeAppointmentApproval", outcome.TargetId);
             }
             else
@@ -121,7 +132,7 @@ public class FeeAppointmentApprovalResolvedIntegrationEventHandler(
             // (Do NOT ClearApprovalMarkers here — that would null the "Rejected" status.)
             if (feeItem.ApprovalStatus == "Pending")
             {
-                feeItem.Reject(Guid.Empty, outcome.Reason ?? "Rejected by approver");
+                feeItem.Reject(approver, outcome.Reason ?? "Rejected by approver");
                 logger.LogInformation("FeeItem {Id} rejected via FeeAppointmentApproval", outcome.TargetId);
             }
             else

--- a/Modules/Appraisal/Appraisal/Application/Features/Appointments/CancelAppointment/CancelAppointmentCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appointments/CancelAppointment/CancelAppointmentCommandHandler.cs
@@ -21,6 +21,12 @@ public class CancelAppointmentCommandHandler(
         if (!assignmentBelongs)
             throw new InvalidOperationException("Appointment does not belong to this appraisal.");
 
+        // Edit lock: reject if an approval is currently awaiting (submitted but not yet resolved) —
+        // mirrors the reschedule guard so a pending reschedule can't be cancelled out from under the approver.
+        if (appointment.ApprovalSubmittedAt.HasValue)
+            throw new InvalidOperationException(
+                "Cannot cancel: an approval is currently awaiting review. Wait for the approval to be resolved.");
+
         appointment.Cancel(command.ChangedBy, command.Reason);
 
         return Unit.Value;

--- a/Modules/Appraisal/Appraisal/Application/Features/Appointments/GetAppointmentHistory/GetAppointmentHistoryEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appointments/GetAppointmentHistory/GetAppointmentHistoryEndpoint.cs
@@ -1,0 +1,29 @@
+namespace Appraisal.Application.Features.Appointments.GetAppointmentHistory;
+
+public class GetAppointmentHistoryEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet(
+                "/appraisals/{appraisalId:guid}/appointment-history",
+                async (
+                    Guid appraisalId,
+                    ISender sender,
+                    CancellationToken cancellationToken
+                ) =>
+                {
+                    var query = new GetAppointmentHistoryQuery(appraisalId);
+
+                    var result = await sender.Send(query, cancellationToken);
+
+                    return Results.Ok(new GetAppointmentHistoryResponse(result.Events));
+                }
+            )
+            .WithName("GetAppointmentHistory")
+            .Produces<GetAppointmentHistoryResponse>(StatusCodes.Status200OK)
+            .WithSummary("Get appointment history")
+            .WithDescription("Get the timeline of appointment and fee events for an appraisal.")
+            .WithTags("Appointment")
+            .RequireAuthorization();
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/Appointments/GetAppointmentHistory/GetAppointmentHistoryQuery.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appointments/GetAppointmentHistory/GetAppointmentHistoryQuery.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.Appointments.GetAppointmentHistory;
+
+public record GetAppointmentHistoryQuery(Guid AppraisalId) : IQuery<GetAppointmentHistoryResult>;

--- a/Modules/Appraisal/Appraisal/Application/Features/Appointments/GetAppointmentHistory/GetAppointmentHistoryQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appointments/GetAppointmentHistory/GetAppointmentHistoryQueryHandler.cs
@@ -1,0 +1,170 @@
+using Dapper;
+
+namespace Appraisal.Application.Features.Appointments.GetAppointmentHistory;
+
+public class GetAppointmentHistoryQueryHandler(ISqlConnectionFactory connectionFactory)
+    : IQueryHandler<GetAppointmentHistoryQuery, GetAppointmentHistoryResult>
+{
+    public async Task<GetAppointmentHistoryResult> Handle(
+        GetAppointmentHistoryQuery query,
+        CancellationToken cancellationToken)
+    {
+        // Single UNION ALL query:
+        //   Part 1 — appointment history events for the appraisal's latest active appointment.
+        //   Part 2 — fee events (FeeAdded / FeeApproved / FeeRejected) for user-added fee items
+        //            on the same assignment chain.
+        //
+        // Appointment resolution: same join as vw_AppointmentList
+        //   Appointments.AssignmentId → AppraisalAssignments.Id (where AppraisalId = @AppraisalId)
+        //   We pick the most-recently-created appointment for this appraisal (matches GetAppointment's intent).
+        //
+        // NewDate computation for Rescheduled rows uses LEAD() to find the
+        // PreviousAppointmentDateTime of the next-newer history row. If there is no
+        // newer row the appointment's current AppointmentDateTime is the new date.
+        //
+        // Actor name: actor fields now store the bank code (= AspNetUsers.UserName). Appointment
+        // events keep a defensive dual join (UserName OR Id-as-Guid) so legacy rows that stored a
+        // Guid still resolve; fee events join on UserName directly.
+        const string sql = """
+            -- ── Part 1: Appointment history events ──────────────────────────────────────
+            SELECT
+                h.EventType,
+                h.Title,
+                h.OldDate,
+                h.NewDate,
+                NULL          AS FeeCode,
+                NULL          AS FeeDescription,
+                NULL          AS Amount,
+                h.Status,
+                h.ActorCode,
+                COALESCE(u.FirstName + ' ' + u.LastName, h.ActorCode) AS ActorName,
+                h.Reason,
+                h.OccurredAt
+            FROM (
+                SELECT
+                    ah.Id,
+                    CASE ah.ChangeType
+                        WHEN 'Rescheduled'        THEN 'AppointmentRescheduled'
+                        WHEN 'Cancelled'          THEN 'AppointmentCancelled'
+                        WHEN 'RescheduleRejected' THEN 'AppointmentRejected'
+                        WHEN 'StatusChanged'      THEN
+                            CASE
+                                WHEN ah.ChangeReason LIKE 'Approved%' THEN 'AppointmentApproved'
+                                ELSE NULL   -- skip Completed and other internal transitions
+                            END
+                        ELSE NULL
+                    END                                                     AS EventType,
+                    CASE ah.ChangeType
+                        WHEN 'Rescheduled'        THEN 'Appointment Rescheduled'
+                        WHEN 'Cancelled'          THEN 'Appointment Cancelled'
+                        WHEN 'RescheduleRejected' THEN 'Reschedule Rejected'
+                        WHEN 'StatusChanged'      THEN
+                            CASE
+                                WHEN ah.ChangeReason LIKE 'Approved%' THEN 'Appointment Approved'
+                                ELSE NULL
+                            END
+                        ELSE NULL
+                    END                                                     AS Title,
+                    CASE ah.ChangeType
+                        WHEN 'Rescheduled' THEN ah.PreviousAppointmentDateTime
+                        ELSE NULL
+                    END                                                     AS OldDate,
+                    CASE ah.ChangeType
+                        WHEN 'Rescheduled' THEN
+                            COALESCE(
+                                LEAD(ah.PreviousAppointmentDateTime)
+                                    OVER (PARTITION BY ah.AppointmentId ORDER BY ah.ChangedAt),
+                                ap.AppointmentDateTime
+                            )
+                        ELSE NULL
+                    END                                                     AS NewDate,
+                    CASE
+                        WHEN ah.ChangeType = 'Rescheduled'                             THEN 'Pending'
+                        WHEN ah.ChangeType = 'Cancelled'                               THEN 'Cancelled'
+                        WHEN ah.ChangeType = 'RescheduleRejected'                      THEN 'Rejected'
+                        WHEN ah.ChangeType = 'StatusChanged'
+                             AND ah.ChangeReason LIKE 'Approved%'                      THEN 'Approved'
+                        ELSE NULL
+                    END                                                     AS Status,
+                    ah.ChangedBy                                            AS ActorCode,
+                    ah.ChangeReason                                         AS Reason,
+                    ah.ChangedAt                                            AS OccurredAt
+                FROM appraisal.AppointmentHistory ah
+                INNER JOIN appraisal.Appointments ap ON ap.Id = ah.AppointmentId
+                INNER JOIN appraisal.AppraisalAssignments aa ON aa.Id = ap.AssignmentId
+                WHERE aa.AppraisalId = @AppraisalId
+            ) h
+            -- ChangedBy may hold either a bank code (UserName) or a user Guid (Id), depending on
+            -- the caller; match either so the name resolves regardless. The literal 'system'
+            -- (auto-apply) matches neither and falls back to the raw ActorCode.
+            LEFT JOIN auth.AspNetUsers u
+                ON u.UserName = h.ActorCode
+                OR u.Id = TRY_CONVERT(UNIQUEIDENTIFIER, h.ActorCode)
+            WHERE h.EventType IS NOT NULL   -- discard skipped rows (e.g. Completed)
+
+            UNION ALL
+
+            -- ── Part 2a: FeeAdded events (one per user-added fee item) ─────────────────
+            SELECT
+                'FeeAdded'          AS EventType,
+                'Fee Added'         AS Title,
+                NULL                AS OldDate,
+                NULL                AS NewDate,
+                fi.FeeCode,
+                fi.FeeDescription,
+                fi.FeeAmount        AS Amount,
+                'Pending'           AS Status,
+                NULL                AS ActorCode,
+                NULL                AS ActorName,
+                NULL                AS Reason,
+                fi.CreatedAt        AS OccurredAt
+            FROM appraisal.AppraisalFeeItems fi
+            INNER JOIN appraisal.AppraisalFees af ON af.Id = fi.AppraisalFeeId
+            INNER JOIN appraisal.AppraisalAssignments aa ON aa.Id = af.AssignmentId
+            WHERE aa.AppraisalId = @AppraisalId
+              AND fi.Source = 'User'
+
+            UNION ALL
+
+            -- ── Part 2b: FeeApproved / FeeRejected events ─────────────────────────────
+            SELECT
+                CASE fi.ApprovalStatus
+                    WHEN 'Approved' THEN 'FeeApproved'
+                    WHEN 'Rejected' THEN 'FeeRejected'
+                    ELSE NULL
+                END                 AS EventType,
+                CASE fi.ApprovalStatus
+                    WHEN 'Approved' THEN 'Fee Approved'
+                    WHEN 'Rejected' THEN 'Fee Rejected'
+                    ELSE NULL
+                END                 AS Title,
+                NULL                AS OldDate,
+                NULL                AS NewDate,
+                fi.FeeCode,
+                fi.FeeDescription,
+                fi.FeeAmount        AS Amount,
+                fi.ApprovalStatus   AS Status,
+                fi.ApprovedBy       AS ActorCode,
+                COALESCE(u2.FirstName + ' ' + u2.LastName, fi.ApprovedBy) AS ActorName,
+                fi.RejectionReason  AS Reason,
+                fi.ApprovedAt       AS OccurredAt
+            FROM appraisal.AppraisalFeeItems fi
+            INNER JOIN appraisal.AppraisalFees af ON af.Id = fi.AppraisalFeeId
+            INNER JOIN appraisal.AppraisalAssignments aa ON aa.Id = af.AssignmentId
+            LEFT JOIN auth.AspNetUsers u2 ON u2.UserName = fi.ApprovedBy
+            WHERE aa.AppraisalId = @AppraisalId
+              AND fi.Source = 'User'
+              AND fi.ApprovalStatus IN ('Approved', 'Rejected')
+              AND fi.ApprovedAt IS NOT NULL
+
+            ORDER BY OccurredAt DESC
+            """;
+
+        var parameters = new DynamicParameters();
+        parameters.Add("AppraisalId", query.AppraisalId);
+
+        var rows = await connectionFactory.QueryAsync<AppointmentHistoryEventDto>(sql, parameters);
+
+        return new GetAppointmentHistoryResult(rows.ToList().AsReadOnly());
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/Appointments/GetAppointmentHistory/GetAppointmentHistoryResponse.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appointments/GetAppointmentHistory/GetAppointmentHistoryResponse.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.Appointments.GetAppointmentHistory;
+
+public record GetAppointmentHistoryResponse(IReadOnlyList<AppointmentHistoryEventDto> Events);

--- a/Modules/Appraisal/Appraisal/Application/Features/Appointments/GetAppointmentHistory/GetAppointmentHistoryResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appointments/GetAppointmentHistory/GetAppointmentHistoryResult.cs
@@ -1,0 +1,30 @@
+namespace Appraisal.Application.Features.Appointments.GetAppointmentHistory;
+
+public record GetAppointmentHistoryResult(IReadOnlyList<AppointmentHistoryEventDto> Events);
+
+public sealed record AppointmentHistoryEventDto
+{
+    /// <summary>
+    /// One of: AppointmentRescheduled, AppointmentApproved, AppointmentRejected,
+    /// AppointmentCancelled, FeeAdded, FeeApproved, FeeRejected.
+    /// </summary>
+    public string EventType { get; set; } = default!;
+
+    public string Title { get; set; } = default!;
+
+    public DateTime? OldDate { get; set; }
+    public DateTime? NewDate { get; set; }
+
+    public string? FeeCode { get; set; }
+    public string? FeeDescription { get; set; }
+    public decimal? Amount { get; set; }
+
+    /// <summary>Approved | Rejected | Pending | Auto</summary>
+    public string? Status { get; set; }
+
+    public string? ActorCode { get; set; }
+    public string? ActorName { get; set; }
+    public string? Reason { get; set; }
+
+    public DateTime OccurredAt { get; set; }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/FeeAppointment/SubmitPendingApproval/SubmitPendingApprovalCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/FeeAppointment/SubmitPendingApproval/SubmitPendingApprovalCommandHandler.cs
@@ -61,12 +61,21 @@ public class SubmitPendingApprovalCommandHandler(
         {
             appointment.MarkApprovalSubmitted();
 
+            // The date before this reschedule — the most recent 'Rescheduled' history entry's
+            // prior value. Snapshotted so the approver can see old → new.
+            var previousDate = appointment.History
+                .Where(h => h.ChangeType == "Rescheduled")
+                .OrderByDescending(h => h.ChangedAt)
+                .Select(h => (DateTime?)h.PreviousAppointmentDateTime)
+                .FirstOrDefault();
+
             requiresApprovalLines.Add(new FeeApprovalRequestedLineDto(
                 "Appointment",
                 appointment.Id,
                 appointment.AppointmentDateTime,
                 appointment.RescheduleCount,
-                null, null, null));
+                null, null, null,
+                previousDate));
 
             logger.LogInformation(
                 "Stamping appointment {AppointmentId} as submitted for appraisal {AppraisalId}",

--- a/Modules/Appraisal/Appraisal/Application/Features/Fees/ApproveFeeItem/ApproveFeeItemCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Fees/ApproveFeeItem/ApproveFeeItemCommand.cs
@@ -6,5 +6,5 @@ public record ApproveFeeItemCommand(
     Guid AppraisalId,
     Guid FeeId,
     Guid ItemId,
-    Guid ApprovedBy
+    string ApprovedBy
 ) : ICommand, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/Fees/ApproveFeeItem/ApproveFeeItemRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Fees/ApproveFeeItem/ApproveFeeItemRequest.cs
@@ -1,3 +1,3 @@
 namespace Appraisal.Application.Features.Fees.ApproveFeeItem;
 
-public record ApproveFeeItemRequest(Guid ApprovedBy);
+public record ApproveFeeItemRequest(string ApprovedBy);

--- a/Modules/Appraisal/Appraisal/Application/Features/Fees/GetAppraisalFees/GetAppraisalFeesResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Fees/GetAppraisalFees/GetAppraisalFeesResult.cs
@@ -38,7 +38,7 @@ public record AppraisalFeeItemDto
     public decimal FeeAmount { get; set; }
     public bool RequiresApproval { get; set; }
     public string? ApprovalStatus { get; set; }
-    public Guid? ApprovedBy { get; set; }
+    public string? ApprovedBy { get; set; } // bank code (e.g. "P5229")
     public DateTime? ApprovedAt { get; set; }
     public string? RejectionReason { get; set; }
 

--- a/Modules/Appraisal/Appraisal/Application/Features/Fees/RejectFeeItem/RejectFeeItemCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Fees/RejectFeeItem/RejectFeeItemCommand.cs
@@ -6,6 +6,6 @@ public record RejectFeeItemCommand(
     Guid AppraisalId,
     Guid FeeId,
     Guid ItemId,
-    Guid RejectedBy,
+    string RejectedBy,
     string Reason
 ) : ICommand, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/Fees/RejectFeeItem/RejectFeeItemRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Fees/RejectFeeItem/RejectFeeItemRequest.cs
@@ -1,3 +1,3 @@
 namespace Appraisal.Application.Features.Fees.RejectFeeItem;
 
-public record RejectFeeItemRequest(Guid RejectedBy, string Reason);
+public record RejectFeeItemRequest(string RejectedBy, string Reason);

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/Appointment.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/Appointment.cs
@@ -178,7 +178,7 @@ public class Appointment : Entity<Guid>
             .OrderByDescending(h => h.ChangedAt)
             .FirstOrDefault();
 
-        RecordHistory("Cancelled", changedBy, reason); // record the revert as a cancellation of the pending change
+        RecordHistory("RescheduleRejected", changedBy, reason); // distinct from a user cancellation — this is an approver rejecting a pending reschedule
 
         if (lastRescheduledHistory is not null)
         {

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/AppointmentHistory.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/AppointmentHistory.cs
@@ -13,7 +13,7 @@ public class AppointmentHistory : Entity<Guid>
     public string? PreviousLocationDetail { get; private set; }
 
     // Change Details
-    public string ChangeType { get; private set; } = null!; // Rescheduled, Cancelled, StatusChanged
+    public string ChangeType { get; private set; } = null!; // Rescheduled, Cancelled, RescheduleRejected, StatusChanged
     public string? ChangeReason { get; private set; }
     public DateTime ChangedAt { get; private set; }
     public string ChangedBy { get; private set; } = default!;
@@ -32,8 +32,10 @@ public class AppointmentHistory : Entity<Guid>
         string? changeReason,
         string changedBy)
     {
-        if (changeType != "Rescheduled" && changeType != "Cancelled" && changeType != "StatusChanged")
-            throw new ArgumentException("ChangeType must be 'Rescheduled', 'Cancelled', or 'StatusChanged'");
+        if (changeType != "Rescheduled" && changeType != "Cancelled"
+            && changeType != "RescheduleRejected" && changeType != "StatusChanged")
+            throw new ArgumentException(
+                "ChangeType must be 'Rescheduled', 'Cancelled', 'RescheduleRejected', or 'StatusChanged'");
 
         return new AppointmentHistory
         {

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalFee.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalFee.cs
@@ -114,6 +114,12 @@ public class AppraisalFee : Entity<Guid>
             .Sum(i => i.FeeAmount);
         VATAmount = TotalFeeBeforeVAT * VATRate / 100;
         TotalFeeAfterVAT = TotalFeeBeforeVAT + VATAmount;
+        // Re-clamp the bank absorb so it can never exceed the (possibly reduced) total. Without
+        // this, removing/editing a fee item below a prior full absorb would leave a stale
+        // BankAbsorbAmount, drive CustomerPayableAmount negative, and make the next fee update
+        // PATCH (which re-sends the stale amount) trip the SetBankAbsorb bounds guard.
+        if (BankAbsorbAmount > TotalFeeAfterVAT)
+            BankAbsorbAmount = TotalFeeAfterVAT;
         CustomerPayableAmount = TotalFeeAfterVAT - BankAbsorbAmount;
         OutstandingAmount = TotalFeeAfterVAT - TotalPaidAmount;
         UpdatePaymentStatus();
@@ -158,6 +164,11 @@ public class AppraisalFee : Entity<Guid>
 
     public void SetBankAbsorb(decimal amount)
     {
+        if (amount < 0 || amount > TotalFeeAfterVAT)
+            throw new ArgumentOutOfRangeException(
+                nameof(amount),
+                $"BankAbsorbAmount must be between 0 and TotalFeeAfterVAT ({TotalFeeAfterVAT:F2}) (got {amount:F2}).");
+
         BankAbsorbAmount = amount;
         CustomerPayableAmount = TotalFeeAfterVAT - BankAbsorbAmount;
         OutstandingAmount = TotalFeeAfterVAT - TotalPaidAmount;

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalFeeItem.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalFeeItem.cs
@@ -31,7 +31,7 @@ public class AppraisalFeeItem : Entity<Guid>
     // Approval (for additional fees)
     public bool RequiresApproval { get; private set; }
     public string? ApprovalStatus { get; private set; } // Pending, Approved, Rejected
-    public Guid? ApprovedBy { get; private set; }
+    public string? ApprovedBy { get; private set; } // bank code (e.g. "P5229"); "system" for auto/system-resolved
     public DateTime? ApprovedAt { get; private set; }
     public string? RejectionReason { get; private set; }
 
@@ -144,7 +144,7 @@ public class AppraisalFeeItem : Entity<Guid>
         ApprovalSubmittedAt = null;
     }
 
-    public void Approve(Guid approvedBy)
+    public void Approve(string approvedBy)
     {
         if (ApprovalStatus != "Pending")
             throw new InvalidOperationException($"Cannot approve fee item in status '{ApprovalStatus}'");
@@ -158,7 +158,7 @@ public class AppraisalFeeItem : Entity<Guid>
         ApprovalSubmittedAt = null;
     }
 
-    public void Reject(Guid rejectedBy, string reason)
+    public void Reject(string rejectedBy, string reason)
     {
         if (ApprovalStatus != "Pending")
             throw new InvalidOperationException($"Cannot reject fee item in status '{ApprovalStatus}'");

--- a/Modules/Appraisal/Appraisal/Infrastructure/Configurations/AppraisalFeeConfiguration.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Configurations/AppraisalFeeConfiguration.cs
@@ -77,6 +77,7 @@ public class AppraisalFeeItemConfiguration : IEntityTypeConfiguration<AppraisalF
         // Approval
         builder.Property(i => i.RequiresApproval).HasDefaultValue(false);
         builder.Property(i => i.ApprovalStatus).HasMaxLength(50);
+        builder.Property(i => i.ApprovedBy).HasMaxLength(100); // bank code (e.g. "P5229")
         builder.Property(i => i.RejectionReason).HasMaxLength(4000);
 
         // Inline-edit approval markers

--- a/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260603172530_ChangeFeeItemApprovedByToCode.Designer.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260603172530_ChangeFeeItemApprovedByToCode.Designer.cs
@@ -4,6 +4,7 @@ using Appraisal.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Appraisal.Infrastructure.Migrations
 {
     [DbContext(typeof(AppraisalDbContext))]
-    partial class AppraisalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260603172530_ChangeFeeItemApprovedByToCode")]
+    partial class ChangeFeeItemApprovedByToCode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260603172530_ChangeFeeItemApprovedByToCode.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260603172530_ChangeFeeItemApprovedByToCode.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Appraisal.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangeFeeItemApprovedByToCode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ApprovedBy",
+                schema: "appraisal",
+                table: "AppraisalFeeItems",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ApprovedBy",
+                schema: "appraisal",
+                table: "AppraisalFeeItems",
+                type: "uniqueidentifier",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+        }
+    }
+}

--- a/Modules/Workflow/Workflow.Contracts/FeeAppointmentApprovals/RaiseFeeAppointmentApprovalCommand.cs
+++ b/Modules/Workflow/Workflow.Contracts/FeeAppointmentApprovals/RaiseFeeAppointmentApprovalCommand.cs
@@ -18,6 +18,7 @@ public record RaiseFeeApprovalLineDto(
     int? RescheduleCount,        // appointment change: current reschedule count after Reschedule()
     string? FeeCode,
     string? FeeDescription,
-    decimal? FeeAmount);
+    decimal? FeeAmount,
+    DateTime? PreviousDate = null); // appointment change: the date before this reschedule
 
 public record RaiseFeeAppointmentApprovalResult(Guid ApprovalId, Guid FollowupWorkflowInstanceId);

--- a/Modules/Workflow/Workflow/FeeAppointmentApprovals/Application/Commands/RaiseFeeAppointmentApprovalCommandHandler.cs
+++ b/Modules/Workflow/Workflow/FeeAppointmentApprovals/Application/Commands/RaiseFeeAppointmentApprovalCommandHandler.cs
@@ -70,7 +70,7 @@ public class RaiseFeeAppointmentApprovalCommandHandler(
                 if (!dto.NewDate.HasValue)
                     throw new ArgumentException("Appointment line must have NewDate");
                 domainLines.Add(FeeAppointmentApprovalLine.CreateAppointment(
-                    dto.TargetId, dto.NewDate.Value, dto.RescheduleCount ?? 0));
+                    dto.TargetId, dto.NewDate.Value, dto.RescheduleCount ?? 0, dto.PreviousDate));
             }
             else if (dto.LineType == "Fee")
             {

--- a/Modules/Workflow/Workflow/FeeAppointmentApprovals/Application/Commands/ResolveFeeAppointmentApprovalCommandHandler.cs
+++ b/Modules/Workflow/Workflow/FeeAppointmentApprovals/Application/Commands/ResolveFeeAppointmentApprovalCommandHandler.cs
@@ -79,12 +79,15 @@ public class ResolveFeeAppointmentApprovalCommandHandler(
                 command.ApprovalId, approval.FollowupWorkflowInstanceId);
         }
 
-        // Apply per-component decisions and raise domain event
+        // Apply per-component decisions and raise domain event.
+        // Capture the resolving user's bank code so the Appraisal module can stamp the real
+        // approver (otherwise the fee/appointment outcome records a "system" placeholder).
         approval.Resolve(
             command.AppointmentDecision.Decision,
             command.AppointmentDecision.Reason,
             command.FeeDecision.Decision,
-            command.FeeDecision.Reason);
+            command.FeeDecision.Reason,
+            currentUser.UserCode);
 
         await dbContext.SaveChangesAsync(cancellationToken);
 

--- a/Modules/Workflow/Workflow/FeeAppointmentApprovals/Application/Queries/FeeAppointmentApprovalDtos.cs
+++ b/Modules/Workflow/Workflow/FeeAppointmentApprovals/Application/Queries/FeeAppointmentApprovalDtos.cs
@@ -23,4 +23,5 @@ public record FeeApprovalLineDto(
     string? FeeDescription,
     decimal? FeeAmount,
     string LineStatus,
-    string? DecisionReason);
+    string? DecisionReason,
+    DateTime? PreviousDate);

--- a/Modules/Workflow/Workflow/FeeAppointmentApprovals/Application/Queries/GetFeeAppointmentApprovalByWorkflowInstanceQueryHandler.cs
+++ b/Modules/Workflow/Workflow/FeeAppointmentApprovals/Application/Queries/GetFeeAppointmentApprovalByWorkflowInstanceQueryHandler.cs
@@ -43,5 +43,6 @@ public class GetFeeAppointmentApprovalByWorkflowInstanceQueryHandler(WorkflowDbC
                 l.FeeDescription,
                 l.FeeAmount,
                 l.LineStatus.ToString(),
-                l.DecisionReason)).ToList());
+                l.DecisionReason,
+                l.PreviousDate)).ToList());
 }

--- a/Modules/Workflow/Workflow/FeeAppointmentApprovals/Domain/Events/FeeAppointmentApprovalEvents.cs
+++ b/Modules/Workflow/Workflow/FeeAppointmentApprovals/Domain/Events/FeeAppointmentApprovalEvents.cs
@@ -9,7 +9,8 @@ public record FeeAppointmentApprovalRaisedDomainEvent(
 public record FeeAppointmentApprovalResolvedDomainEvent(
     Guid ApprovalId,
     Guid AppraisalId,
-    IReadOnlyList<(string LineType, Guid TargetId, string Decision, string? Reason)> LineOutcomes) : IDomainEvent;
+    IReadOnlyList<(string LineType, Guid TargetId, string Decision, string? Reason)> LineOutcomes,
+    string? ResolvedByCode) : IDomainEvent;
 
 public record FeeAppointmentApprovalCancelledDomainEvent(
     Guid ApprovalId,

--- a/Modules/Workflow/Workflow/FeeAppointmentApprovals/Domain/FeeAppointmentApproval.cs
+++ b/Modules/Workflow/Workflow/FeeAppointmentApprovals/Domain/FeeAppointmentApproval.cs
@@ -95,7 +95,8 @@ public class FeeAppointmentApproval : Aggregate<Guid>
         string appointmentDecision,
         string? appointmentReason,
         string feeDecision,
-        string? feeReason)
+        string? feeReason,
+        string? resolvedByCode = null)
     {
         if (Status != FeeAppointmentApprovalStatus.Open)
             throw new InvalidOperationException("Approval is not open");
@@ -123,7 +124,7 @@ public class FeeAppointmentApproval : Aggregate<Guid>
         Status = FeeAppointmentApprovalStatus.Resolved;
         ResolvedAt = DateTime.Now;
 
-        AddDomainEvent(new FeeAppointmentApprovalResolvedDomainEvent(Id, AppraisalId, outcomes));
+        AddDomainEvent(new FeeAppointmentApprovalResolvedDomainEvent(Id, AppraisalId, outcomes, resolvedByCode));
     }
 
     /// <summary>

--- a/Modules/Workflow/Workflow/FeeAppointmentApprovals/Domain/FeeAppointmentApprovalLine.cs
+++ b/Modules/Workflow/Workflow/FeeAppointmentApprovals/Domain/FeeAppointmentApprovalLine.cs
@@ -19,6 +19,7 @@ public class FeeAppointmentApprovalLine
 
     // Appointment snapshot
     [JsonInclude] public DateTime? NewDate { get; private set; }
+    [JsonInclude] public DateTime? PreviousDate { get; private set; }
     [JsonInclude] public int? RescheduleCount { get; private set; }
 
     // Fee snapshot
@@ -33,7 +34,7 @@ public class FeeAppointmentApprovalLine
     public FeeAppointmentApprovalLine() { }
 
     internal static FeeAppointmentApprovalLine CreateAppointment(
-        Guid targetId, DateTime newDate, int rescheduleCount)
+        Guid targetId, DateTime newDate, int rescheduleCount, DateTime? previousDate = null)
     {
         return new FeeAppointmentApprovalLine
         {
@@ -41,6 +42,7 @@ public class FeeAppointmentApprovalLine
             LineType = FeeApprovalLineType.Appointment,
             TargetId = targetId,
             NewDate = newDate,
+            PreviousDate = previousDate,
             RescheduleCount = rescheduleCount,
             LineStatus = FeeApprovalLineStatus.Pending
         };

--- a/Modules/Workflow/Workflow/FeeAppointmentApprovals/EventHandlers/FeeAppointmentApprovalNotificationHandlers.cs
+++ b/Modules/Workflow/Workflow/FeeAppointmentApprovals/EventHandlers/FeeAppointmentApprovalNotificationHandlers.cs
@@ -57,6 +57,7 @@ public class FeeAppointmentApprovalResolvedNotificationHandler(
         {
             AppraisalId = notification.AppraisalId,
             ApprovalId = notification.ApprovalId,
+            ResolvedByCode = notification.ResolvedByCode,
             LineOutcomes = notification.LineOutcomes
                 .Select(o => new FeeApprovalLineOutcome(
                     o.LineType, o.TargetId, o.Decision, o.Reason))

--- a/Modules/Workflow/Workflow/FeeAppointmentApprovals/EventHandlers/FeeAppointmentApprovalRequestedConsumer.cs
+++ b/Modules/Workflow/Workflow/FeeAppointmentApprovals/EventHandlers/FeeAppointmentApprovalRequestedConsumer.cs
@@ -29,7 +29,8 @@ public class FeeAppointmentApprovalRequestedConsumer(
                 l.RescheduleCount,
                 l.FeeCode,
                 l.FeeDescription,
-                l.FeeAmount))
+                l.FeeAmount,
+                l.PreviousDate))
             .ToList();
 
         var command = new RaiseFeeAppointmentApprovalCommand(

--- a/Modules/Workflow/Workflow/Tasks/Features/GetTaskById/GetTaskByIdQueryHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/GetTaskById/GetTaskByIdQueryHandler.cs
@@ -36,10 +36,12 @@ public class GetTaskByIdQueryHandler(
             COALESCE(df.RequestId, qr.RequestId, pt.CorrelationId) AS RequestId,
             -- Resolve the effective AppraisalId:
             --   1. document-followup tasks: df.AppraisalId
-            --   2. quotation-workflow tasks: first linked appraisal via QuotationRequestAppraisals
-            --   3. regular appraisal-workflow tasks: appraisal whose RequestId = pt.CorrelationId
+            --   2. fee/appointment-approval sub-workflow tasks: faa.AppraisalId
+            --   3. quotation-workflow tasks: first linked appraisal via QuotationRequestAppraisals
+            --   4. regular appraisal-workflow tasks: appraisal whose RequestId = pt.CorrelationId
             COALESCE(
                 df.AppraisalId,
+                faa.AppraisalId,
                 qra_first.AppraisalId,
                 (SELECT TOP 1 Id FROM appraisal.Appraisals
                  WHERE RequestId = pt.CorrelationId
@@ -50,6 +52,10 @@ public class GetTaskByIdQueryHandler(
         OUTER APPLY (SELECT TOP 1 RequestId, AppraisalId
                      FROM workflow.DocumentFollowups
                      WHERE FollowupWorkflowInstanceId = pt.WorkflowInstanceId) df
+        -- Fee/appointment-approval sub-workflow tasks: resolve AppraisalId via FollowupWorkflowInstanceId
+        OUTER APPLY (SELECT TOP 1 AppraisalId
+                     FROM workflow.FeeAppointmentApprovals
+                     WHERE FollowupWorkflowInstanceId = pt.WorkflowInstanceId) faa
         -- Quotation tasks: pt.CorrelationId = QuotationRequestId for quotation-workflow instances
         OUTER APPLY (SELECT TOP 1 qr2.Id, qr2.RequestId
                      FROM appraisal.QuotationRequests qr2

--- a/Shared/Shared.Messaging/Events/FeeAppointmentApprovalRequestedIntegrationEvent.cs
+++ b/Shared/Shared.Messaging/Events/FeeAppointmentApprovalRequestedIntegrationEvent.cs
@@ -20,4 +20,5 @@ public record FeeApprovalRequestedLineDto(
     int? RescheduleCount,
     string? FeeCode,
     string? FeeDescription,
-    decimal? FeeAmount);
+    decimal? FeeAmount,
+    DateTime? PreviousDate = null); // appointment change: the date before this reschedule

--- a/Shared/Shared.Messaging/Events/FeeAppointmentApprovalResolvedIntegrationEvent.cs
+++ b/Shared/Shared.Messaging/Events/FeeAppointmentApprovalResolvedIntegrationEvent.cs
@@ -9,6 +9,14 @@ public class FeeAppointmentApprovalResolvedIntegrationEvent
     public Guid AppraisalId { get; init; }
     public Guid ApprovalId { get; init; }
     public IReadOnlyList<FeeApprovalLineOutcome> LineOutcomes { get; init; } = [];
+
+    /// <summary>
+    /// The bank code (e.g. "P5229", = AspNetUsers.UserName) of the user who resolved the approval.
+    /// Used by the Appraisal module to stamp the real approver on the Appointment / AppraisalFeeItem
+    /// instead of a system placeholder. Null only for system-initiated resolutions.
+    /// </summary>
+    public string? ResolvedByCode { get; init; }
+
     public DateTime OccurredOn { get; set; }
 }
 

--- a/Shared/Shared/Identity/CurrentUserService.cs
+++ b/Shared/Shared/Identity/CurrentUserService.cs
@@ -17,6 +17,7 @@ public class CurrentUserService(IHttpContextAccessor httpContextAccessor) : ICur
     }
 
     public string? Username => User?.FindFirst("name")?.Value;
+    public string? UserCode => User?.FindFirst("preferred_username")?.Value;
     public bool IsAuthenticated => User?.Identity?.IsAuthenticated ?? false;
 
     public IReadOnlyList<string> Permissions

--- a/Shared/Shared/Identity/DevAuthenticationHandler.cs
+++ b/Shared/Shared/Identity/DevAuthenticationHandler.cs
@@ -30,6 +30,7 @@ public class DevAuthenticationHandler(
         {
             new Claim("sub", devId),
             new Claim("name", "dev-user"),
+            new Claim("preferred_username", "dev-user"), // bank code (UserCode) — used for actor/audit stamping
             new Claim("company_id", devId),
             // Permissions
             new Claim("permissions", "auth:read"),

--- a/Shared/Shared/Identity/ICurrentUserService.cs
+++ b/Shared/Shared/Identity/ICurrentUserService.cs
@@ -15,6 +15,14 @@ public interface ICurrentUserService
     string? Username { get; }
 
     /// <summary>
+    /// Gets the current user's bank code (e.g. "P5229") from the "preferred_username" claim
+    /// (= AspNetUsers.UserName). This is the canonical user identifier used for actor/audit
+    /// fields throughout the domain — prefer this over <see cref="UserId"/> (Guid) for stamping
+    /// who performed an action. Returns null if not authenticated.
+    /// </summary>
+    string? UserCode { get; }
+
+    /// <summary>
     /// Gets whether the current request has an authenticated user.
     /// </summary>
     bool IsAuthenticated { get; }

--- a/Tests/Unit/Appraisal.Tests/Domain/FeeAppointmentApprovalDomainTests.cs
+++ b/Tests/Unit/Appraisal.Tests/Domain/FeeAppointmentApprovalDomainTests.cs
@@ -92,7 +92,7 @@ public class FeeAppointmentApprovalDomainTests
         var fee = NewFeeWithBase(5000m);
         var approved = AddCompanyFee(fee, "02", 1000m);
         approved.MakePendingApproval();
-        approved.Approve(Guid.NewGuid());
+        approved.Approve("P5229");
         Assert.Equal("Approved", approved.ApprovalStatus);
 
         // A later re-evaluation must leave the bank-approved item untouched.
@@ -111,7 +111,7 @@ public class FeeAppointmentApprovalDomainTests
         AddCompanyFee(fee, "02", 200m);                 // counts
         var approved = AddCompanyFee(fee, "03", 300m);  // excluded once approved
         approved.MakePendingApproval();
-        approved.Approve(Guid.NewGuid());
+        approved.Approve("P5229");
 
         var cumulative = fee.Items
             .Where(i => i.Source == FeeItemSource.User && i.ApprovalStatus != "Approved")
@@ -142,7 +142,7 @@ public class FeeAppointmentApprovalDomainTests
         item.MarkApprovalSubmitted();
         Assert.NotNull(item.ApprovalSubmittedAt);
 
-        item.Approve(Guid.NewGuid());
+        item.Approve("P5229");
 
         Assert.Equal("Approved", item.ApprovalStatus);
         Assert.False(item.RequiresApproval);
@@ -157,7 +157,7 @@ public class FeeAppointmentApprovalDomainTests
     {
         var fee = NewFeeWithBase();
         var item = AddCompanyFee(fee, "02", 100m); // billable, ApprovalStatus == null
-        Assert.Throws<InvalidOperationException>(() => item.Approve(Guid.NewGuid()));
+        Assert.Throws<InvalidOperationException>(() => item.Approve("P5229"));
     }
 
     [Fact]
@@ -168,7 +168,7 @@ public class FeeAppointmentApprovalDomainTests
         item.MakePendingApproval();
         item.MarkApprovalSubmitted();
 
-        item.Reject(Guid.Empty, "Test");
+        item.Reject("P5229", "Test");
 
         Assert.Equal("Rejected", item.ApprovalStatus); // not nulled
         Assert.Null(item.ApprovalSubmittedAt);          // awaiting badge clears
@@ -185,7 +185,7 @@ public class FeeAppointmentApprovalDomainTests
         var fee = NewFeeWithBase(5000m);
         var rejected = AddCompanyFee(fee, "02", 1000m);
         rejected.MakePendingApproval();
-        rejected.Reject(Guid.Empty, "no");
+        rejected.Reject("P5229", "no");
 
         // A later add triggers re-evaluation — the rejected fee must stay Rejected.
         fee.ReevaluateAddedFees(requiresApproval: true);
@@ -202,7 +202,7 @@ public class FeeAppointmentApprovalDomainTests
         var item = AddCompanyFee(fee, "02", 1000m);
         item.Id = Guid.NewGuid(); // Create() leaves Id empty (EF assigns); set a unique one for lookup
         item.MakePendingApproval();
-        item.Approve(Guid.NewGuid());
+        item.Approve("P5229");
 
         Assert.Throws<InvalidOperationException>(
             () => fee.UpdateItem(item.Id, "02", "changed", 2000m));

--- a/Tests/Unit/Common.Tests/Monitoring/MonitoringActivityMapTests.cs
+++ b/Tests/Unit/Common.Tests/Monitoring/MonitoringActivityMapTests.cs
@@ -198,6 +198,7 @@ internal sealed class FakeCurrentUserService(IEnumerable<string> permissions, st
 
     public Guid? UserId => null;
     public string? Username => username;
+    public string? UserCode => username;
     public bool IsAuthenticated => true;
     public IReadOnlyList<string> Permissions => _permissions;
     public IReadOnlyList<string> Roles => [];

--- a/docs/fee-appointment-history/appointment-card-mockup.html
+++ b/docs/fee-appointment-history/appointment-card-mockup.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Appointment Card — redesign options</title>
+<style>
+  :root{
+    --bg:#f1f5f9; --card:#fff; --line:#e7ebf0; --ink:#0f172a; --muted:#64748b; --faint:#94a3b8;
+    --primary:#2563eb; --accent:#ea580c; --accent-bg:#fff7ed;
+    --green:#16a34a; --green-bg:#f0fdf4; --green-bd:#bbf7d0;
+    --amber:#d97706; --amber-bg:#fffbeb; --amber-bd:#fde68a;
+    --red:#dc2626; --red-bg:#fef2f2; --red-bd:#fecaca;
+    --slate-btn:#334155;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;font-size:14px;line-height:1.5}
+  .wrap{max-width:1040px;margin:0 auto;padding:28px 20px 90px}
+  h1{font-size:22px;font-weight:700;margin:0 0 2px}
+  .sub{color:var(--muted);margin:0 0 22px}
+  .toolbar{position:sticky;top:12px;z-index:5;display:flex;align-items:center;gap:10px;background:#fff;border:1px solid var(--line);border-radius:12px;padding:10px 14px;margin-bottom:24px;box-shadow:0 1px 2px rgba(2,6,23,.04)}
+  .toolbar .lbl{font-weight:600}
+  .seg{display:inline-flex;background:#f1f5f9;border-radius:9px;padding:3px;flex-wrap:wrap}
+  .seg button{border:0;background:transparent;padding:6px 12px;border-radius:7px;font-size:13px;font-weight:600;color:var(--muted);cursor:pointer}
+  .seg button.active{background:#fff;color:var(--ink);box-shadow:0 1px 2px rgba(2,6,23,.12)}
+  .variant{margin-bottom:30px}
+  .variant > .cap{font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;color:var(--faint);margin:0 0 10px}
+  .variant > .note{color:var(--muted);font-size:13px;margin:10px 2px 0}
+
+  /* shared bits */
+  .pin,.ava{display:inline-flex;align-items:center;justify-content:center}
+  .ava{width:26px;height:26px;border-radius:99px;background:#e2e8f0;color:#64748b;font-size:11px;font-weight:700}
+  .badge{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:700;padding:3px 9px;border-radius:99px;border:1px solid transparent;white-space:nowrap}
+  .badge.approved{background:var(--green-bg);color:var(--green);border-color:var(--green-bd)}
+  .badge.awaiting{background:#eff6ff;color:var(--primary);border-color:#bfdbfe}
+  .badge.pending{background:var(--amber-bg);color:var(--amber);border-color:var(--amber-bd)}
+  .dot{width:5px;height:5px;border-radius:99px;background:currentColor;display:inline-block}
+  .btn{display:inline-flex;align-items:center;gap:7px;font-size:13px;font-weight:600;padding:9px 14px;border-radius:10px;cursor:pointer;border:1px solid transparent;background:#fff;transition:.15s}
+  .btn.cancel{border-color:var(--red-bd);background:var(--red-bg);color:var(--red)}
+  .btn.cancel:hover{background:#fee2e2}
+  .btn.resched{background:var(--slate-btn);color:#fff}
+  .btn.resched:hover{background:#1e293b}
+  .btn.ghost{border-color:var(--line);background:#fff;color:var(--muted)}
+  .btn.ghost:hover{background:#f8fafc;color:var(--ink)}
+  .ico{width:15px;height:15px;display:inline-block;vertical-align:-2px}
+  .meta{display:inline-flex;align-items:center;gap:8px;color:var(--faint);font-size:12.5px}
+  .meta a{color:var(--muted);text-decoration:none;display:inline-flex;align-items:center;gap:5px;font-weight:600}
+  .meta a:hover{color:var(--primary)}
+  .muted{color:var(--muted)} .faint{color:var(--faint)}
+
+  /* ============ A: calendar tile ============ */
+  .cardA{background:var(--card);border:1px solid var(--line);border-radius:16px;box-shadow:0 1px 2px rgba(2,6,23,.05);padding:16px 18px;display:flex;align-items:center;gap:18px}
+  .calA{flex-shrink:0;width:76px;border:1px solid var(--line);border-radius:12px;overflow:hidden;text-align:center;background:#fff}
+  .calA .m{background:var(--accent);color:#fff;font-size:11px;font-weight:700;letter-spacing:.08em;padding:3px 0;text-transform:uppercase}
+  .calA .d{font-size:28px;font-weight:800;line-height:1.1;padding-top:6px;color:var(--ink)}
+  .calA .w{font-size:11px;color:var(--muted);padding-bottom:6px}
+  .Amid{flex:1;min-width:0}
+  .Atime{font-size:16px;font-weight:700;display:flex;align-items:center;gap:7px}
+  .Arow{display:flex;align-items:center;gap:7px;color:var(--muted);font-size:13px;margin-top:3px}
+  .Ameta{margin-top:7px}
+  .Aright{display:flex;flex-direction:column;align-items:flex-end;gap:10px;flex-shrink:0}
+  .Aactions{display:flex;gap:8px}
+
+  /* ============ B: header strip ============ */
+  .cardB{background:var(--card);border:1px solid var(--line);border-radius:16px;box-shadow:0 1px 2px rgba(2,6,23,.05);overflow:hidden}
+  .Bhead{display:flex;align-items:center;gap:10px;padding:10px 18px;border-bottom:1px solid var(--line);background:#f8fafc}
+  .Bhead .t{font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
+  .Bhead .sp{flex:1}
+  .Bbody{display:flex;align-items:center;gap:22px;padding:16px 18px}
+  .Bdate{flex-shrink:0;padding-right:22px;border-right:1px solid var(--line)}
+  .Bdate .w{font-size:12px;font-weight:600;color:var(--accent)}
+  .Bdate .d{font-size:19px;font-weight:800;line-height:1.15}
+  .Bdate .ti{font-size:13px;color:var(--muted)}
+  .Bdetails{flex:1;display:flex;flex-direction:column;gap:6px}
+  .Bactions{display:flex;gap:8px;flex-shrink:0}
+
+  /* ============ C: accent bar, two-tier ============ */
+  .cardC{position:relative;background:var(--card);border:1px solid var(--line);border-radius:16px;box-shadow:0 1px 2px rgba(2,6,23,.05);padding:16px 18px 14px 22px;overflow:hidden}
+  .cardC::before{content:"";position:absolute;left:0;top:0;bottom:0;width:4px;background:var(--accent)}
+  .Ctop{display:flex;align-items:flex-start;gap:18px}
+  .Cdate{flex-shrink:0}
+  .Cdate .w{font-size:12px;font-weight:600;color:var(--accent)}
+  .Cdate .d{font-size:20px;font-weight:800;line-height:1.15}
+  .Cdate .ti{display:inline-flex;align-items:center;gap:6px;font-size:13px;color:var(--muted);margin-top:2px}
+  .Cdetails{flex:1;min-width:0;display:flex;flex-direction:column;gap:5px;padding-top:2px}
+  .Cline{display:flex;align-items:center;gap:8px;color:var(--muted);font-size:13px}
+  .Cright{display:flex;flex-direction:column;align-items:flex-end;gap:10px;flex-shrink:0}
+  .Cactions{display:flex;gap:8px}
+  .Cfoot{display:flex;align-items:center;gap:8px;margin-top:12px;padding-top:11px;border-top:1px solid var(--line)}
+
+  /* pending reschedule (old→new) demo */
+  .oldnew{display:inline-flex;align-items:center;gap:9px}
+  .old{color:var(--faint);text-decoration:line-through;text-decoration-color:#fca5a5}
+  .arrow{color:var(--amber);font-weight:700}
+
+  .hideblock{display:none}
+  svg{stroke:currentColor;fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Appointment card — redesign options</h1>
+  <p class="sub">Same data as today (date / time / location / contact / reschedule count / history / status / actions). Pick a direction.</p>
+
+  <div class="toolbar">
+    <span class="lbl">Variant</span>
+    <div class="seg">
+      <button class="active" onclick="show('A')">A · Calendar tile</button>
+      <button onclick="show('B')">B · Header strip</button>
+      <button onclick="show('C')">C · Accent + footer</button>
+    </div>
+    <div class="seg" style="margin-left:auto">
+      <button class="active" onclick="setState('approved')" id="s-approved">Approved</button>
+      <button onclick="setState('awaiting')" id="s-awaiting">Awaiting approval</button>
+    </div>
+  </div>
+
+  <!-- ============ VARIANT A ============ -->
+  <div class="variant" id="vA">
+    <p class="cap">Variant A — Calendar date tile</p>
+    <div class="cardA">
+      <div class="calA">
+        <div class="m">Apr</div>
+        <div class="d">11</div>
+        <div class="w">Sat</div>
+      </div>
+      <div class="Amid">
+        <div class="Atime">
+          <svg class="ico" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+          9:00 AM
+        </div>
+        <div class="Arow">
+          <svg class="ico" viewBox="0 0 24 24"><path d="M12 21s7-5.7 7-11a7 7 0 1 0-14 0c0 5.3 7 11 7 11Z"/><circle cx="12" cy="10" r="2.5"/></svg>
+          <span class="faint">Location not specified</span>
+        </div>
+        <div class="Arow">
+          <span class="ava">JD</span>
+          <span>John Doe <span class="faint">· 089814xxxx</span></span>
+        </div>
+        <div class="Ameta meta">
+          <span>Rescheduled 3×</span><span class="dot" style="color:#cbd5e1"></span>
+          <a href="#"><svg class="ico" viewBox="0 0 24 24"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 4v4h4"/><path d="M12 8v4l3 2"/></svg>View history <b style="margin-left:2px">(28)</b></a>
+        </div>
+      </div>
+      <div class="Aright">
+        <span class="badge approved st-approved">● Approved</span>
+        <span class="badge awaiting st-awaiting hideblock">Awaiting approval</span>
+        <div class="Aactions">
+          <button class="btn cancel"><svg class="ico" viewBox="0 0 24 24"><path d="M6 6l12 12M18 6 6 18"/></svg>Cancel</button>
+          <button class="btn resched"><svg class="ico" viewBox="0 0 24 24"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 4v4h4"/></svg>Re-schedule</button>
+        </div>
+      </div>
+    </div>
+    <p class="note">Date reads instantly as a calendar chip; status pill sits above the actions; history is a quiet link in the meta line. Most scannable.</p>
+  </div>
+
+  <!-- ============ VARIANT B ============ -->
+  <div class="variant hideblock" id="vB">
+    <p class="cap">Variant B — Header strip (status + history up top)</p>
+    <div class="cardB">
+      <div class="Bhead">
+        <span class="t">Appointment</span>
+        <span class="badge approved st-approved">● Approved</span>
+        <span class="badge awaiting st-awaiting hideblock">Awaiting approval</span>
+        <span class="sp"></span>
+        <a class="meta" href="#" style="color:var(--muted);font-weight:600;text-decoration:none">
+          <svg class="ico" viewBox="0 0 24 24"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 4v4h4"/><path d="M12 8v4l3 2"/></svg>View history (28)
+        </a>
+      </div>
+      <div class="Bbody">
+        <div class="Bdate">
+          <div class="w">Saturday</div>
+          <div class="d">April 11, 2026</div>
+          <div class="ti">9:00 AM</div>
+        </div>
+        <div class="Bdetails">
+          <div class="meta" style="color:var(--muted);font-size:13px">
+            <svg class="ico" viewBox="0 0 24 24"><path d="M12 21s7-5.7 7-11a7 7 0 1 0-14 0c0 5.3 7 11 7 11Z"/><circle cx="12" cy="10" r="2.5"/></svg>
+            <span class="faint">Location not specified</span>
+          </div>
+          <div class="meta" style="color:var(--muted);font-size:13px">
+            <span class="ava">JD</span><span>John Doe <span class="faint">· 089814xxxx</span></span>
+          </div>
+          <div class="meta"><span>Rescheduled 3×</span></div>
+        </div>
+        <div class="Bactions">
+          <button class="btn cancel"><svg class="ico" viewBox="0 0 24 24"><path d="M6 6l12 12M18 6 6 18"/></svg>Cancel</button>
+          <button class="btn resched"><svg class="ico" viewBox="0 0 24 24"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 4v4h4"/></svg>Re-schedule</button>
+        </div>
+      </div>
+    </div>
+    <p class="note">Status and history are promoted to a header bar, so the body is just the facts. Good if status matters at a glance; slightly taller.</p>
+  </div>
+
+  <!-- ============ VARIANT C ============ -->
+  <div class="variant hideblock" id="vC">
+    <p class="cap">Variant C — Accent bar + meta footer</p>
+    <div class="cardC">
+      <div class="Ctop">
+        <div class="Cdate">
+          <div class="w">Saturday</div>
+          <div class="d">April 11, 2026</div>
+          <div class="ti"><svg class="ico" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>9:00 AM</div>
+        </div>
+        <div class="Cdetails">
+          <div class="Cline">
+            <svg class="ico" viewBox="0 0 24 24"><path d="M12 21s7-5.7 7-11a7 7 0 1 0-14 0c0 5.3 7 11 7 11Z"/><circle cx="12" cy="10" r="2.5"/></svg>
+            <span class="faint">Location not specified</span>
+          </div>
+          <div class="Cline">
+            <span class="ava">JD</span><span>John Doe <span class="faint">· 089814xxxx</span></span>
+          </div>
+        </div>
+        <div class="Cright">
+          <span class="badge approved st-approved">● Approved</span>
+          <span class="badge awaiting st-awaiting hideblock">Awaiting approval</span>
+          <div class="Cactions">
+            <button class="btn cancel"><svg class="ico" viewBox="0 0 24 24"><path d="M6 6l12 12M18 6 6 18"/></svg>Cancel</button>
+            <button class="btn resched"><svg class="ico" viewBox="0 0 24 24"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 4v4h4"/></svg>Re-schedule</button>
+          </div>
+        </div>
+      </div>
+      <div class="Cfoot meta">
+        <svg class="ico" viewBox="0 0 24 24" style="color:#cbd5e1"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 4v4h4"/></svg>
+        <span>Rescheduled 3×</span><span class="dot" style="color:#cbd5e1"></span>
+        <a href="#">View full history (28)</a>
+      </div>
+    </div>
+    <p class="note">Coloured accent bar signals status type; reschedule + history live in a clear footer separated from the primary actions. Cleanest separation of concerns.</p>
+  </div>
+
+  <!-- pending reschedule example (applies to whichever variant, shown once) -->
+  <div class="variant" id="pendingDemo">
+    <p class="cap">Pending reschedule state (old → new) — applies to the chosen variant</p>
+    <div class="cardA" style="border-color:#fde68a;background:#fffdf7">
+      <div class="calA" style="border-color:#fde68a">
+        <div class="m" style="background:var(--amber)">Apr</div>
+        <div class="d">16</div>
+        <div class="w">Tue</div>
+      </div>
+      <div class="Amid">
+        <div class="Atime oldnew">
+          <span class="old" style="font-size:13px;font-weight:600">Sat, Apr 11 · 9:00 AM</span>
+          <span class="arrow">→</span>
+          <span>Tue, Apr 16 · 10:00 AM</span>
+        </div>
+        <div class="Arow"><span class="ava">JD</span><span>John Doe <span class="faint">· 089814xxxx</span></span></div>
+        <div class="Ameta meta"><span>Rescheduled 4×</span><span class="dot" style="color:#cbd5e1"></span><a href="#">View history (29)</a></div>
+      </div>
+      <div class="Aright">
+        <span class="badge awaiting">Awaiting approval</span>
+        <div class="Aactions">
+          <button class="btn cancel" style="opacity:.45;cursor:not-allowed">Cancel</button>
+          <button class="btn resched" style="opacity:.45;cursor:not-allowed">Re-schedule</button>
+        </div>
+      </div>
+    </div>
+    <p class="note">While a reschedule awaits approval: old date struck through → new proposed date, amber tint, actions locked. (Same treatment in B/C.)</p>
+  </div>
+</div>
+
+<script>
+  function show(v){
+    ['A','B','C'].forEach(x=>document.getElementById('v'+x).classList.toggle('hideblock',x!==v));
+    document.querySelectorAll('.toolbar .seg:first-of-type button').forEach(b=>b.classList.remove('active'));
+    event.target.classList.add('active');
+  }
+  function setState(s){
+    document.querySelectorAll('.st-approved').forEach(e=>e.classList.toggle('hideblock',s!=='approved'));
+    document.querySelectorAll('.st-awaiting').forEach(e=>e.classList.toggle('hideblock',s!=='awaiting'));
+    document.getElementById('s-approved').classList.toggle('active',s==='approved');
+    document.getElementById('s-awaiting').classList.toggle('active',s==='awaiting');
+  }
+</script>
+</body>
+</html>

--- a/docs/fee-appointment-history/history-mockup.html
+++ b/docs/fee-appointment-history/history-mockup.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Appointment &amp; Fee — History drawer (draft idea)</title>
+<style>
+  :root {
+    --bg: #f1f5f9;
+    --card: #ffffff;
+    --line: #e2e8f0;
+    --ink: #0f172a;
+    --muted: #64748b;
+    --faint: #94a3b8;
+    --primary: #2563eb;
+    --amber: #d97706;
+    --amber-bg: #fffbeb;
+    --amber-bd: #fde68a;
+    --green: #16a34a;
+    --green-bg: #f0fdf4;
+    --green-bd: #bbf7d0;
+    --red: #dc2626;
+    --red-bg: #fef2f2;
+    --red-bd: #fecaca;
+    --blue-bg: #eff6ff;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 14px; line-height: 1.5;
+  }
+  .wrap { max-width: 880px; margin: 0 auto; padding: 28px 20px 80px; }
+  .page-title { font-size: 22px; font-weight: 700; margin: 0 0 2px; }
+  .page-sub { color: var(--muted); margin: 0 0 22px; }
+
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 14px; box-shadow: 0 1px 2px rgba(15,23,42,.04); }
+  .card-h { padding: 12px 16px; border-bottom: 1px solid var(--line); display: flex; align-items: center; gap: 8px; }
+  .card-h .t { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+  .card-b { padding: 14px 16px; }
+  .kv { display: flex; justify-content: space-between; padding: 4px 0; }
+  .kv .k { color: var(--muted); }
+  .kv .v { font-weight: 600; }
+  .big-date { font-size: 18px; font-weight: 700; margin-bottom: 6px; }
+  .context-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 18px; }
+
+  /* the trigger button (lives in the section header / action bar) */
+  .history-btn {
+    display: inline-flex; align-items: center; gap: 8px; cursor: pointer;
+    background: #fff; border: 1px solid var(--line); border-radius: 10px;
+    padding: 9px 14px; font-size: 13px; font-weight: 600; color: var(--ink);
+    box-shadow: 0 1px 2px rgba(15,23,42,.05);
+  }
+  .history-btn:hover { background: #f8fafc; border-color: #cbd5e1; }
+  .history-btn .clk { font-size: 15px; }
+  .history-btn .cnt { background: var(--blue-bg); color: var(--primary); font-size: 11px; font-weight: 700; border-radius: 99px; padding: 1px 8px; }
+
+  .hint-row { display: flex; align-items: center; gap: 12px; margin: 6px 0 4px; }
+  .hint-row .arrow-hint { color: var(--amber); font-size: 13px; font-weight: 600; }
+
+  /* badges */
+  .badge { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; font-weight: 700; padding: 3px 9px; border-radius: 99px; border: 1px solid transparent; white-space: nowrap; }
+  .badge.approved { background: var(--green-bg); color: var(--green); border-color: var(--green-bd); }
+  .badge.rejected { background: var(--red-bg); color: var(--red); border-color: var(--red-bd); }
+  .badge.pending  { background: var(--amber-bg); color: var(--amber); border-color: var(--amber-bd); }
+  .badge.auto     { background: #f1f5f9; color: var(--muted); border-color: var(--line); }
+
+  /* ---------- drawer ---------- */
+  .scrim { position: fixed; inset: 0; background: rgba(15,23,42,.45); opacity: 0; pointer-events: none; transition: opacity .22s ease; z-index: 40; }
+  .scrim.open { opacity: 1; pointer-events: auto; }
+  .drawer {
+    position: fixed; top: 0; right: 0; height: 100vh; width: 460px; max-width: 92vw;
+    background: var(--card); box-shadow: -8px 0 30px rgba(15,23,42,.18);
+    transform: translateX(100%); transition: transform .26s cubic-bezier(.4,0,.2,1);
+    z-index: 50; display: flex; flex-direction: column;
+  }
+  .drawer.open { transform: translateX(0); }
+  .drawer-h { padding: 16px 18px; border-bottom: 1px solid var(--line); display: flex; align-items: center; gap: 10px; }
+  .drawer-h .icon { width: 30px; height: 30px; border-radius: 8px; display: grid; place-items: center; background: var(--blue-bg); color: var(--primary); font-size: 15px; }
+  .drawer-h h2 { font-size: 15px; margin: 0; }
+  .drawer-h .sub { font-size: 12px; color: var(--faint); }
+  .drawer-h .x { margin-left: auto; border: 0; background: #f1f5f9; width: 30px; height: 30px; border-radius: 8px; cursor: pointer; font-size: 15px; color: var(--muted); }
+  .drawer-h .x:hover { background: #e2e8f0; }
+  .drawer-b { overflow-y: auto; padding: 6px 18px 24px; flex: 1; }
+
+  /* filter chips inside drawer */
+  .chips { display: flex; gap: 8px; padding: 12px 0 4px; position: sticky; top: 0; background: #fff; }
+  .chip { border: 1px solid var(--line); background: #fff; border-radius: 99px; padding: 5px 12px; font-size: 12px; font-weight: 600; color: var(--muted); cursor: pointer; }
+  .chip.active { background: var(--ink); color: #fff; border-color: var(--ink); }
+
+  /* timeline */
+  .tl-item { position: relative; padding: 16px 0 16px 40px; }
+  .tl-item:not(:last-child)::before { content: ""; position: absolute; left: 13px; top: 30px; bottom: -6px; width: 2px; background: var(--line); }
+  .tl-node { position: absolute; left: 4px; top: 16px; width: 22px; height: 22px; border-radius: 99px; display: grid; place-items: center; font-size: 11px; color: #fff; z-index: 1; }
+  .tl-node.appt { background: var(--primary); }
+  .tl-node.fee  { background: #7c3aed; }
+  .tl-node.approved { background: var(--green); }
+  .tl-node.rejected { background: var(--red); }
+  .tl-node.pending  { background: var(--amber); }
+  .tl-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .tl-title { font-weight: 700; }
+  .tl-when { width: 100%; font-size: 12px; color: var(--faint); margin-top: 2px; }
+  .tl-body { margin-top: 6px; }
+  .tl-row { color: var(--muted); font-size: 13px; }
+  .tl-actor { font-size: 12px; color: var(--faint); margin-top: 4px; }
+  .change { display: inline-flex; align-items: center; gap: 8px; margin-top: 4px; font-weight: 600; }
+  .old { color: var(--faint); text-decoration: line-through; text-decoration-color: var(--red); }
+  .arrow { color: var(--amber); font-weight: 700; }
+  .new { color: var(--ink); }
+  .reason-quote { margin-top: 8px; padding: 8px 12px; background: #f8fafc; border-left: 3px solid var(--line); border-radius: 0 8px 8px 0; color: var(--muted); font-size: 13px; font-style: italic; }
+  .reason-quote.rej { background: var(--red-bg); border-left-color: var(--red); color: #991b1b; }
+
+  .legend { margin-top: 22px; background: #f8fafc; border: 1px dashed var(--line); border-radius: 12px; padding: 14px 18px; }
+  .legend h3 { margin: 0 0 8px; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+  .legend code { background: #eef2ff; color: #3730a3; padding: 1px 6px; border-radius: 5px; font-size: 12px; }
+  .legend li { margin: 4px 0; color: var(--muted); font-size: 13px; }
+  .data-appt { } .data-fee { }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1 class="page-title">Appointment &amp; Fee page</h1>
+  <p class="page-sub">Draft idea · the new <b>View history</b> button opens a slide-out timeline drawer →</p>
+
+  <!-- current-state context -->
+  <div class="context-grid">
+    <div class="card">
+      <div class="card-h"><span class="t">Appointment</span>
+        <span class="badge approved" style="margin-left:auto;">Approved</span>
+      </div>
+      <div class="card-b">
+        <div class="big-date">Tue, 16 Jun 2026 · 10:00</div>
+        <div class="hint-row">
+          <button class="history-btn" onclick="openDrawer()">
+            <span class="clk">🕑</span> View history <span class="cnt">6</span>
+          </button>
+          <span class="arrow-hint">← rescheduled twice</span>
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-h"><span class="t">Fees</span>
+        <span class="v" style="margin-left:auto; font-weight:700;">฿ 5,800.00</span>
+      </div>
+      <div class="card-b">
+        <div class="kv"><span class="k">Appraisal fee <span class="badge auto">System</span></span><span class="v">฿ 4,500.00</span></div>
+        <div class="kv"><span class="k">Travel — remote area <span class="badge approved">Approved</span></span><span class="v">฿ 1,300.00</span></div>
+        <div class="kv"><span class="k" style="color:var(--faint)">Urgent handling <span class="badge rejected">Rejected</span></span><span class="v" style="color:var(--faint); text-decoration:line-through;">฿ 2,000.00</span></div>
+      </div>
+    </div>
+  </div>
+
+  <p style="color:var(--faint); font-size:13px;">↑ The <b>View history</b> button sits on the appointment card (and can mirror into the bottom action bar). Click it to open the drawer.</p>
+
+  <div class="legend">
+    <h3>Where each field comes from (nothing here is invented)</h3>
+    <ul style="margin:0; padding-left:18px;">
+      <li>Date change (old → new), action, when, by, reason → <code>AppointmentHistory</code></li>
+      <li>Appointment approve/reject → <code>AppointmentHistory</code> + <code>Appointment.ApprovedBy/ApprovedAt</code></li>
+      <li>Fee decision, amount, by, reason → <code>AppraisalFeeItem</code> (<code>ApprovalStatus</code>, <code>FeeAmount</code>, <code>ApprovedBy</code>, <code>ApprovedAt</code>, <code>RejectionReason</code>)</li>
+      <li>“Auto-applied” vs “Needs approval” → <code>RequiresApproval</code> / <code>ApprovalSubmittedAt</code></li>
+    </ul>
+  </div>
+</div>
+
+<!-- ============ DRAWER ============ -->
+<div class="scrim" id="scrim" onclick="closeDrawer()"></div>
+<aside class="drawer" id="drawer" aria-label="History">
+  <div class="drawer-h">
+    <span class="icon">🕑</span>
+    <div>
+      <h2>History</h2>
+      <div class="sub">Appraisal AP-2026-004821 · 6 events</div>
+    </div>
+    <button class="x" onclick="closeDrawer()">✕</button>
+  </div>
+  <div class="drawer-b">
+    <div class="chips">
+      <span class="chip active" data-f="all" onclick="filt('all')">All</span>
+      <span class="chip" data-f="appt" onclick="filt('appt')">Appointment</span>
+      <span class="chip" data-f="fee" onclick="filt('fee')">Fees</span>
+    </div>
+
+    <div id="timeline">
+      <div class="tl-item data-appt">
+        <div class="tl-node approved">✓</div>
+        <div class="tl-head"><span class="tl-title">Reschedule approved</span><span class="badge approved">Approved</span>
+          <span class="tl-when">Mon, 8 Jun 2026 · 09:14</span></div>
+        <div class="tl-body">
+          <div class="change"><span class="old">Thu, 12 Jun 2026</span><span class="arrow">→</span><span class="new">Tue, 16 Jun 2026 · 10:00</span></div>
+          <div class="tl-actor">Approved by <b>Nattapong S.</b> (bank reviewer)</div>
+        </div>
+      </div>
+
+      <div class="tl-item data-fee">
+        <div class="tl-node rejected">✕</div>
+        <div class="tl-head"><span class="tl-title">Fee rejected — Urgent handling</span><span class="badge rejected">Rejected</span>
+          <span class="tl-when">Mon, 8 Jun 2026 · 09:13</span></div>
+        <div class="tl-body">
+          <div class="tl-row">Urgent handling · <b>฿ 2,000.00</b></div>
+          <div class="tl-actor">Rejected by <b>Nattapong S.</b> (bank reviewer)</div>
+          <div class="reason-quote rej">“Urgent surcharge not justified for this engagement window.”</div>
+        </div>
+      </div>
+
+      <div class="tl-item data-fee">
+        <div class="tl-node fee">฿</div>
+        <div class="tl-head"><span class="tl-title">Submitted for approval</span><span class="badge pending">2 items</span>
+          <span class="tl-when">Fri, 5 Jun 2026 · 16:40</span></div>
+        <div class="tl-body">
+          <div class="tl-row">1 reschedule + 1 added fee bundled for bank review</div>
+          <div class="tl-actor">Submitted by <b>Premier Valuation Co.</b> (external)</div>
+        </div>
+      </div>
+
+      <div class="tl-item data-fee">
+        <div class="tl-node fee">฿</div>
+        <div class="tl-head"><span class="tl-title">Fee added — Travel (remote area)</span><span class="badge pending">Pending → Approved</span>
+          <span class="tl-when">Fri, 5 Jun 2026 · 16:35</span></div>
+        <div class="tl-body">
+          <div class="tl-row">Travel — remote area · <b>฿ 1,300.00</b></div>
+          <div class="tl-actor">Added by <b>Premier Valuation Co.</b> · later approved Mon, 8 Jun</div>
+        </div>
+      </div>
+
+      <div class="tl-item data-appt">
+        <div class="tl-node pending">⟲</div>
+        <div class="tl-head"><span class="tl-title">Reschedule requested</span><span class="badge pending">Needs approval</span>
+          <span class="tl-when">Fri, 5 Jun 2026 · 16:30</span></div>
+        <div class="tl-body">
+          <div class="change"><span class="old">Thu, 12 Jun 2026</span><span class="arrow">→</span><span class="new">Tue, 16 Jun 2026</span></div>
+          <div class="tl-actor">Requested by <b>Premier Valuation Co.</b></div>
+          <div class="reason-quote">“Owner unavailable on the 12th; earliest on-site access is the 16th.”</div>
+        </div>
+      </div>
+
+      <div class="tl-item data-appt">
+        <div class="tl-node approved">✓</div>
+        <div class="tl-head"><span class="tl-title">Reschedule auto-applied</span><span class="badge auto">No approval needed</span>
+          <span class="tl-when">Wed, 3 Jun 2026 · 11:02</span></div>
+        <div class="tl-body">
+          <div class="change"><span class="old">Mon, 9 Jun 2026</span><span class="arrow">→</span><span class="new">Thu, 12 Jun 2026</span></div>
+          <div class="tl-actor">Changed by <b>Premier Valuation Co.</b> · within policy, applied immediately</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</aside>
+
+<script>
+  function openDrawer() { document.getElementById('drawer').classList.add('open'); document.getElementById('scrim').classList.add('open'); }
+  function closeDrawer() { document.getElementById('drawer').classList.remove('open'); document.getElementById('scrim').classList.remove('open'); }
+  function filt(f) {
+    document.querySelectorAll('.chip').forEach(c => c.classList.toggle('active', c.dataset.f === f));
+    document.querySelectorAll('#timeline .tl-item').forEach(it => {
+      const show = f === 'all' || it.classList.contains('data-' + f);
+      it.style.display = show ? '' : 'none';
+    });
+  }
+  document.addEventListener('keydown', e => { if (e.key === 'Escape') closeDrawer(); });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Fee/appointment approval hardening: actor columns now store the bank code, appointment history read, and the workflow side of fee-appointment approvals.

- **Actor code**: `AppraisalFeeItem.ApprovedBy` Guid→string (bank code); new `ICurrentUserService.UserCode` (from `preferred_username` claim) as the canonical actor identifier.
- **Appointment**: `GetAppointmentHistory` read, `CancelAppointment` / `SubmitPendingApproval` handlers, `AppointmentHistory` domain.
- **Workflow**: `FeeAppointmentApprovals` resolve/raise/query commands, `GetTaskById` enrichment, integration events carrying resolved details.

## Migration
- `ChangeFeeItemApprovedByToCode` (Appraisal)

## Test
`dotnet build` 0 errors. `FeeAppointmentApprovalDomainTests` pass. (9 `IncomeCalculationServiceTests` failures are pre-existing on `main` — that service is untouched by this PR.)

⚠️ Migration not applied by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)