### PR TITLE
feat(pricing): WQS market reference, rental/lease reads, property-group resequence

### DIFF
--- a/Database/Scripts/Views/Appraisal/vw_PropertyGroupDetail.sql
+++ b/Database/Scripts/Views/Appraisal/vw_PropertyGroupDetail.sql
@@ -44,7 +44,8 @@ SELECT PG.AppraisalId,
        CASE
            WHEN AP.PropertyType IN ('L', 'LB') THEN LTN.TitleNumbers
            WHEN AP.PropertyType = 'U' THEN C.TitleNumber
-           END                                                       AS TitleNo
+           END                                                       AS TitleNo,
+       L.IsRentedOut                                                 AS IsRentedOut
 FROM appraisal.PropertyGroups PG
          LEFT JOIN appraisal.PricingAnalysis PA ON PA.AnchorId = PG.Id AND PA.SubjectType = 0
          LEFT JOIN appraisal.PropertyGroupItems PGI ON PGI.PropertyGroupId = PG.Id

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetLeaseAgreement/GetLeaseAgreementQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetLeaseAgreement/GetLeaseAgreementQueryHandler.cs
@@ -15,9 +15,8 @@ public class GetLeaseAgreementQueryHandler(
         var property = appraisal.GetProperty(query.PropertyId)
             ?? throw new PropertyNotFoundException(query.PropertyId);
 
-        if (!property.PropertyType.IsLeaseAgreement)
-            throw new InvalidOperationException($"Property {query.PropertyId} is not a lease agreement property");
-
+        // LeaseAgreementDetail is present on lease-agreement properties and on plain
+        // land (L/LB) flagged "rented out to others" — both are valid sources.
         var detail = property.LeaseAgreementDetail
             ?? throw new InvalidOperationException($"Lease agreement detail not found for property {query.PropertyId}");
 

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetPropertyGroupById/GetPropertyGroupByIdQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetPropertyGroupById/GetPropertyGroupByIdQueryHandler.cs
@@ -170,6 +170,8 @@ public record PropertyGroupItemDto
     public string? Location { get; set; }
     /// <summary>Title deed no(s): comma-joined LandTitles for land, unit deed for condo.</summary>
     public string? TitleNo { get; set; }
+    /// <summary>True for plain land (L/LB) flagged "rented out to others"; null for non-land types.</summary>
+    public bool? IsRentedOut { get; set; }
     public List<PropertyPhotoDto>? Photos { get; set; }
     /// <summary>Full land titles (land/land-and-building only); null/empty for other types.</summary>
     public List<LandTitleDto>? Titles { get; set; }

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetRentalInfo/GetRentalInfoQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetRentalInfo/GetRentalInfoQueryHandler.cs
@@ -15,9 +15,8 @@ public class GetRentalInfoQueryHandler(
         var property = appraisal.GetProperty(query.PropertyId)
             ?? throw new PropertyNotFoundException(query.PropertyId);
 
-        if (!property.PropertyType.IsLeaseAgreement)
-            throw new InvalidOperationException($"Property {query.PropertyId} is not a lease agreement property");
-
+        // RentalInfo is present on lease-agreement properties and on plain land
+        // (L/LB) flagged "rented out to others" — both are valid sources.
         var info = property.RentalInfo
             ?? throw new InvalidOperationException($"Rental info not found for property {query.PropertyId}");
 

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetRentalSchedule/GetRentalScheduleQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetRentalSchedule/GetRentalScheduleQueryHandler.cs
@@ -15,9 +15,8 @@ public class GetRentalScheduleQueryHandler(
         var property = appraisal.GetProperty(query.PropertyId)
             ?? throw new PropertyNotFoundException(query.PropertyId);
 
-        if (!property.PropertyType.IsLeaseAgreement)
-            throw new InvalidOperationException($"Property {query.PropertyId} is not a lease agreement property");
-
+        // RentalInfo is present on lease-agreement properties and on plain land
+        // (L/LB) flagged "rented out to others" — both are valid sources.
         var info = property.RentalInfo
             ?? throw new InvalidOperationException($"Rental info not found for property {query.PropertyId}");
 

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/UpdateLeaseAgreement/UpdateLeaseAgreementCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/UpdateLeaseAgreement/UpdateLeaseAgreementCommandHandler.cs
@@ -15,9 +15,8 @@ public class UpdateLeaseAgreementCommandHandler(
         var property = appraisal.GetProperty(command.PropertyId)
             ?? throw new PropertyNotFoundException(command.PropertyId);
 
-        if (!property.PropertyType.IsLeaseAgreement)
-            throw new InvalidOperationException($"Property {command.PropertyId} is not a lease agreement property");
-
+        // LeaseAgreementDetail is present on lease-agreement properties and on plain
+        // land (L/LB) flagged "rented out to others" — both are valid sources.
         var detail = property.LeaseAgreementDetail
             ?? throw new InvalidOperationException($"Lease agreement detail not found for property {command.PropertyId}");
 

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/UpdateRentalInfo/UpdateRentalInfoCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/UpdateRentalInfo/UpdateRentalInfoCommandHandler.cs
@@ -15,9 +15,8 @@ public class UpdateRentalInfoCommandHandler(
         var property = appraisal.GetProperty(command.PropertyId)
             ?? throw new PropertyNotFoundException(command.PropertyId);
 
-        if (!property.PropertyType.IsLeaseAgreement)
-            throw new InvalidOperationException($"Property {command.PropertyId} is not a lease agreement property");
-
+        // RentalInfo is present on lease-agreement properties and on plain land
+        // (L/LB) flagged "rented out to others" — both are valid sources.
         var info = property.RentalInfo
             ?? throw new InvalidOperationException($"Rental info not found for property {command.PropertyId}");
 

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/CreateReferenceFromMethod/CreateReferenceFromMethodCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/CreateReferenceFromMethod/CreateReferenceFromMethodCommand.cs
@@ -1,0 +1,19 @@
+using Appraisal.Application.Configurations;
+using Appraisal.Application.Features.PricingAnalysis.CreateOrGetReference;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.PricingAnalysis.CreateReferenceFromMethod;
+
+/// <summary>
+/// Creates a reference PricingAnalysis by deep-cloning an existing Cost-approach method
+/// (WQS / SaleGrid / DirectComparison) into a new "Market" approach, optionally overriding
+/// the land area. Idempotent: returns the existing reference if one already exists for the anchor.
+/// </summary>
+public record CreateReferenceFromMethodCommand(
+    PricingAnalysisSubjectType SubjectType,
+    Guid AnchorId,
+    Guid? HostMethodId,
+    Guid SourcePricingAnalysisId,
+    Guid SourceMethodId,
+    decimal? LandAreaOverride
+) : ICommand<CreateOrGetReferenceResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/CreateReferenceFromMethod/CreateReferenceFromMethodCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/CreateReferenceFromMethod/CreateReferenceFromMethodCommandHandler.cs
@@ -1,0 +1,76 @@
+using Appraisal.Application.Features.PricingAnalysis.CreateOrGetReference;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.PricingAnalysis.CreateReferenceFromMethod;
+
+/// <summary>
+/// Clones an existing Cost-approach method (WQS / SaleGrid / DirectComparison) into a
+/// new reference PricingAnalysis (IncomeLandRef), optionally overriding the land area.
+/// Idempotent: if a reference already exists for (SubjectType, AnchorId, null), returns it.
+/// </summary>
+public class CreateReferenceFromMethodCommandHandler(
+    IPricingAnalysisRepository repository
+) : ICommandHandler<CreateReferenceFromMethodCommand, CreateOrGetReferenceResult>
+{
+    private static readonly HashSet<string> AllowedSourceMethodTypes =
+        new(StringComparer.OrdinalIgnoreCase) { "WQS", "SaleGrid", "DirectComparison" };
+
+    public async Task<CreateOrGetReferenceResult> Handle(
+        CreateReferenceFromMethodCommand command,
+        CancellationToken cancellationToken)
+    {
+        // Guard: this endpoint is land-copy-specific
+        if (command.SubjectType != PricingAnalysisSubjectType.IncomeLandRef)
+            throw new InvalidOperationException(
+                $"CreateReferenceFromMethod only supports SubjectType=IncomeLandRef; got {command.SubjectType}.");
+
+        // Idempotent: return existing reference without re-cloning
+        var existing = await repository.FindReferenceAsync(
+            command.SubjectType,
+            command.AnchorId,
+            anchorRefKey: null,
+            cancellationToken);
+
+        if (existing is not null)
+        {
+            var existingMarket = existing.Approaches.FirstOrDefault(a => a.ApproachType == "Market");
+            return new CreateOrGetReferenceResult(
+                existing.Id,
+                existingMarket?.Id ?? Guid.Empty,
+                WasCreated: false);
+        }
+
+        // Load the source PA (must include all data to deep-clone)
+        var sourcePa = await repository.GetByIdWithAllDataAsync(
+            command.SourcePricingAnalysisId, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"Source PricingAnalysis {command.SourcePricingAnalysisId} not found.");
+
+        // Find the source method by id across all its approaches
+        var sourceMethod = sourcePa.Approaches
+            .SelectMany(a => a.Methods)
+            .FirstOrDefault(m => m.Id == command.SourceMethodId)
+            ?? throw new InvalidOperationException(
+                $"Source method {command.SourceMethodId} not found in PricingAnalysis {command.SourcePricingAnalysisId}.");
+
+        // Guard: source must be a market-comparison method type
+        if (!AllowedSourceMethodTypes.Contains(sourceMethod.MethodType))
+            throw new InvalidOperationException(
+                $"Source method type '{sourceMethod.MethodType}' is not allowed for cloning. " +
+                $"Expected one of: {string.Join(", ", AllowedSourceMethodTypes)}.");
+
+        // Create the reference PA with the cloned method
+        var pa = Domain.Appraisals.PricingAnalysis.CreateReferenceFromMethod(
+            command.SubjectType,
+            command.AnchorId,
+            command.HostMethodId,
+            sourceMethod,
+            command.LandAreaOverride);
+
+        await repository.AddAsync(pa, cancellationToken);
+
+        var marketApproach = pa.Approaches.First(a => a.ApproachType == "Market");
+
+        return new CreateOrGetReferenceResult(pa.Id, marketApproach.Id, WasCreated: true);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/CreateReferenceFromMethod/CreateReferenceFromMethodEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/CreateReferenceFromMethod/CreateReferenceFromMethodEndpoint.cs
@@ -1,0 +1,40 @@
+using Appraisal.Application.Features.PricingAnalysis.CreateOrGetReference;
+using Carter;
+using Mapster;
+using MediatR;
+
+namespace Appraisal.Application.Features.PricingAnalysis.CreateReferenceFromMethod;
+
+public class CreateReferenceFromMethodEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPost(
+                "/pricing-analysis/references/from-method",
+                async (
+                    CreateReferenceFromMethodRequest request,
+                    ISender sender,
+                    CancellationToken cancellationToken
+                ) =>
+                {
+                    var command = request.Adapt<CreateReferenceFromMethodCommand>();
+
+                    var result = await sender.Send(command, cancellationToken);
+
+                    var response = result.Adapt<CreateOrGetReferenceResponse>();
+
+                    return Results.Ok(response);
+                }
+            )
+            .WithName("CreateReferenceFromMethod")
+            .Produces<CreateOrGetReferenceResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Create a reference analysis by cloning an existing method")
+            .WithDescription(
+                "Deep-clones a Cost-approach method (WQS / SaleGrid / DirectComparison) into a new " +
+                "IncomeLandRef reference PricingAnalysis, optionally overriding the land area. " +
+                "Idempotent: returns the existing reference if one already exists for the anchor.")
+            .WithTags("PricingAnalysis");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/CreateReferenceFromMethod/CreateReferenceFromMethodRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/CreateReferenceFromMethod/CreateReferenceFromMethodRequest.cs
@@ -1,0 +1,13 @@
+namespace Appraisal.Application.Features.PricingAnalysis.CreateReferenceFromMethod;
+
+/// <summary>
+/// HTTP request body for POST /pricing-analysis/references/from-method.
+/// </summary>
+public record CreateReferenceFromMethodRequest(
+    PricingAnalysisSubjectType SubjectType,
+    Guid AnchorId,
+    Guid? HostMethodId,
+    Guid SourcePricingAnalysisId,
+    Guid SourceMethodId,
+    decimal? LandAreaOverride = null
+);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/DeletePricingAnalysisReference/DeletePricingAnalysisReferenceCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/DeletePricingAnalysisReference/DeletePricingAnalysisReferenceCommand.cs
@@ -1,0 +1,13 @@
+using Appraisal.Application.Configurations;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.PricingAnalysis.DeletePricingAnalysisReference;
+
+/// <summary>
+/// Deletes a market-reference PricingAnalysis by its id (used by the reference list / group
+/// References section). Guarded to reference subtypes only — property-group / project-model
+/// valuation analyses are managed via their own anchors, not this endpoint.
+/// </summary>
+public record DeletePricingAnalysisReferenceCommand(
+    Guid PricingAnalysisId
+) : ICommand<DeletePricingAnalysisReferenceResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/DeletePricingAnalysisReference/DeletePricingAnalysisReferenceCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/DeletePricingAnalysisReference/DeletePricingAnalysisReferenceCommandHandler.cs
@@ -1,0 +1,34 @@
+using Appraisal.Domain.Appraisals;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.PricingAnalysis.DeletePricingAnalysisReference;
+
+public class DeletePricingAnalysisReferenceCommandHandler(
+    IPricingAnalysisRepository repository
+) : ICommandHandler<DeletePricingAnalysisReferenceCommand, DeletePricingAnalysisReferenceResult>
+{
+    public async Task<DeletePricingAnalysisReferenceResult> Handle(
+        DeletePricingAnalysisReferenceCommand command,
+        CancellationToken cancellationToken)
+    {
+        var pa = await repository.GetByIdAsync(command.PricingAnalysisId, cancellationToken);
+
+        // Idempotent: already gone.
+        if (pa is null)
+            return new DeletePricingAnalysisReferenceResult(true);
+
+        // Guard: only reference analyses may be deleted here. PropertyGroup / ProjectModel
+        // valuation analyses are owned by their anchors and cleaned up via those paths.
+        if (pa.SubjectType is PricingAnalysisSubjectType.PropertyGroup
+            or PricingAnalysisSubjectType.ProjectModel)
+        {
+            throw new InvalidOperationException(
+                "Only market-reference analyses can be deleted via this endpoint.");
+        }
+
+        // Remove the reference PA — children (approaches/methods/comparables/scores/…) cascade at the DB.
+        await repository.DeleteAsync(pa, cancellationToken);
+
+        return new DeletePricingAnalysisReferenceResult(true);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/DeletePricingAnalysisReference/DeletePricingAnalysisReferenceEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/DeletePricingAnalysisReference/DeletePricingAnalysisReferenceEndpoint.cs
@@ -1,0 +1,25 @@
+using Carter;
+using MediatR;
+
+namespace Appraisal.Application.Features.PricingAnalysis.DeletePricingAnalysisReference;
+
+public class DeletePricingAnalysisReferenceEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapDelete("/pricing-analysis/{id:guid}",
+            async (Guid id, ISender sender, CancellationToken cancellationToken) =>
+            {
+                await sender.Send(new DeletePricingAnalysisReferenceCommand(id), cancellationToken);
+                return Results.NoContent();
+            })
+            .WithName("DeletePricingAnalysisReference")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .WithSummary("Delete a market-reference pricing analysis")
+            .WithDescription(
+                "Deletes a reference PricingAnalysis (and its cascade). Reference subtypes only — " +
+                "property-group / project-model valuation analyses are rejected.")
+            .WithTags("PricingAnalysis");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/DeletePricingAnalysisReference/DeletePricingAnalysisReferenceResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/DeletePricingAnalysisReference/DeletePricingAnalysisReferenceResult.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.PricingAnalysis.DeletePricingAnalysisReference;
+
+public record DeletePricingAnalysisReferenceResult(bool Success);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveLeaseholdAnalysis/SaveLeaseholdAnalysisCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveLeaseholdAnalysis/SaveLeaseholdAnalysisCommandHandler.cs
@@ -84,6 +84,14 @@ public class SaveLeaseholdAnalysisCommandHandler(
         var propertyData = await propertyDataService.GetPropertyDataAsync(
             pricingAnalysis.AnchorId!.Value, cancellationToken);
 
+        // Require at least one rental-bearing property (a lease-agreement property,
+        // or plain land rented out to others) rather than silently producing an
+        // all-zero result.
+        if (propertyData.ContractSchedule.Count == 0)
+            throw new BadRequestException(
+                "Leasehold analysis requires at least one property with a rental schedule "
+                + "(a lease-agreement property, or land rented out to others) in the group.");
+
         // Build appraisal schedule and map to leasehold record type
         var sharedSchedule = PricingPropertyDataService.BuildAppraisalSchedule(
             propertyData.ContractSchedule, propertyData.AppointmentDate);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveProfitRentAnalysis/SaveProfitRentAnalysisCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveProfitRentAnalysis/SaveProfitRentAnalysisCommandHandler.cs
@@ -66,6 +66,14 @@ public class SaveProfitRentAnalysisCommandHandler(
         var propertyData = await propertyDataService.GetPropertyDataAsync(
             pricingAnalysis.AnchorId!.Value, cancellationToken);
 
+        // Require at least one rental-bearing property (a lease-agreement property,
+        // or plain land rented out to others) rather than silently producing an
+        // all-zero result.
+        if (propertyData.ContractSchedule.Count == 0)
+            throw new BadRequestException(
+                "ProfitRent analysis requires at least one property with a rental schedule "
+                + "(a lease-agreement property, or land rented out to others) in the group.");
+
         // Build appraisal schedule
         var schedule = PricingPropertyDataService.BuildAppraisalSchedule(
             propertyData.ContractSchedule, propertyData.AppointmentDate);

--- a/Modules/Appraisal/Appraisal/Application/Services/PricingPropertyDataService.cs
+++ b/Modules/Appraisal/Appraisal/Application/Services/PricingPropertyDataService.cs
@@ -95,7 +95,10 @@ public class PricingPropertyDataService(
             .Where(p => propertyIds.Contains(p.Id))
             .ToList();
 
-        // Rental schedule from contract entries
+        // Rental schedule from contract entries — sourced from any rental-bearing
+        // property in the group. RentalInfo is attached only to lease-agreement
+        // properties and to plain land (L/LB) flagged "rented out to others",
+        // so a mixed group only needs at least one such property.
         var contractSchedule = groupProperties
             .Where(p => p.RentalInfo is not null)
             .SelectMany(p => p.RentalInfo!.ScheduleEntries)

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/Appraisal.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/Appraisal.cs
@@ -501,9 +501,13 @@ public class Appraisal : Aggregate<Guid>
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(groupName);
 
-        var groupNumber = _groups.Count + 1;
-        var group = PropertyGroup.Create(Id, groupNumber, groupName, description);
+        // Provisional number (count + 1); ResequenceGroups reassigns it and uses it as the
+        // tie-breaker so this new, not-yet-saved group (null CreatedAt) sorts last.
+        var group = PropertyGroup.Create(Id, _groups.Count + 1, groupName, description);
         _groups.Add(group);
+
+        // Order by creation time and reapply group numbers by order
+        ResequenceGroups();
 
         return group;
     }
@@ -552,8 +556,25 @@ public class Appraisal : Aggregate<Guid>
 
         _groups.Remove(group);
 
-        // Resequence remaining groups
-        for (var i = 0; i < _groups.Count; i++) _groups[i].UpdateGroupNumber(i + 1);
+        // Order by creation time and reapply group numbers by order
+        ResequenceGroups();
+    }
+
+    /// <summary>
+    /// Order groups by creation time and reapply contiguous group numbers (1..n).
+    /// A not-yet-saved group has a null CreatedAt and is treated as newest (sorted last,
+    /// since CreateGroup gives it a provisional number of _groups.Count + 1).
+    /// The current GroupNumber is the tie-breaker, keeping the resequence stable (it only
+    /// compacts the numbering and preserves the existing relative order on equal timestamps).
+    /// </summary>
+    private void ResequenceGroups()
+    {
+        var ordered = _groups
+            .OrderBy(g => g.CreatedAt ?? DateTime.MaxValue)
+            .ThenBy(g => g.GroupNumber)
+            .ToList();
+
+        for (var i = 0; i < ordered.Count; i++) ordered[i].UpdateGroupNumber(i + 1);
     }
 
     /// <summary>

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysis.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysis.cs
@@ -130,6 +130,57 @@ public class PricingAnalysis : Aggregate<Guid>
         };
     }
 
+    /// <summary>
+    /// Creates a reference PricingAnalysis by deep-cloning a source method into a new "Market" approach.
+    /// The clone is fully independent — editing it never touches the source.
+    /// </summary>
+    /// <param name="subjectType">One of the Ref subtypes (MachineryCostRef…ProfitRentRef). Must not be PropertyGroup/ProjectModel.</param>
+    /// <param name="anchorId">Owning entity id for this reference.</param>
+    /// <param name="hostMethodId">PricingAnalysisMethod that logically owns the field. Used for cleanup.</param>
+    /// <param name="sourceMethod">The Cost-approach method to clone (WQS/SaleGrid/DirectComparison).</param>
+    /// <param name="landAreaOverride">When set, overrides the cloned method's FinalValue.LandArea to this value while preserving LandValue.</param>
+    public static PricingAnalysis CreateReferenceFromMethod(
+        PricingAnalysisSubjectType subjectType,
+        Guid anchorId,
+        Guid? hostMethodId,
+        PricingAnalysisMethod sourceMethod,
+        decimal? landAreaOverride = null)
+    {
+        if (subjectType is PricingAnalysisSubjectType.PropertyGroup or PricingAnalysisSubjectType.ProjectModel)
+            throw new ArgumentException(
+                "Use CreateForPropertyGroup / CreateForProjectModel for non-reference subject types.",
+                nameof(subjectType));
+
+        if (anchorId == Guid.Empty)
+            throw new ArgumentException("AnchorId must not be empty.", nameof(anchorId));
+
+        var pa = new PricingAnalysis
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectType = subjectType,
+            AnchorId = anchorId,
+            AnchorRefKey = null,
+            HostMethodId = hostMethodId,
+            Status = "Draft"
+        };
+
+        var approach = PricingAnalysisApproach.Create(pa.Id, "Market");
+        pa._approaches.Add(approach);
+
+        var clonedMethod = approach.AttachClonedMethod(sourceMethod);
+
+        // Override land area when a partial-land value is specified (DCF non-HBU land reference).
+        // Keep the existing LandValue; only update LandArea.
+        if (landAreaOverride.HasValue && clonedMethod.FinalValue is not null)
+        {
+            clonedMethod.FinalValue.SetLandAreaValues(
+                landAreaOverride.Value,
+                clonedMethod.FinalValue.LandValue ?? 0m);
+        }
+
+        return pa;
+    }
+
     // ── Approach management ───────────────────────────────────────────────────
 
     public PricingAnalysisApproach AddApproach(string approachType, decimal? weight = null)

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysisApproach.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysisApproach.cs
@@ -54,6 +54,18 @@ public class PricingAnalysisApproach : Entity<Guid>
         return clone;
     }
 
+    /// <summary>
+    /// Clones <paramref name="source"/> into this approach and returns the cloned method.
+    /// Used by <see cref="PricingAnalysis.CreateReferenceFromMethod"/> to attach a deep-copied
+    /// method without going through the factory guard in <see cref="AddMethod"/>.
+    /// </summary>
+    public PricingAnalysisMethod AttachClonedMethod(PricingAnalysisMethod source)
+    {
+        var clone = PricingAnalysisMethod.CloneForApproach(source, Id);
+        _methods.Add(clone);
+        return clone;
+    }
+
     public PricingAnalysisMethod AddMethod(string methodType, string status = "Selected")
     {
         var method = PricingAnalysisMethod.Create(Id, methodType, status);


### PR DESCRIPTION
## Summary
Migration-free Appraisal read/domain enhancements (no schema changes — `AppraisalDbContextModelSnapshot` untouched).

- **WQS Market Reference**: `CreateReferenceFromMethod` / `DeletePricingAnalysisReference` (saved reference anchored to non-property fields), plus leasehold / profit-rent analysis save updates and `PricingPropertyDataService`.
- **Rental / lease reads**: `GetRentalInfo`, `GetRentalSchedule`, `GetLeaseAgreement`, `GetPropertyGroupById`, `UpdateRentalInfo`, `UpdateLeaseAgreement`.
- **Property-group resequence**: `Appraisal.ResequenceGroups` (orders groups by `CreatedAt`); `vw_PropertyGroupDetail` view update.
- Monitoring test adapted for the new `ICurrentUserService.UserCode` member (interface change lands in #224).

## Test
`dotnet build` — succeeds (0 errors). No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)