### PR TITLE
refactor(reporting): extract shared summary head/sign-off partials; m…

### DIFF
--- a/Modules/Reporting/Reporting/Templates/partials/book-letter-external.html
+++ b/Modules/Reporting/Reporting/Templates/partials/book-letter-external.html
@@ -26,7 +26,7 @@
   </div>
 
   <!-- Key–value table: rows rendered only when value is non-null -->
-  <table class="kv-table">
+  <table class="kv-table" role="presentation">
     {{ if model.customer_name }}
     <tr>
       <td class="kv-label">ลูกค้า</td>
@@ -185,7 +185,7 @@
 
   <!-- Signature block: 3 columns -->
   <div style="margin-top:4px; font-size:10pt;">ขอแสดงความนับถือ</div>
-  <table class="sig-table">
+  <table class="sig-table" role="presentation">
     <tr>
       <td>
         <div class="sig-line"></div>

--- a/Modules/Reporting/Reporting/Templates/partials/summary-block-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-block-body.html
@@ -15,28 +15,9 @@
 
 <div class="form">
 
-  <!-- ════ HEADER ════ -->
-  <div class="head">
-    <div class="logo">
-      <div class="lh">LH <span class="b">BANK</span></div>
-      <div class="bars"></div>
-    </div>
-    <div class="title">สรุปรายงานการประเมินราคาทรัพย์สิน</div>
-    <div class="meta">
-      <div class="row"><span class="lbl">รายงานเลขที่</span><span class="val">{{ model.appraisal_book_number }}</span></div>
-      <div class="row"><span class="lbl">วันที่สำรวจและประเมินราคา</span><span class="val">{{ thai.date model.appraisal_date }}</span></div>
-    </div>
-  </div>
-
-  <!-- ════ INFO BLOCK ════ -->
-  <div class="pad">
-    <div class="kv"><span class="k">ชื่อลูกค้า :</span><span class="v">{{ model.customer_name }}</span></div>
-    <div class="kv"><span class="k">ผู้แจ้ง :</span><span class="v">{{ model.ao_name }}</span></div>
-    <div class="cols2">
-      <div class="kv"><span class="k">วัตถุประสงค์ :</span><span class="v">{{ model.appraisal_purpose }}</span></div>
-      <div class="kv"><span class="k">ประเภททรัพย์สิน :</span><span class="v">{{ model.property_type }}</span></div>
-    </div>
-    <div class="kv"><span class="k">ที่ตั้งทรัพย์สิน :</span><span class="v">{{ model.collateral_address }}</span></div>
+  <!-- ════ HEADER + INFO BLOCK opening — shared partial (opens .pad) ════ -->
+  {{ summary_title = "สรุปรายงานการประเมินราคาทรัพย์สิน" }}
+  {{ include 'partials/summary-head' }}
     <div class="cols2">
       <div class="kv"><span class="k">เขตการปกครอง :</span><span class="v">{{ model.administrative_district }}</span></div>
       <div class="kv"><span class="k">ผู้ประเมินราคา :</span><span class="v">{{ model.appraiser }}</span></div>
@@ -102,27 +83,8 @@
     <div class="comment-box">{{ model.appraiser_comment }}</div>
   </div>
 
-  <!-- ════ SIGN-OFF ════ -->
-  <div class="signoff">
-    <div class="cell">
-      <div>ผู้ประเมิน</div>
-      <div class="nm">( {{ if model.appraisal_staff_name; model.appraisal_staff_name; else; ".............................."; end }} )</div>
-      <div class="pos">{{ model.appraisal_staff_position }}</div>
-    </div>
-    <div class="cell">
-      <div>ผู้ตรวจสอบ</div>
-      <div class="nm">( {{ if model.appraisal_checker_name; model.appraisal_checker_name; else; ".............................."; end }} )</div>
-      <div class="pos">{{ model.appraisal_checker_position }}</div>
-    </div>
-    <div class="cell">
-      <div>ผู้สอบทาน</div>
-      <div class="nm">( {{ if model.appraisal_verify_name; model.appraisal_verify_name; else; ".............................."; end }} )</div>
-      <div class="pos">{{ model.appraisal_verify_position }}</div>
-    </div>
-  </div>
-
-  <!-- ════ COMMITTEE BLOCK (shared partial) ════ -->
-  {{ include 'partials/approver-block' }}
+  <!-- ════ SIGN-OFF + COMMITTEE BLOCK — shared partial ════ -->
+  {{ include 'partials/summary-signoff' }}
 
   <!-- ════ UNIT TABLE: LB / Land ════ -->
   {{ if model.building_units.size > 0 }}

