### PR TITLE
fix(auth): seed COMPANY_MANAGE permission and gate company mutations

### DIFF
--- a/Modules/Auth/Auth/Application/Features/Companies/CreateCompany/CreateCompanyEndpoint.cs
+++ b/Modules/Auth/Auth/Application/Features/Companies/CreateCompany/CreateCompanyEndpoint.cs
@@ -15,6 +15,7 @@ public class CreateCompanyEndpoint : ICarterModule
             .Produces<CreateCompanyResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .WithSummary("Create Company")
-            .WithDescription("Create a new company");
+            .WithDescription("Create a new company")
+            .RequireAuthorization("CanManageCompanies");
     }
 }

--- a/Modules/Auth/Auth/Application/Features/Companies/DeleteCompany/DeleteCompanyEndpoint.cs
+++ b/Modules/Auth/Auth/Application/Features/Companies/DeleteCompany/DeleteCompanyEndpoint.cs
@@ -14,6 +14,7 @@ public class DeleteCompanyEndpoint : ICarterModule
             .Produces<DeleteCompanyResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .WithSummary("Delete Company")
-            .WithDescription("Soft delete a company");
+            .WithDescription("Soft delete a company")
+            .RequireAuthorization("CanManageCompanies");
     }
 }

--- a/Modules/Auth/Auth/Application/Features/Companies/UpdateCompany/UpdateCompanyEndpoint.cs
+++ b/Modules/Auth/Auth/Application/Features/Companies/UpdateCompany/UpdateCompanyEndpoint.cs
@@ -19,6 +19,7 @@ public class UpdateCompanyEndpoint : ICarterModule
             .Produces<UpdateCompanyResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .WithSummary("Update Company")
-            .WithDescription("Update an existing company including bank account details.");
+            .WithDescription("Update an existing company including bank account details.")
+            .RequireAuthorization("CanManageCompanies");
     }
 }

--- a/Modules/Auth/Auth/Infrastructure/Seed/AuthDataSeed.cs
+++ b/Modules/Auth/Auth/Infrastructure/Seed/AuthDataSeed.cs
@@ -651,7 +651,10 @@ public class AuthDataSeed(
             ("TEAM_MANAGE", "Manage Teams", "Create, update, and delete teams and team members", "Auth"),
             // Auth audit trail
             ("AUTH_AUDIT_VIEW", "View Auth Audit Trail",
-                "View the user/role/permission/group/team change history", "Auth")
+                "View the user/role/permission/group/team change history", "Auth"),
+            // Company maintenance
+            ("COMPANY_MANAGE", "Manage Companies",
+                "Create, update, and delete external appraisal companies", "Auth")
         };
 
         foreach (var (code, displayName, description, module) in seedPermissions)


### PR DESCRIPTION
## Problem

The `COMPANY_MANAGE` permission was referenced in two places but **never seeded**:
- Companies menu item `ViewPermissionCode` (`MenuSeedData.cs`)
- Auth policy `CanManageCompanies → COMPANY_MANAGE` (`AuthModule.cs`)

Because the permission row was never created, nobody could hold it — not even Admin (which auto-grants all *seeded* permissions). So the Companies admin menu item never appeared and the route always blocked.

## Changes

- **Seed `COMPANY_MANAGE`** in `AuthDataSeed.cs` `seedPermissions`. It's idempotent (`CodeExistsAsync`) and `SeedAdminRoleAsync` auto-grants it to Admin on startup re-seed. No EF migration needed (runtime seed data, not schema).
- **Gate company mutations** with `RequireAuthorization("CanManageCompanies")` on Create/Update/Delete endpoints so the backend enforces the policy, not just the UI. Read endpoints (`GetCompanies`, `GetCompanyById`, `GetEligibleCompanies`) intentionally stay ungated — they're shared with assignment dropdowns and company-overview enrichment.

## Companion PR

Frontend route-guard + response-wrapper fixes: immortalgky/collateral-appraisal-system-app#194

## Verification

1. Restart the API so the seeder creates `COMPANY_MANAGE` and grants it to Admin.
2. Log in as Admin → Companies menu item appears and the page opens.
3. As a user without `COMPANY_MANAGE`, the item is hidden and direct nav is blocked; create/update/delete return 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)