### PR TITLE
feat(validation): harden command/query validators across modules

### DIFF
--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveHypothesisAnalysis/SaveHypothesisAnalysisCommandValidator.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveHypothesisAnalysis/SaveHypothesisAnalysisCommandValidator.cs
@@ -7,7 +7,7 @@ namespace Appraisal.Application.Features.PricingAnalysis.SaveHypothesisAnalysis;
 
 public class SaveHypothesisAnalysisCommandValidator : AbstractValidator<SaveHypothesisAnalysisCommand>
 {
-    private const int MaxRemarkLength = 2000;
+    private const int MaxRemarkLength = 4000;
 
     public SaveHypothesisAnalysisCommandValidator()
     {

--- a/Modules/Auth/Auth/Application/Features/Companies/CreateCompany/CreateCompanyCommandValidator.cs
+++ b/Modules/Auth/Auth/Application/Features/Companies/CreateCompany/CreateCompanyCommandValidator.cs
@@ -14,5 +14,6 @@ public class CreateCompanyCommandValidator : AbstractValidator<CreateCompanyComm
         RuleFor(x => x.City).MaximumLength(100);
         RuleFor(x => x.Province).MaximumLength(100);
         RuleFor(x => x.PostalCode).MaximumLength(20);
+        RuleFor(x => x.ContactPerson).MaximumLength(200);
     }
 }

--- a/Modules/Auth/Auth/Application/Features/Companies/UpdateCompany/UpdateCompanyCommandValidator.cs
+++ b/Modules/Auth/Auth/Application/Features/Companies/UpdateCompany/UpdateCompanyCommandValidator.cs
@@ -15,6 +15,7 @@ public class UpdateCompanyCommandValidator : AbstractValidator<UpdateCompanyComm
         RuleFor(x => x.City).MaximumLength(100);
         RuleFor(x => x.Province).MaximumLength(100);
         RuleFor(x => x.PostalCode).MaximumLength(20);
+        RuleFor(x => x.ContactPerson).MaximumLength(200);
         RuleFor(x => x.BankAccountNo).MaximumLength(20);
         RuleFor(x => x.BankAccountName).MaximumLength(200);
     }

--- a/Modules/Auth/Auth/Application/Features/Users/UpdateUser/UpdateUserCommandValidator.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/UpdateUser/UpdateUserCommandValidator.cs
@@ -8,7 +8,7 @@ public class UpdateUserCommandValidator : AbstractValidator<UpdateUserCommand>
     {
         RuleFor(x => x.FirstName).NotEmpty().MaximumLength(100);
         RuleFor(x => x.LastName).NotEmpty().MaximumLength(100);
-        RuleFor(x => x.Position).MaximumLength(200);
-        RuleFor(x => x.Department).MaximumLength(200);
+        RuleFor(x => x.Position).MaximumLength(100);
+        RuleFor(x => x.Department).MaximumLength(100);
     }
 }

--- a/Modules/Document/Document/Application/Features/Documents/UploadDocument/UploadDocumentCommandValidator.cs
+++ b/Modules/Document/Document/Application/Features/Documents/UploadDocument/UploadDocumentCommandValidator.cs
@@ -35,8 +35,8 @@ public class UploadDocumentCommandValidator : AbstractValidator<UploadDocumentCo
         RuleFor(x => x.DocumentType)
             .NotEmpty()
             .WithMessage("Document type is required")
-            .MaximumLength(50)
-            .WithMessage("Document type cannot exceed 50 characters");
+            .MaximumLength(10)
+            .WithMessage("Document type cannot exceed 10 characters");
 
         // RuleFor(x => x.DocumentCategory)
         //     .NotEmpty()

