### PR TITLE
Add authentication event auditing for login/logout actions

### DIFF
--- a/Modules/Auth/Auth/Application/Controllers/OpenIddictController.cs
+++ b/Modules/Auth/Auth/Application/Controllers/OpenIddictController.cs
@@ -5,10 +5,11 @@ using Microsoft.AspNetCore.Authorization;
 using OpenIddict.Server.AspNetCore;
 using Auth.Application.Helpers;
 using Auth.Application.Services;
+using Auth.Domain.Auditing;
 
 namespace Auth.Application.Controllers;
 
-public class OpenIddictController(ITokenService tokenService) : Controller
+public class OpenIddictController(ITokenService tokenService, IAuthAuditWriter auditWriter) : Controller
 {
     [Authorize(AuthenticationSchemes = "Identity.Application")]
     [AllowAnonymous]
@@ -105,6 +106,14 @@ public class OpenIddictController(ITokenService tokenService) : Controller
     [HttpPost("~/connect/logout")]
     public async Task<IActionResult> Logout()
     {
+        // /connect/logout is anonymous and may be hit without an active session, so only
+        // audit when we actually have an authenticated user to attribute the logout to.
+        if (User.Identity?.IsAuthenticated == true)
+        {
+            Guid? userId = Guid.TryParse(User.FindFirst(ClaimTypes.NameIdentifier)?.Value, out var id) ? id : null;
+            await auditWriter.RecordAuthEventAsync(AuditAction.LoggedOut, userId, User.Identity?.Name);
+        }
+
         await HttpContext.SignOutAsync("Identity.Application");
         RefreshTokenCookieHelper.ClearRefreshTokenCookie(HttpContext);
 

--- a/Modules/Auth/Auth/Application/Services/AuthAuditWriter.cs
+++ b/Modules/Auth/Auth/Application/Services/AuthAuditWriter.cs
@@ -75,6 +75,29 @@ public class AuthAuditWriter(
         dbContext.AuthAuditLogs.Add(log);
     }
 
+    public async Task RecordAuthEventAsync(
+        AuditAction action,
+        Guid? userId,
+        string? username,
+        object? details = null,
+        CancellationToken cancellationToken = default)
+    {
+        var log = AuthAuditLog.Create(
+            occurredAt: dateTimeProvider.ApplicationNow,
+            actorUserId: userId,
+            actorName: username ?? "anonymous",
+            action: action,
+            entityType: AuditEntityType.User,
+            entityId: userId,
+            entityName: username,
+            changesJson: details is null ? null : JsonSerializer.Serialize(details, JsonOptions),
+            workstation: null,
+            ipAddress: httpContextAccessor.HttpContext?.Connection.RemoteIpAddress?.ToString());
+
+        dbContext.AuthAuditLogs.Add(log);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
     public void RecordAssignmentChange(
         AuditEntityType entityType,
         Guid entityId,

--- a/Modules/Auth/Auth/Application/Services/IAuthAuditWriter.cs
+++ b/Modules/Auth/Auth/Application/Services/IAuthAuditWriter.cs
@@ -38,4 +38,18 @@ public interface IAuthAuditWriter
         IEnumerable<string> before,
         IEnumerable<string> after,
         string setName);
+
+    /// <summary>
+    /// Records a self-action authentication event (login / failed login / logout) and
+    /// flushes it immediately. Unlike Record/RecordAssignmentChange, the actor is passed
+    /// explicitly (the principal is not yet established at login time) and this method
+    /// calls SaveChanges itself, since auth events have no surrounding transaction to
+    /// piggyback on. The audited entity is always the user (EntityType.User).
+    /// </summary>
+    Task RecordAuthEventAsync(
+        AuditAction action,
+        Guid? userId,
+        string? username,
+        object? details = null,
+        CancellationToken cancellationToken = default);
 }

--- a/Modules/Auth/Auth/Domain/Auditing/AuditAction.cs
+++ b/Modules/Auth/Auth/Domain/Auditing/AuditAction.cs
@@ -5,5 +5,8 @@ public enum AuditAction
     Created,
     Updated,
     Deleted,
-    AssignmentChanged
+    AssignmentChanged,
+    LoggedIn,
+    LoginFailed,
+    LoggedOut
 }

--- a/Modules/Auth/Auth/Pages/Account/Login.cshtml.cs
+++ b/Modules/Auth/Auth/Pages/Account/Login.cshtml.cs
@@ -1,5 +1,6 @@
 using Auth.Application.Configurations;
 using Auth.Application.Services;
+using Auth.Domain.Auditing;
 using Auth.Infrastructure.Configuration;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Options;
@@ -16,6 +17,7 @@ public class Login(
     ILogger<Login> logger,
     IDateTimeProvider dateTimeProvider,
     IPasswordPolicyProvider passwordPolicyProvider,
+    IAuthAuditWriter auditWriter,
     AuthDbContext dbContext)
     : PageModel
 {
@@ -53,12 +55,14 @@ public class Login(
         if (user is null)
         {
             logger.LogWarning("Login attempt for non-existent user: {Username}", Username);
+            await auditWriter.RecordAuthEventAsync(AuditAction.LoginFailed, null, Username, new { reason = "UserNotFound" });
             Error = "Invalid login attempt.";
             return Page();
         }
 
         if (!user.IsActive)
         {
+            await auditWriter.RecordAuthEventAsync(AuditAction.LoginFailed, user.Id, Username, new { reason = "Inactive" });
             Error = "This account is deactivated. Contact your administrator.";
             return Page();
         }
@@ -75,6 +79,7 @@ public class Login(
         if (!_ldapConfig.Enabled)
         {
             logger.LogWarning("LDAP user {Username} attempted login but LDAP is disabled", Username);
+            await auditWriter.RecordAuthEventAsync(AuditAction.LoginFailed, user.Id, Username, new { reason = "LdapDisabled" });
             Error = "Invalid login attempt.";
             return Page();
         }
@@ -83,6 +88,7 @@ public class Login(
         // SignInManager, so without this LDAP accounts would have no app-level brute-force throttle.
         if (await userManager.IsLockedOutAsync(user))
         {
+            await auditWriter.RecordAuthEventAsync(AuditAction.LoginFailed, user.Id, Username, new { reason = "LockedOut" });
             Error = "Account locked out.";
             return Page();
         }
@@ -92,6 +98,7 @@ public class Login(
         {
             await userManager.AccessFailedAsync(user);
             logger.LogWarning("LDAP auth failed for {Username}: {Error}", Username, ldapResult.ErrorMessage);
+            await auditWriter.RecordAuthEventAsync(AuditAction.LoginFailed, user.Id, Username, new { reason = "InvalidCredentials" });
             Error = "Invalid login attempt.";
             return Page();
         }
@@ -101,6 +108,7 @@ public class Login(
         await StampLastLoginAsync(user);
         await signInManager.SignInAsync(user, RememberMe);
         logger.LogInformation("User {Username} logged in via LDAP", Username);
+        await auditWriter.RecordAuthEventAsync(AuditAction.LoggedIn, user.Id, Username, new { source = "Ldap" });
         return Redirect(GetSafeRedirectUrl(user));
     }
 
@@ -112,15 +120,18 @@ public class Login(
             await EnforcePasswordExpiryAsync(user);
             await StampLastLoginAsync(user);
             logger.LogInformation("User {Username} logged in successfully", Username);
+            await auditWriter.RecordAuthEventAsync(AuditAction.LoggedIn, user.Id, Username, new { source = "Local" });
             return Redirect(GetSafeRedirectUrl(user));
         }
 
         if (result.IsLockedOut)
         {
+            await auditWriter.RecordAuthEventAsync(AuditAction.LoginFailed, user.Id, Username, new { reason = "LockedOut" });
             Error = "Account locked out.";
             return Page();
         }
 
+        await auditWriter.RecordAuthEventAsync(AuditAction.LoginFailed, user.Id, Username, new { reason = "InvalidCredentials" });
         Error = "Invalid login attempt.";
         return Page();
     }


### PR DESCRIPTION
## Summary
Adds comprehensive audit logging for authentication events (login, failed login, logout) to track user authentication activities with detailed context.

## Key Changes

- **New `RecordAuthEventAsync` method** in `IAuthAuditWriter` and `AuthAuditWriter`:
  - Async method that immediately persists audit events (unlike other audit methods that batch with transactions)
  - Accepts explicit actor information (userId/username) since principal may not be established at login time
  - Supports optional details object for contextual information (reason, source)
  - Automatically captures IP address from HTTP context

- **Extended `AuditAction` enum** with three new actions:
  - `LoggedIn`: Successful authentication
  - `LoginFailed`: Failed authentication attempt
  - `LoggedOut`: User logout

- **Login page auditing** (`Login.cshtml.cs`):
  - Records failed login attempts with specific reasons: UserNotFound, Inactive, LdapDisabled, LockedOut, InvalidCredentials
  - Records successful logins with source information (Ldap or Local)
  - Handles both LDAP and local password authentication flows

- **Logout auditing** (`OpenIddictController.cs`):
  - Records logout events only when user is authenticated (handles anonymous logout requests gracefully)
  - Extracts userId and username from claims for audit attribution

## Implementation Details

- Auth events are persisted immediately via `SaveChangesAsync` since they occur outside normal transaction boundaries
- Failed login attempts include a `reason` field to distinguish between different failure modes
- Successful logins include a `source` field to track authentication method
- Logout auditing is defensive—only records when an authenticated session exists
- All audit records capture IP address automatically from HTTP context

https://claude.ai/code/session_01QHUsPUpsqwCDWiUvaXo3k8