--- a/Modules/Reporting/Reporting/Templates/partials/summary-construction-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-construction-body.html
@@ -5,28 +5,9 @@
 -->
 <div class="form">
 
-  <!-- ════ HEADER ════ -->
-  <div class="head">
-    <div class="logo">
-      <div class="lh">LH <span class="b">BANK</span></div>
-      <div class="bars"></div>
-    </div>
-    <div class="title">สรุปรายงานการตรวจงานก่อสร้าง</div>
-    <div class="meta">
-      <div class="row"><span class="lbl">รายงานเลขที่</span><span class="val">{{ model.appraisal_book_number }}</span></div>
-      <div class="row"><span class="lbl">วันที่สำรวจและประเมินราคา</span><span class="val">{{ thai.date model.appraisal_date }}</span></div>
-    </div>
-  </div>
-
-  <!-- ════ INFO BLOCK ════ -->
-  <div class="pad">
-    <div class="kv"><span class="k">ชื่อลูกค้า :</span><span class="v">{{ model.customer_name }}</span></div>
-    <div class="kv"><span class="k">ผู้แจ้ง :</span><span class="v">{{ model.ao_name }}</span></div>
-    <div class="cols2">
-      <div class="kv"><span class="k">วัตถุประสงค์ :</span><span class="v">{{ model.appraisal_purpose }}</span></div>
-      <div class="kv"><span class="k">ประเภททรัพย์สิน :</span><span class="v">{{ model.property_type }}</span></div>
-    </div>
-    <div class="kv"><span class="k">ที่ตั้งทรัพย์สิน :</span><span class="v">{{ model.collateral_address }}</span></div>
+  <!-- ════ HEADER + INFO BLOCK opening — shared partial (opens .pad) ════ -->
+  {{ summary_title = "สรุปรายงานการตรวจงานก่อสร้าง" }}
+  {{ include 'partials/summary-head' }}
     <div class="kv"><span class="k">ผู้ประเมินราคา :</span><span class="v">{{ model.appraiser }}</span></div>
   </div>
 
@@ -143,26 +124,7 @@
     </tbody>
   </table>
 
-  <!-- ════ SIGN-OFF (3 cols: ผู้ประเมิน / ผู้ตรวจสอบ / ผู้สอบทาน) ════ -->
-  <div class="signoff">
-    <div class="cell">
-      <div>ผู้ประเมิน</div>
-      <div class="nm">( {{ if model.appraisal_staff_name; model.appraisal_staff_name; else; ".............................."; end }} )</div>
-      <div class="pos">{{ model.appraisal_staff_position }}</div>
-    </div>
-    <div class="cell">
-      <div>ผู้ตรวจสอบ</div>
-      <div class="nm">( {{ if model.appraisal_checker_name; model.appraisal_checker_name; else; ".............................."; end }} )</div>
-      <div class="pos">{{ model.appraisal_checker_position }}</div>
-    </div>
-    <div class="cell">
-      <div>ผู้สอบทาน</div>
-      <div class="nm">( {{ if model.appraisal_verify_name; model.appraisal_verify_name; else; ".............................."; end }} )</div>
-      <div class="pos">{{ model.appraisal_verify_position }}</div>
-    </div>
-  </div>
-
-  <!-- ════ COMMITTEE BLOCK (shared partial) ════ -->
-  {{ include 'partials/approver-block' }}
+  <!-- ════ SIGN-OFF + COMMITTEE BLOCK — shared partial ════ -->
+  {{ include 'partials/summary-signoff' }}
 
 </div>