--- a/Modules/Integration/Integration/Application/Features/AppraisalRequests/CreateRequest/CreateRequestCommandValidator.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalRequests/CreateRequest/CreateRequestCommandValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+using Integration.Application.Validation;
+
+namespace Integration.Application.Features.AppraisalRequests.CreateRequest;
+
+public class CreateRequestCommandValidator : AbstractValidator<CreateRequestCommand>
+{
+    public CreateRequestCommandValidator()
+    {
+        RuleFor(x => x.Purpose).NotEmpty().MaximumLength(10);
+        RuleFor(x => x.Channel).NotEmpty().MaximumLength(10);
+        RuleFor(x => x.Priority).NotEmpty().MaximumLength(255);
+        RuleFor(x => x.ExternalCaseKey).MaximumLength(100);
+
+        RuleFor(x => x.Requestor).NotNull().SetValidator(new UserInfoDtoValidator());
+        RuleFor(x => x.Creator).NotNull().SetValidator(new UserInfoDtoValidator());
+
+        RuleFor(x => x.Detail!).SetValidator(new RequestDetailDtoValidator());
+
+        RuleForEach(x => x.Customers).SetValidator(new RequestCustomerDtoValidator());
+        RuleForEach(x => x.Properties).SetValidator(new RequestPropertyDtoValidator());
+        RuleForEach(x => x.Titles).SetValidator(new RequestTitleDtoValidator());
+        RuleForEach(x => x.Documents).SetValidator(new RequestDocumentDtoValidator());
+        RuleForEach(x => x.Comments).SetValidator(new RequestCommentDtoValidator());
+    }
+}

--- a/Modules/Integration/Integration/Application/Features/AppraisalRequests/ResubmitRequest/ResubmitRequestCommandValidator.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalRequests/ResubmitRequest/ResubmitRequestCommandValidator.cs
@@ -1,0 +1,35 @@
+using FluentValidation;
+using Integration.Application.Validation;
+
+namespace Integration.Application.Features.AppraisalRequests.ResubmitRequest;
+
+public class ResubmitRequestCommandValidator : AbstractValidator<ResubmitRequestCommand>
+{
+    // Mode is parsed case-insensitively by the handler; null defaults to DataFix.
+    private static readonly string[] AllowedModes = { "DataFix", "Followup" };
+
+    public ResubmitRequestCommandValidator()
+    {
+        RuleFor(x => x.RequestId).NotEmpty();
+
+        RuleFor(x => x.Mode)
+            .Must(m => m is null || AllowedModes.Any(a => a.Equals(m, StringComparison.OrdinalIgnoreCase)))
+            .WithMessage("Mode must be 'DataFix' or 'Followup'.");
+
+        // Presence of these fields is mode-dependent and enforced in the handler (DataFix requires
+        // them). Here we only bound length/shape for whatever is supplied.
+        RuleFor(x => x.Purpose).MaximumLength(10);
+        RuleFor(x => x.Channel).MaximumLength(10);
+        RuleFor(x => x.Priority).MaximumLength(255);
+
+        RuleFor(x => x.Requestor!).SetValidator(new UserInfoDtoValidator());
+        RuleFor(x => x.Creator!).SetValidator(new UserInfoDtoValidator());
+
+        RuleFor(x => x.Detail!).SetValidator(new RequestDetailDtoValidator());
+
+        RuleForEach(x => x.Customers).SetValidator(new RequestCustomerDtoValidator());
+        RuleForEach(x => x.Properties).SetValidator(new RequestPropertyDtoValidator());
+        RuleForEach(x => x.Titles).SetValidator(new RequestTitleDtoValidator());
+        RuleForEach(x => x.Documents).SetValidator(new RequestDocumentDtoValidator());
+    }
+}

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQueryValidators.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQueryValidators.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace Integration.Application.Features.AppraisalResults.GetAppraisalResult;
+
+public class GetAppraisalResultByNumberQueryValidator : AbstractValidator<GetAppraisalResultByNumberQuery>
+{
+    public GetAppraisalResultByNumberQueryValidator()
+    {
+        RuleFor(x => x.AppraisalNumber).NotEmpty().MaximumLength(50);
+    }
+}
+
+public class GetAppraisalResultsByCaseKeyQueryValidator : AbstractValidator<GetAppraisalResultsByCaseKeyQuery>
+{
+    public GetAppraisalResultsByCaseKeyQueryValidator()
+    {
+        RuleFor(x => x.ExternalCaseKey).NotEmpty().MaximumLength(100);
+    }
+}

