### PR TITLE
feat(as400): emit status-R collateral result on committee rejection

### DIFF
--- a/Modules/Collateral/Collateral/CollateralMasters/Consumers/AppraisalRejectedConsumer.cs
+++ b/Modules/Collateral/Collateral/CollateralMasters/Consumers/AppraisalRejectedConsumer.cs
@@ -1,0 +1,78 @@
+using Collateral.CollateralMasters.Models;
+using Collateral.Data;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using Shared.Messaging.Events;
+using Shared.Messaging.Filters;
+using Shared.Time;
+
+namespace Collateral.CollateralMasters.Consumers;
+
+/// <summary>
+/// Listens for <see cref="AppraisalRejectedIntegrationEvent"/> and spools a
+/// <see cref="PendingCollateralResult"/> row so the next <c>CollateralResultExportJob</c>
+/// run emits a status-R record to the AS400 Collateral Result interface.
+///
+/// Idempotency: InboxGuard deduplicates retried/concurrent delivery; the unique index on
+/// <c>PendingCollateralResults.AppraisalId</c> is a second-line guard.
+///
+/// HostCollateralId is NULL at this point — no CollateralEngagement exists before approval,
+/// so the AS400 collateral key cannot be resolved. The R row will be exported with a blank
+/// CCDCID field. See PendingCollateralResult for the full TODO note.
+/// </summary>
+public class AppraisalRejectedConsumer(
+    CollateralDbContext dbContext,
+    IDateTimeProvider dateTimeProvider,
+    ILogger<AppraisalRejectedConsumer> logger,
+    InboxGuard<CollateralDbContext> inboxGuard)
+    : IConsumer<AppraisalRejectedIntegrationEvent>
+{
+    public async Task Consume(ConsumeContext<AppraisalRejectedIntegrationEvent> context)
+    {
+        if (await inboxGuard.TryClaimAsync(context.MessageId, GetType().Name, context.CancellationToken))
+            return;
+
+        var msg = context.Message;
+        var ct = context.CancellationToken;
+
+        // Second-line idempotency beyond InboxGuard: a re-rejection of the same appraisal
+        // (route-back → re-review → reject again) arrives with a DIFFERENT MessageId, so InboxGuard
+        // does not dedupe it. Without this check the unique index on AppraisalId throws an unhandled
+        // DbUpdateException. First rejection wins; subsequent ones are acked as no-ops.
+        var alreadySpooled = await dbContext.PendingCollateralResults
+            .AnyAsync(p => p.AppraisalId == msg.AppraisalId, ct);
+        if (alreadySpooled)
+        {
+            logger.LogInformation(
+                "AppraisalRejectedConsumer: PendingCollateralResult already spooled for AppraisalId={AppraisalId} — skipping",
+                msg.AppraisalId);
+            await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
+            return;
+        }
+
+        logger.LogInformation(
+            "AppraisalRejectedConsumer: spooling R result for AppraisalId={AppraisalId} AppraisalNo={AppraisalNo}",
+            msg.AppraisalId, msg.AppraisalNo);
+
+        var rejectedAt = msg.RejectedAt == default
+            ? dateTimeProvider.ApplicationNow
+            : msg.RejectedAt;
+
+        // TODO: resolve HostCollateralId from a pre-approval master-link when available.
+        // For now, stored as null; the export emits a blank CCDCID field for R rows.
+        var pending = PendingCollateralResult.Create(
+            appraisalId: msg.AppraisalId,
+            appraisalNumber: msg.AppraisalNo ?? string.Empty,
+            hostCollateralId: null,
+            rejectedAt: rejectedAt);
+
+        dbContext.PendingCollateralResults.Add(pending);
+        await dbContext.SaveChangesAsync(ct);
+
+        await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
+
+        logger.LogInformation(
+            "AppraisalRejectedConsumer: spooled PendingCollateralResult {PendingId} for AppraisalId={AppraisalId}",
+            pending.Id, msg.AppraisalId);
+    }
+}

--- a/Modules/Workflow/Workflow/Workflow/Activities/ApprovalActivity.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/ApprovalActivity.cs
@@ -471,6 +471,46 @@ public class ApprovalActivity : WorkflowActivityBase
                     }
                 }
 
+                // Emit committee rejection event when decision == "reject".
+                // Consumer: Collateral module spools a PendingCollateralResult so the next
+                // export run emits a status-R record to the AS400 Collateral Result interface.
+                if (successOutput["decision"] is string rejDecision &&
+                    string.Equals(rejDecision, "reject", StringComparison.OrdinalIgnoreCase))
+                {
+                    var rejAppraisalId = ResolveAppraisalId(context.Variables);
+                    if (rejAppraisalId is not null)
+                    {
+                        var rejCommitteeCode = GetVariable<string>(context, $"{normalizedId}_committeeCode") ?? string.Empty;
+                        var rejCommitteeName = GetVariable<string>(context, $"{normalizedId}_committeeName");
+                        var rejAppraisalNo = context.WorkflowInstance.Variables.TryGetValue("appraisalNumber", out var rejNumObj)
+                            ? rejNumObj?.ToString()
+                            : null;
+
+                        _outbox.Publish(new AppraisalRejectedIntegrationEvent
+                        {
+                            AppraisalId = rejAppraisalId.Value,
+                            AppraisalNo = rejAppraisalNo,
+                            RejectedAt = _dateTimeProvider.ApplicationNow,
+                            RejectedBy = voter,
+                            CommitteeCode = rejCommitteeCode,
+                            CommitteeName = rejCommitteeName,
+                            VotesApprove = approveCount,
+                            VotesReject = rejectCount,
+                            VotesRouteBack = routeBackCount
+                        }, rejAppraisalId.Value.ToString());
+
+                        _logger.LogInformation(
+                            "ApprovalActivity {ActivityId}: Published AppraisalRejectedIntegrationEvent for AppraisalId {AppraisalId} CommitteeCode {CommitteeCode}",
+                            context.ActivityId, rejAppraisalId.Value, rejCommitteeCode);
+                    }
+                    else
+                    {
+                        _logger.LogWarning(
+                            "ApprovalActivity {ActivityId}: Decision=reject but no appraisalId in workflow variables; skipping rejection emit",
+                            context.ActivityId);
+                    }
+                }
+
                 return ActivityResult.Success(successOutput);
             }
 


### PR DESCRIPTION
## Summary
Committee rejections now reach the AS400 Collateral Result interface: when an `ApprovalActivity` decision is **reject**, a status-**R** record is spooled for the next `CollateralResultExportJob` run.

> **Stacked on #250** (`fix/security-review-hardening`). Merge #250 first; this PR's base then retargets to `main` automatically. Independent of the appraisal-book PR.

## Changes
- **`ApprovalActivity`** — publishes `AppraisalRejectedIntegrationEvent` through the outbox when the decision is `reject` (appraisal id, number, committee code/name, vote counts). Logs a warning and skips when no `appraisalId` is in the workflow variables.
- **`AppraisalRejectedConsumer`** (Collateral) — spools a `PendingCollateralResult` row. Idempotency is two-line: `InboxGuard` dedupes retried/concurrent delivery of the same message, and an `AppraisalId` existence check handles re-rejection after route-back (which arrives with a *different* MessageId) — first rejection wins, later ones ack as no-ops instead of tripping the unique index.

## Known limitation
`HostCollateralId` is null pre-approval (no `CollateralEngagement` exists yet), so R rows export a blank `CCDCID` field for now — see the TODO on `PendingCollateralResult` for the planned pre-approval master-link resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
