### PR TITLE
fix(integration): require authentication on resubmit/parameters/valuers endpoints

### DIFF
--- a/Modules/Integration/Integration/Application/Features/AppraisalRequests/ResubmitRequest/ResubmitRequestEndpoint.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalRequests/ResubmitRequest/ResubmitRequestEndpoint.cs
@@ -59,7 +59,6 @@ public class ResubmitRequestEndpoint : ICarterModule
             .ProducesProblem(StatusCodes.Status404NotFound)
             .WithTags("Integration - Appraisal Requests")
             .WithSummary("Resubmit an existing request")
-            .WithDescription("Resubmits an existing request in the system.")
-            .AllowAnonymous();
+            .WithDescription("Resubmits an existing request in the system.");
     }
 }

--- a/Modules/Integration/Integration/Application/Features/Parameters/GetParameters/GetParametersEndpoint.cs
+++ b/Modules/Integration/Integration/Application/Features/Parameters/GetParameters/GetParametersEndpoint.cs
@@ -26,6 +26,5 @@ public class GetParametersEndpoint : ICarterModule
             .WithName("Integration_GetParameters")
             .WithTags("Integration - Parameters")
             .Produces<List<ParameterGroupResult>>();
-        //.RequireAuthorization("Integration");
     }
 }

--- a/Modules/Integration/Integration/Application/Features/Quotations/GetQuotationValuers/GetQuotationValuersEndpoint.cs
+++ b/Modules/Integration/Integration/Application/Features/Quotations/GetQuotationValuers/GetQuotationValuersEndpoint.cs
@@ -20,7 +20,6 @@ public class GetQuotationValuersEndpoint : ICarterModule
         })
         .WithName("GetQuotationValuers")
         .WithTags("Integration - Quotations")
-        //.RequireAuthorization("Integration")
         .Produces<GetQuotationValuersResult>()
         .ProducesProblem(StatusCodes.Status404NotFound);
     }


### PR DESCRIPTION
## Summary
Security review **Tier 3 — item 1** (`docs/security-review/SECURITY-REVIEW-2026-06-08.md`). Three `Integration` module endpoints bypassed the global `RequireAuthenticatedUser` fallback (`AuthModule.cs:362`). This makes all three require an authenticated caller.

Per decision, **no specific `Integration` permission policy is added** — the endpoints rely on the authenticated-user fallback, so existing external bank callers that authenticate but lack that scope are not broken.

## Changes (3 files)
| Endpoint | Change | Effect |
|---|---|---|
| `ResubmitRequest` | remove `.AllowAnonymous()` | **Behavior change**: a state-mutating, bank-facing resubmit was fully unauthenticated → now requires authentication |
| `GetParameters` | remove dead `//.RequireAuthorization("Integration")` comment | Cleanup only — already authenticated-only via fallback at runtime |
| `GetQuotationValuers` | remove dead `//.RequireAuthorization("Integration")` comment | Cleanup only — already authenticated-only via fallback at runtime |

## ⚠ Reviewer note
`ResubmitRequest` flips **anonymous → authenticated**. Confirm no external caller currently invokes `PUT /api/v1/requests/{requestId}/resubmit` anonymously before merge. The other two are no-op cleanups (they already enforced authentication; only a misleading dead comment was removed).

## Verification
- `dotnet build` clean (0 errors).
- Diff = 3 files, 1 insertion / 4 deletions — auth-line removals only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)