--- a/Modules/Integration/Integration/Application/Features/Appraisals/GetAppraisalStatus/GetAppraisalStatusQueryValidator.cs
+++ b/Modules/Integration/Integration/Application/Features/Appraisals/GetAppraisalStatus/GetAppraisalStatusQueryValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace Integration.Application.Features.Appraisals.GetAppraisalStatus;
+
+public class GetAppraisalStatusQueryValidator : AbstractValidator<GetAppraisalStatusQuery>
+{
+    public GetAppraisalStatusQueryValidator()
+    {
+        RuleFor(x => x.AppraisalNumber).NotEmpty().MaximumLength(50);
+    }
+}

--- a/Modules/Integration/Integration/Application/Features/Parameters/GetParameters/GetParametersQueryValidator.cs
+++ b/Modules/Integration/Integration/Application/Features/Parameters/GetParameters/GetParametersQueryValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace Integration.Application.Features.Parameters.GetParameters;
+
+public class GetParametersQueryValidator : AbstractValidator<GetParametersQuery>
+{
+    public GetParametersQueryValidator()
+    {
+        When(x => x.Groups is not null, () =>
+        {
+            RuleFor(x => x.Groups!.Count).LessThanOrEqualTo(50)
+                .WithMessage("At most 50 parameter groups can be requested at once.");
+            RuleForEach(x => x.Groups).NotEmpty().MaximumLength(100);
+        });
+    }
+}

--- a/Modules/Integration/Integration/Application/Features/Quotations/ApproveQuotation/ApproveQuotationCommandValidator.cs
+++ b/Modules/Integration/Integration/Application/Features/Quotations/ApproveQuotation/ApproveQuotationCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace Integration.Application.Features.Quotations.ApproveQuotation;
+
+public class ApproveQuotationCommandValidator : AbstractValidator<ApproveQuotationCommand>
+{
+    public ApproveQuotationCommandValidator()
+    {
+        RuleFor(x => x.QuotationId).NotEmpty();
+        // ApprovalReason is free text with no DB column to mirror; boundary cap.
+        RuleFor(x => x.ApprovalReason).MaximumLength(4000);
+    }
+}

--- a/Modules/Integration/Integration/Application/Features/UploadSessions/CreateUploadSession/CreateUploadSessionCommandValidator.cs
+++ b/Modules/Integration/Integration/Application/Features/UploadSessions/CreateUploadSession/CreateUploadSessionCommandValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace Integration.Application.Features.UploadSessions.CreateUploadSession;
+
+public class CreateUploadSessionCommandValidator : AbstractValidator<CreateUploadSessionCommand>
+{
+    public CreateUploadSessionCommandValidator()
+    {
+        // ClientReference / ExternalCaseKey have no DB length to mirror; these are boundary caps.
+        RuleFor(x => x.ClientReference).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.ExternalCaseKey).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.UserAgent).MaximumLength(512);
+        RuleFor(x => x.IpAddress).MaximumLength(45); // IPv6 max textual length
+    }
+}

--- a/Modules/Integration/Integration/Application/Features/WebhookDeliveries/GetWebhookDeliveries/GetWebhookDeliveriesQueryValidator.cs
+++ b/Modules/Integration/Integration/Application/Features/WebhookDeliveries/GetWebhookDeliveries/GetWebhookDeliveriesQueryValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using Integration.Domain.WebhookDeliveries;
+
+namespace Integration.Application.Features.WebhookDeliveries.GetWebhookDeliveries;
+
+public class GetWebhookDeliveriesQueryValidator : AbstractValidator<GetWebhookDeliveriesQuery>
+{
+    private static readonly string[] AllowedStatuses =
+        { DeliveryStatus.Pending, DeliveryStatus.Delivered, DeliveryStatus.Failed };
+
+    public GetWebhookDeliveriesQueryValidator()
+    {
+        // Handler converts to the 0-based PaginationRequest via PageNumber - 1, so callers send 1-based.
+        RuleFor(x => x.PageNumber).GreaterThanOrEqualTo(1);
+        RuleFor(x => x.PageSize).InclusiveBetween(1, 200);
+
+        RuleFor(x => x.Status)
+            .Must(s => s is null || AllowedStatuses.Any(a => a.Equals(s, StringComparison.OrdinalIgnoreCase)))
+            .WithMessage("Status must be one of: Pending, Delivered, Failed.");
+
+        RuleFor(x => x.EventType).MaximumLength(100);
+    }
+}