--- a/Modules/Reporting/Reporting/Templates/partials/summary-head.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-head.html
@@ -1,0 +1,29 @@
+<!--
+  Partial: shared report header + common info-block opening of the three summary bodies
+  (standard / construction / block). The includer MUST:
+    1. set {{ summary_title }} before the include (the report title differs per body), and
+    2. close the still-open div.pad after appending its body-specific info rows.
+  Shares the parent Scriban scope; expects: model.* (AppraisalSummaryModel snake_case fields).
+-->
+<!-- ════ HEADER ════ -->
+<div class="head">
+  <div class="logo">
+    <div class="lh">LH <span class="b">BANK</span></div>
+    <div class="bars"></div>
+  </div>
+  <div class="title">{{ summary_title }}</div>
+  <div class="meta">
+    <div class="row"><span class="lbl">รายงานเลขที่</span><span class="val">{{ model.appraisal_book_number }}</span></div>
+    <div class="row"><span class="lbl">วันที่สำรวจและประเมินราคา</span><span class="val">{{ thai.date model.appraisal_date }}</span></div>
+  </div>
+</div>
+
+<!-- ════ INFO BLOCK (common opening — includer adds its rows and closes .pad) ════ -->
+<div class="pad">
+  <div class="kv"><span class="k">ชื่อลูกค้า :</span><span class="v">{{ model.customer_name }}</span></div>
+  <div class="kv"><span class="k">ผู้แจ้ง :</span><span class="v">{{ model.ao_name }}</span></div>
+  <div class="cols2">
+    <div class="kv"><span class="k">วัตถุประสงค์ :</span><span class="v">{{ model.appraisal_purpose }}</span></div>
+    <div class="kv"><span class="k">ประเภททรัพย์สิน :</span><span class="v">{{ model.property_type }}</span></div>
+  </div>
+  <div class="kv"><span class="k">ที่ตั้งทรัพย์สิน :</span><span class="v">{{ model.collateral_address }}</span></div>

--- a/Modules/Reporting/Reporting/Templates/partials/summary-signoff.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-signoff.html
@@ -1,0 +1,25 @@
+<!--
+  Partial: shared 3-column sign-off (ผู้ประเมิน / ผู้ตรวจสอบ / ผู้สอบทาน) + committee block,
+  identical across the three summary bodies (standard / construction / block).
+  Shares the parent Scriban scope; expects: model.* (AppraisalSummaryModel snake_case fields).
+-->
+<div class="signoff">
+  <div class="cell">
+    <div>ผู้ประเมิน</div>
+    <div class="nm">( {{ if model.appraisal_staff_name; model.appraisal_staff_name; else; ".............................."; end }} )</div>
+    <div class="pos">{{ model.appraisal_staff_position }}</div>
+  </div>
+  <div class="cell">
+    <div>ผู้ตรวจสอบ</div>
+    <div class="nm">( {{ if model.appraisal_checker_name; model.appraisal_checker_name; else; ".............................."; end }} )</div>
+    <div class="pos">{{ model.appraisal_checker_position }}</div>
+  </div>
+  <div class="cell">
+    <div>ผู้สอบทาน</div>
+    <div class="nm">( {{ if model.appraisal_verify_name; model.appraisal_verify_name; else; ".............................."; end }} )</div>
+    <div class="pos">{{ model.appraisal_verify_position }}</div>
+  </div>
+</div>
+
+<!-- ════ COMMITTEE BLOCK (shared partial) ════ -->
+{{ include 'partials/approver-block' }}

--- a/Modules/Reporting/Reporting/Templates/partials/summary-standard-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-standard-body.html
@@ -5,28 +5,9 @@
 -->
 <div class="form">
 
