### PR TITLE
feat(health): wire LDAP/SMTP/SFTP checks + /health/external; fix rabbitmq check

### DIFF
--- a/Bootstrapper/Api/Api.csproj
+++ b/Bootstrapper/Api/Api.csproj
@@ -23,7 +23,6 @@
         <PackageReference Include="Serilog.Sinks.MSSqlServer"/>
         <PackageReference Include="AspNetCore.HealthChecks.SqlServer"/>
         <PackageReference Include="AspNetCore.HealthChecks.Redis"/>
-        <PackageReference Include="AspNetCore.HealthChecks.RabbitMQ"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Bootstrapper/Api/Program.cs
+++ b/Bootstrapper/Api/Program.cs
@@ -205,9 +205,10 @@ builder.Services.AddHealthChecks()
         builder.Configuration.GetConnectionString("Redis")!,
         "redis",
         tags: ["cache", "ready"])
-    .AddRabbitMQ(
-        name: "rabbitmq",
-        tags: ["messaging", "ready"])
+    // RabbitMQ messaging readiness is covered by MassTransit's own "masstransit-bus" health check
+    // (auto-registered by AddMassTransit, tagged "ready"), which probes the real bus connection.
+    // The AspNetCore.HealthChecks.RabbitMQ check is not used: its v9 overload resolves a
+    // RabbitMQ.Client.IConnection from DI, which MassTransit does not register.
     // External integrations (LDAP / SMTP / SFTP). Tagged "external", NOT "ready": an outage here
     // surfaces in /health and /health/external but must not pull a node out of LB rotation.
     .AddAuthHealthChecks()

--- a/Bootstrapper/Api/Program.cs
+++ b/Bootstrapper/Api/Program.cs
@@ -26,6 +26,9 @@ using Shared.Messaging.Filters;
 using Shared.Messaging.Services;
 using Workflow.Data;
 using Shared.Observability;
+using Auth.Infrastructure.HealthChecks;
+using Notification.Infrastructure.Email.HealthChecks;
+using Integration.Infrastructure.HealthChecks;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -204,7 +207,12 @@ builder.Services.AddHealthChecks()
         tags: ["cache", "ready"])
     .AddRabbitMQ(
         name: "rabbitmq",
-        tags: ["messaging", "ready"]);
+        tags: ["messaging", "ready"])
+    // External integrations (LDAP / SMTP / SFTP). Tagged "external", NOT "ready": an outage here
+    // surfaces in /health and /health/external but must not pull a node out of LB rotation.
+    .AddAuthHealthChecks()
+    .AddNotificationHealthChecks()
+    .AddIntegrationHealthChecks();
 
 var corsConfig = builder.Configuration
     .GetSection(CorsConfiguration.SectionName)
@@ -313,6 +321,31 @@ app.MapHealthChecks("/health/live", new HealthCheckOptions
 app.MapHealthChecks("/health/ready", new HealthCheckOptions
 {
     Predicate = check => check.Tags.Contains("ready"),
+    ResponseWriter = async (context, report) =>
+    {
+        context.Response.ContentType = "application/json";
+        var response = new
+        {
+            status = report.Status.ToString(),
+            checks = report.Entries.Select(x => new
+            {
+                name = x.Key,
+                status = x.Value.Status.ToString(),
+                exception = x.Value.Exception?.Message,
+                duration = x.Value.Duration.ToString(),
+                data = x.Value.Data
+            }),
+            totalDuration = report.TotalDuration.ToString()
+        };
+        await context.Response.WriteAsync(System.Text.Json.JsonSerializer.Serialize(response));
+    }
+}).AllowAnonymous();
+
+// External-dependency probes (LDAP / SMTP / SFTP) only. Lets ops poll the integration links
+// without the DB/cache/bus noise — and keeps them out of /health/ready (LB rotation).
+app.MapHealthChecks("/health/external", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("external"),
     ResponseWriter = async (context, report) =>
     {
         context.Response.ContentType = "application/json";

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AspNetCore.HealthChecks.RabbitMQ" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
     <PackageVersion Include="Carter" Version="9.0.0" />


### PR DESCRIPTION
## Why

Two health-check fixes:

1. **Missing wiring.** The LDAP/SMTP/SFTP health-check classes landed on `main` in `b7d6a861`, but that commit dropped the `Bootstrapper/Api/Program.cs` registration — so the checks were inert: nothing called the `AddXHealthChecks()` extensions, `/health` excluded them, and `/health/external` 404'd.
2. **Broken rabbitmq check.** The existing `.AddRabbitMQ()` (AspNetCore.HealthChecks.RabbitMQ v9) resolves a `RabbitMQ.Client.IConnection` from DI, which this app never registers (it drives RabbitMQ via MassTransit). It failed at runtime — *"No service for type 'RabbitMQ.Client.IConnection' has been registered"* — turning `/health` Unhealthy.

## What

- Chains `.AddAuthHealthChecks()` / `.AddNotificationHealthChecks()` / `.AddIntegrationHealthChecks()` onto `AddHealthChecks()` and adds the `/health/external` endpoint (filters the `external` tag).
- Removes the redundant/broken `.AddRabbitMQ()` call and its now-unused package reference. MassTransit 8.x auto-registers a `masstransit-bus` health check (tagged `ready`) that probes the real bus connection, so messaging readiness stays covered.

## Behavior

- External checks are tagged `external`, **not** `ready` — an LDAP/SMTP/SFTP outage surfaces in `/health` and `/health/external` but never affects `/health/ready` or F5 LB rotation.
- Disabled integrations (`Ldap:Enabled=false`, `Mail:Enabled=false`, `FileTransfer:*:FileSource=Local`) report `Healthy` with `data.state = "disabled"`.
- `/health/ready` now reports `sqlserver` + `redis` + `masstransit-bus` (was the failing `rabbitmq`).

## Verification

- `dotnet build` → 0 errors.
- `GET /health` → no more `rabbitmq` Unhealthy entry; `masstransit-bus` Healthy; ldap/smtp/sftp present.
- `GET /health/external` → only the 5 external entries.
- `GET /health/ready` → core infra only (excludes external checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)