--- a/Modules/Integration/Integration/Application/Validation/RequestContractDtoValidators.cs
+++ b/Modules/Integration/Integration/Application/Validation/RequestContractDtoValidators.cs
@@ -1,0 +1,209 @@
+using FluentValidation;
+using Request.Contracts.RequestDocuments.Dto;
+using Request.Contracts.Requests.Dtos;
+
+namespace Integration.Application.Validation;
+
+// Reusable validators for the shared Request contract DTOs that arrive over the external
+// Integration API. Lengths mirror the Request module's EF HasMaxLength configuration so an
+// over-length value is rejected with a clean 400 at the boundary instead of surfacing as a
+// DbUpdateException (500) at SaveChanges. A few free-text fields are nvarchar(max) in the DB
+// (no column ceiling to mirror); those use a generous boundary cap of MaxFreeText, marked below.
+internal static class ContractLengths
+{
+    // Boundary cap for fields that are nvarchar(max) in the DB (Comment, TitleDetail, title Notes).
+    public const int MaxFreeText = 4000;
+}
+
+public class UserInfoDtoValidator : AbstractValidator<UserInfoDto>
+{
+    public UserInfoDtoValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty().MaximumLength(10);
+        RuleFor(x => x.Username).NotEmpty().MaximumLength(100);
+    }
+}
+
+public class AddressDtoValidator : AbstractValidator<AddressDto>
+{
+    public AddressDtoValidator()
+    {
+        RuleFor(x => x.HouseNumber).MaximumLength(30);
+        RuleFor(x => x.ProjectName).MaximumLength(100);
+        RuleFor(x => x.Moo).MaximumLength(50);
+        RuleFor(x => x.Soi).MaximumLength(50);
+        RuleFor(x => x.Road).MaximumLength(50);
+        RuleFor(x => x.SubDistrict).MaximumLength(10);
+        RuleFor(x => x.District).MaximumLength(10);
+        RuleFor(x => x.Province).MaximumLength(10);
+        RuleFor(x => x.Postcode).MaximumLength(10);
+    }
+}
+
+public class ContactDtoValidator : AbstractValidator<ContactDto>
+{
+    public ContactDtoValidator()
+    {
+        RuleFor(x => x.ContactPersonName).MaximumLength(100);
+        RuleFor(x => x.ContactPersonPhone).MaximumLength(100);
+        RuleFor(x => x.DealerCode).MaximumLength(20);
+    }
+}
+
+public class AppointmentDtoValidator : AbstractValidator<AppointmentDto>
+{
+    public AppointmentDtoValidator()
+    {
+        RuleFor(x => x.AppointmentLocation).MaximumLength(4000);
+    }
+}
+
+public class FeeDtoValidator : AbstractValidator<FeeDto>
+{
+    public FeeDtoValidator()
+    {
+        RuleFor(x => x.FeePaymentType).MaximumLength(10);
+        RuleFor(x => x.FeeNotes).MaximumLength(4000);
+    }
+}
+
+public class LoanDetailDtoValidator : AbstractValidator<LoanDetailDto>
+{
+    public LoanDetailDtoValidator()
+    {
+        RuleFor(x => x.BankingSegment).MaximumLength(10);
+        RuleFor(x => x.LoanApplicationNumber).MaximumLength(20);
+    }
+}
+
+public class RequestDetailDtoValidator : AbstractValidator<RequestDetailDto>
+{
+    public RequestDetailDtoValidator()
+    {
+        RuleFor(x => x.PrevAppraisalNumber).MaximumLength(20);
+
+        // SetValidator no-ops when the nested property is null (FluentValidation built-in).
+        RuleFor(x => x.LoanDetail!).SetValidator(new LoanDetailDtoValidator());
+        RuleFor(x => x.Address!).SetValidator(new AddressDtoValidator());
+        RuleFor(x => x.Contact!).SetValidator(new ContactDtoValidator());
+        RuleFor(x => x.Appointment!).SetValidator(new AppointmentDtoValidator());
+        RuleFor(x => x.Fee!).SetValidator(new FeeDtoValidator());
+    }
+}
+
+public class RequestCustomerDtoValidator : AbstractValidator<RequestCustomerDto>
+{
+    public RequestCustomerDtoValidator()
+    {
+        RuleFor(x => x.Name).MaximumLength(80);
+        RuleFor(x => x.ContactNumber).MaximumLength(100);
+    }
+}
+
+public class RequestPropertyDtoValidator : AbstractValidator<RequestPropertyDto>
+{
+    public RequestPropertyDtoValidator()
+    {
+        RuleFor(x => x.PropertyType).MaximumLength(10);
+        RuleFor(x => x.BuildingType).MaximumLength(10);
+    }
+}
+
+public class RequestTitleDocumentDtoValidator : AbstractValidator<RequestTitleDocumentDto>
+{
+    public RequestTitleDocumentDtoValidator()
+    {
+        RuleFor(x => x.DocumentType).MaximumLength(100);
+        RuleFor(x => x.FileName).MaximumLength(255);
+        RuleFor(x => x.Prefix).MaximumLength(50);
+        RuleFor(x => x.Notes).MaximumLength(500);
+        RuleFor(x => x.FilePath).MaximumLength(255);
+        RuleFor(x => x.Source).MaximumLength(10);
+        RuleFor(x => x.UploadedBy).MaximumLength(10);
+        RuleFor(x => x.UploadedByName).MaximumLength(100);
+    }
+}
+
+public class RequestTitleDtoValidator : AbstractValidator<RequestTitleDto>
+{
+    public RequestTitleDtoValidator()
+    {
+        RuleFor(x => x.CollateralType).NotEmpty().MaximumLength(10);
+
+        // TitleDeedInfo
+        RuleFor(x => x.TitleNumber).MaximumLength(200);
+        RuleFor(x => x.TitleType).MaximumLength(50);
+        RuleFor(x => x.TitleDetail).MaximumLength(ContractLengths.MaxFreeText); // nvarchar(max) in DB
+
+        // LandLocationInfo
+        RuleFor(x => x.BookNumber).MaximumLength(100);
+        RuleFor(x => x.PageNumber).MaximumLength(100);
+        RuleFor(x => x.LandParcelNumber).MaximumLength(100);
+        RuleFor(x => x.SurveyNumber).MaximumLength(100);
+        RuleFor(x => x.MapSheetNumber).MaximumLength(100);
+        RuleFor(x => x.Rawang).MaximumLength(100);
+        RuleFor(x => x.AerialMapName).MaximumLength(100);
+        RuleFor(x => x.AerialMapNumber).MaximumLength(100);
+
+        RuleFor(x => x.OwnerName).MaximumLength(500);
+
+        // VehicleInfo
+        RuleFor(x => x.VehicleType).MaximumLength(10);
+        RuleFor(x => x.VehicleLocation).MaximumLength(300);
+        RuleFor(x => x.VIN).MaximumLength(50);
+        RuleFor(x => x.LicensePlateNumber).MaximumLength(20);
+
+        // VesselInfo
+        RuleFor(x => x.VesselType).MaximumLength(10);
+        RuleFor(x => x.VesselLocation).MaximumLength(300);
+        RuleFor(x => x.HIN).MaximumLength(50);
+        RuleFor(x => x.VesselRegistrationNumber).MaximumLength(50);
+
+        // MachineInfo
+        RuleFor(x => x.RegistrationNumber).MaximumLength(50);
+        RuleFor(x => x.MachineType).MaximumLength(10);
+        RuleFor(x => x.InstallationStatus).MaximumLength(10);
+        RuleFor(x => x.InvoiceNumber).MaximumLength(20);
+
+        // BuildingInfo
+        RuleFor(x => x.BuildingType).MaximumLength(10);
+
+        // CondoInfo
+        RuleFor(x => x.CondoName).MaximumLength(100);
+        RuleFor(x => x.BuildingNumber).MaximumLength(100);
+        RuleFor(x => x.RoomNumber).MaximumLength(30);
+        RuleFor(x => x.FloorNumber).MaximumLength(10);
+
+        RuleFor(x => x.Notes).MaximumLength(ContractLengths.MaxFreeText); // nvarchar(max) in DB
+
+        RuleFor(x => x.TitleAddress!).SetValidator(new AddressDtoValidator());
+        RuleFor(x => x.DopaAddress!).SetValidator(new AddressDtoValidator());
+
+        RuleForEach(x => x.Documents).SetValidator(new RequestTitleDocumentDtoValidator());
+    }
+}
+
+public class RequestDocumentDtoValidator : AbstractValidator<RequestDocumentDto>
+{
+    public RequestDocumentDtoValidator()
+    {
+        RuleFor(x => x.DocumentType).NotEmpty().MaximumLength(10);
+        RuleFor(x => x.FileName).MaximumLength(255);
+        RuleFor(x => x.Prefix).MaximumLength(50);
+        RuleFor(x => x.Notes).MaximumLength(4000);
+        RuleFor(x => x.FilePath).MaximumLength(500);
+        RuleFor(x => x.Source).MaximumLength(10);
+        RuleFor(x => x.UploadedBy).MaximumLength(10);
+        RuleFor(x => x.UploadedByName).MaximumLength(100);
+    }
+}
+
+public class RequestCommentDtoValidator : AbstractValidator<RequestCommentDto>
+{
+    public RequestCommentDtoValidator()
+    {
+        RuleFor(x => x.Comment).NotEmpty().MaximumLength(ContractLengths.MaxFreeText); // nvarchar(max) in DB
+        RuleFor(x => x.CommentedBy).MaximumLength(10);
+        RuleFor(x => x.CommentedByName).MaximumLength(100);
+    }
+}