-  <!-- ════ HEADER ════ -->
-  <div class="head">
-    <div class="logo">
-      <div class="lh">LH <span class="b">BANK</span></div>
-      <div class="bars"></div>
-    </div>
-    <div class="title">สรุปรายงานการประเมินราคาทรัพย์สิน</div>
-    <div class="meta">
-      <div class="row"><span class="lbl">รายงานเลขที่</span><span class="val">{{ model.appraisal_book_number }}</span></div>
-      <div class="row"><span class="lbl">วันที่สำรวจและประเมินราคา</span><span class="val">{{ thai.date model.appraisal_date }}</span></div>
-    </div>
-  </div>
-
-  <!-- ════ INFO BLOCK (fields 1–12) ════ -->
-  <div class="pad">
-    <div class="kv"><span class="k">ชื่อลูกค้า :</span><span class="v">{{ model.customer_name }}</span></div>
-    <div class="kv"><span class="k">ผู้แจ้ง :</span><span class="v">{{ model.ao_name }}</span></div>
-    <div class="cols2">
-      <div class="kv"><span class="k">วัตถุประสงค์ :</span><span class="v">{{ model.appraisal_purpose }}</span></div>
-      <div class="kv"><span class="k">ประเภททรัพย์สิน :</span><span class="v">{{ model.property_type }}</span></div>
-    </div>
-    <div class="kv"><span class="k">ที่ตั้งทรัพย์สิน :</span><span class="v">{{ model.collateral_address }}</span></div>
+  <!-- ════ HEADER + INFO BLOCK opening (fields 1–12) — shared partial (opens .pad) ════ -->
+  {{ summary_title = "สรุปรายงานการประเมินราคาทรัพย์สิน" }}
+  {{ include 'partials/summary-head' }}
     <div class="cols3">
       <div class="kv"><span class="k">เขตการปกครอง :</span><span class="v">{{ model.administrative_district }}</span></div>
       <div class="kv"><span class="k">สำนักงานที่ดิน :</span><span class="v">{{ model.land_office }}</span></div>
@@ -70,8 +51,8 @@
     </tbody>
   </table>
 
-  <!-- ════ TOTALS (fields 20–23) ════ -->
-  <table class="totals">
+  <!-- ════ TOTALS (fields 20–23) — label/value layout table, not tabular data ════ -->
+  <table class="totals" role="presentation">
     <tr>
       <td class="tl">รวมราคาประเมินทรัพย์สินเป็นเงินทั้งสิ้น</td>
       <td class="tv">{{ if model.total_appraisal_value; model.total_appraisal_value | math.format "N2"; else; "-"; end }}</td>
@@ -122,26 +103,7 @@
     <div class="comment-box">{{ model.appraiser_comment }}</div>
   </div>
 
-  <!-- ════ SIGN-OFF (fields 36–41) ════ -->
-  <div class="signoff">
-    <div class="cell">
-      <div>ผู้ประเมิน</div>
-      <div class="nm">( {{ if model.appraisal_staff_name; model.appraisal_staff_name; else; ".............................."; end }} )</div>
-      <div class="pos">{{ model.appraisal_staff_position }}</div>
-    </div>
-    <div class="cell">
-      <div>ผู้ตรวจสอบ</div>
-      <div class="nm">( {{ if model.appraisal_checker_name; model.appraisal_checker_name; else; ".............................."; end }} )</div>
-      <div class="pos">{{ model.appraisal_checker_position }}</div>
-    </div>
-    <div class="cell">
-      <div>ผู้สอบทาน</div>
-      <div class="nm">( {{ if model.appraisal_verify_name; model.appraisal_verify_name; else; ".............................."; end }} )</div>
-      <div class="pos">{{ model.appraisal_verify_position }}</div>
-    </div>
-  </div>
-
-  <!-- ════ COMMITTEE BLOCK (fields 42–51) — shared partial ════ -->
-  {{ include 'partials/approver-block' }}
+  <!-- ════ SIGN-OFF (fields 36–41) + COMMITTEE BLOCK (fields 42–51) — shared partial ════ -->
+  {{ include 'partials/summary-signoff' }}
 
 </div><!-- .form -->


### PR DESCRIPTION
…ark layout tables presentational

Fixes the SonarCloud quality gate on this PR: the three summary bodies duplicated the report header + info-block opening and the 3-column sign-off + committee block (new_duplicated_lines_density 3.9% > 3%) — now shared via summary-head (title parameterized through summary_title, leaves div.pad open for body-specific rows) and summary-signoff. The letter's key-value/signature tables and the totals table are layout tables, not tabular data, so role="presentation" instead of <th> headers (Web:S5256 x3).