--- a/Modules/Integration/Integration/Domain/WebhookDeliveries/WebhookDelivery.cs
+++ b/Modules/Integration/Integration/Domain/WebhookDeliveries/WebhookDelivery.cs
@@ -28,6 +28,10 @@ public class WebhookDelivery : Entity<Guid>
         AttemptCount = 0;
     }
 
+    // Defensive cap on the outbound webhook body. Payload is internally generated, so this
+    // guards against pathological sizes rather than untrusted input; tune if event payloads grow.
+    public const int MaxPayloadLength = 1_000_000;
+
     public static WebhookDelivery Create(
         Guid subscriptionId,
         string eventType,
@@ -35,6 +39,11 @@ public class WebhookDelivery : Entity<Guid>
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(eventType);
         ArgumentException.ThrowIfNullOrWhiteSpace(payload);
+
+        if (payload.Length > MaxPayloadLength)
+            throw new ArgumentException(
+                $"Webhook payload exceeds the maximum allowed length of {MaxPayloadLength} characters.",
+                nameof(payload));
 
         return new WebhookDelivery(subscriptionId, eventType, payload);
     }

--- a/Shared/Shared/Behaviors/ValidationBehavior.cs
+++ b/Shared/Shared/Behaviors/ValidationBehavior.cs
@@ -1,11 +1,14 @@
 using FluentValidation;
 using MediatR;
-using Shared.CQRS;
 
 namespace Shared.Behaviors;
 
+// Validates any request (commands AND queries) that has registered validators. Requests without
+// a validator pass through (empty validator set). Note: this intentionally has no ICommand
+// constraint — IQuery requests must be validated too, and several query validators in the
+// codebase rely on this behavior running for IQuery.
 public class ValidationBehavior<TRequest, TResponse>(IEnumerable<IValidator<TRequest>> validators)
-    : IPipelineBehavior<TRequest, TResponse> where TRequest : ICommand<TResponse>
+    : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
 {
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next,
         CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
Part 1 of an 8-PR split of a large working tree. **Independent — can merge anytime.**

- Relax `ValidationBehavior` constraint from `ICommand` to `notnull` so **queries** are validated too (requests without a registered validator still pass through).
- Add Integration module validators: create/resubmit request, get appraisal result/status, get parameters, approve quotation, create upload session, get webhook deliveries, plus shared request-contract DTO validators.
- Add Auth (company create/update, user update) and Document upload length validators, and an Appraisal hypothesis validator.
- Defensive payload-size cap on `WebhookDelivery`.

## Test plan
- `dotnet build` of the full solution succeeds (0 errors).
- Smoke a validator-less query endpoint to confirm the behavior change doesn't break pass-through.

## Merge order
Independent. No prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)