### PR TITLE
feat(workflow): persist decision ReasonCode on CompletedTask

### DIFF
--- a/Database/Migration/Scripts/20260630000000_UpdateRoutebackReasonParameters.sql
+++ b/Database/Migration/Scripts/20260630000000_UpdateRoutebackReasonParameters.sql
@@ -1,0 +1,24 @@
+-- ----------------------------------------
+-- Replace placeholder RoutebackReason parameters with real bilingual reasons.
+-- Used by the Summary & Decision screen routeback (movement "B") reason dropdown.
+-- ----------------------------------------
+DELETE FROM parameter.Parameters WHERE [group] = N'RoutebackReason';
+GO
+
+INSERT INTO parameter.Parameters ([group], [country], [language], [code], [description], [isactive], [seqno])
+VALUES
+    (N'RoutebackReason', N'TH', N'EN', N'01', N'Incomplete or missing documents', 1, 1),
+    (N'RoutebackReason', N'TH', N'TH', N'01', N'เอกสารไม่ครบถ้วนหรือขาดหาย', 1, 1),
+    (N'RoutebackReason', N'TH', N'EN', N'02', N'Incorrect request information', 1, 2),
+    (N'RoutebackReason', N'TH', N'TH', N'02', N'ข้อมูลคำขอไม่ถูกต้อง', 1, 2),
+    (N'RoutebackReason', N'TH', N'EN', N'03', N'Additional information required', 1, 3),
+    (N'RoutebackReason', N'TH', N'TH', N'03', N'ต้องการข้อมูลเพิ่มเติม', 1, 3),
+    (N'RoutebackReason', N'TH', N'EN', N'04', N'Incorrect collateral/property details', 1, 4),
+    (N'RoutebackReason', N'TH', N'TH', N'04', N'ข้อมูลหลักประกันไม่ถูกต้อง', 1, 4),
+    (N'RoutebackReason', N'TH', N'EN', N'05', N'Title document issue', 1, 5),
+    (N'RoutebackReason', N'TH', N'TH', N'05', N'เอกสารสิทธิ์มีปัญหา', 1, 5),
+    (N'RoutebackReason', N'TH', N'EN', N'06', N'Pending customer confirmation', 1, 6),
+    (N'RoutebackReason', N'TH', N'TH', N'06', N'รอการยืนยันจากลูกค้า', 1, 6),
+    (N'RoutebackReason', N'TH', N'EN', N'99', N'Other', 1, 7),
+    (N'RoutebackReason', N'TH', N'TH', N'99', N'อื่นๆ', 1, 7);
+GO

--- a/Modules/Workflow/Workflow/Data/Configurations/CompletedTaskConfiguration.cs
+++ b/Modules/Workflow/Workflow/Data/Configurations/CompletedTaskConfiguration.cs
@@ -55,6 +55,10 @@ public class CompletedTaskConfiguration : IEntityTypeConfiguration<CompletedTask
             .IsRequired()
             .HasDefaultValue("F");
 
+        builder.Property(p => p.ReasonCode)
+            .HasMaxLength(20)
+            .IsRequired(false);
+
         builder.Property(p => p.AssigneeCompanyId)
             .IsRequired(false);
 

--- a/Modules/Workflow/Workflow/Infrastructure/Migrations/20260630043308_AddReasonCodeToCompletedTask.Designer.cs
+++ b/Modules/Workflow/Workflow/Infrastructure/Migrations/20260630043308_AddReasonCodeToCompletedTask.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Workflow.Data;
 
@@ -11,9 +12,11 @@ using Workflow.Data;
 namespace Workflow.Infrastructure.Migrations
 {
     [DbContext(typeof(WorkflowDbContext))]
-    partial class WorkflowDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260630043308_AddReasonCodeToCompletedTask")]
+    partial class AddReasonCodeToCompletedTask
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modules/Workflow/Workflow/Infrastructure/Migrations/20260630043308_AddReasonCodeToCompletedTask.cs
+++ b/Modules/Workflow/Workflow/Infrastructure/Migrations/20260630043308_AddReasonCodeToCompletedTask.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Workflow.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReasonCodeToCompletedTask : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ReasonCode",
+                schema: "workflow",
+                table: "CompletedTasks",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ReasonCode",
+                schema: "workflow",
+                table: "CompletedTasks");
+        }
+    }
+}

--- a/Modules/Workflow/Workflow/Tasks/EventHandlers/TaskCompletedDomainEventHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/EventHandlers/TaskCompletedDomainEventHandler.cs
@@ -48,7 +48,7 @@ public class TaskCompletedDomainEventHandler(
 
         var completedTask = CompletedTask.CreateFromPendingTask(
             pendingTask, notification.ActionTaken, notification.CompletedAt, notification.Remark,
-            notification.Movement);
+            notification.Movement, notification.ReasonCode);
 
         await assignmentRepository.AddCompletedTaskAsync(completedTask, cancellationToken);
         await assignmentRepository.RemovePendingTaskAsync(pendingTask, cancellationToken);

--- a/Modules/Workflow/Workflow/Tasks/Models/CompletedTask.cs
+++ b/Modules/Workflow/Workflow/Tasks/Models/CompletedTask.cs
@@ -19,6 +19,13 @@ public class CompletedTask : Aggregate<Guid>
     public string Movement { get; private set; } = "F";
 
     /// <summary>
+    /// Optional reason code for the decision, interpreted via <see cref="Movement"/>
+    /// (e.g. a CancelReason code when Movement is "C", a RoutebackReason code when "B").
+    /// Null for forward movements or completions without a coded reason.
+    /// </summary>
+    public string? ReasonCode { get; private set; }
+
+    /// <summary>
     /// Carried forward from PendingTask.AssigneeCompanyId so historical pool-task
     /// visibility queries can enforce per-company isolation on completed rows.
     /// Null for non-fan-out tasks.
@@ -34,7 +41,7 @@ public class CompletedTask : Aggregate<Guid>
         string assignedType, DateTime assignedAt, string actionTaken, DateTime completedAt,
         DateTime? dueAt = null, string? slaStatus = null, DateTime? slaBreachedAt = null,
         string? taskDescription = null, string? remark = null, string movement = "F",
-        string? activityId = null, Guid? assigneeCompanyId = null)
+        string? activityId = null, Guid? assigneeCompanyId = null, string? reasonCode = null)
     {
         Id = id;
         CorrelationId = correlationId;
@@ -53,18 +60,19 @@ public class CompletedTask : Aggregate<Guid>
         Remark = remark;
         Movement = movement;
         AssigneeCompanyId = assigneeCompanyId;
+        ReasonCode = reasonCode;
     }
 
     public static CompletedTask Create(Guid id, Guid correlationId, string taskName, string assignedTo,
         string assignedType, DateTime assignedAt, string actionTaken, DateTime completedAt,
-        string? remark = null, string movement = "F")
+        string? remark = null, string movement = "F", string? reasonCode = null)
     {
         return new CompletedTask(id, correlationId, taskName, assignedTo, assignedType, assignedAt,
-            actionTaken, completedAt, remark: remark, movement: movement);
+            actionTaken, completedAt, remark: remark, movement: movement, reasonCode: reasonCode);
     }
 
     public static CompletedTask CreateFromPendingTask(PendingTask pendingTask, string actionTaken,
-        DateTime completedAt, string? remark = null, string? movement = null)
+        DateTime completedAt, string? remark = null, string? movement = null, string? reasonCode = null)
     {
         return new CompletedTask(
             pendingTask.Id,
@@ -82,7 +90,8 @@ public class CompletedTask : Aggregate<Guid>
             remark,
             movement ?? pendingTask.Movement,
             pendingTask.ActivityId,
-            pendingTask.AssigneeCompanyId
+            pendingTask.AssigneeCompanyId,
+            reasonCode
         );
     }
 

--- a/Modules/Workflow/Workflow/Workflow/Activities/TaskActivity.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/TaskActivity.cs
@@ -171,6 +171,12 @@ public class TaskActivity : WorkflowActivityBase
             if (resumeInput.TryGetValue("comments", out var commentsValue))
                 outputData[$"{NormalizeActivityId(context.ActivityId)}_comments"] = commentsValue;
 
+            // Capture optional coded decision reason (e.g. CancelReason/RoutebackReason code)
+            // so PublishTaskCompletedEventAsync can persist it onto CompletedTask.ReasonCode.
+            // `reasonCode` is reserved below so the generic passthrough loop skips it.
+            if (resumeInput.TryGetValue("reasonCode", out var reasonCodeValue))
+                outputData[$"{NormalizeActivityId(context.ActivityId)}_reasonCode"] = reasonCodeValue;
+
             // Process all input data using inputMappings (unified approach)
             foreach (var kvp in resumeInput)
                 if (!IsReservedKey(kvp.Key))
@@ -454,6 +460,7 @@ public class TaskActivity : WorkflowActivityBase
         return key.Equals("decisionTaken", StringComparison.OrdinalIgnoreCase) ||
                key.Equals("decision", StringComparison.OrdinalIgnoreCase) ||
                key.Equals("comments", StringComparison.OrdinalIgnoreCase) ||
+               key.Equals("reasonCode", StringComparison.OrdinalIgnoreCase) ||
                key.Equals("completedBy", StringComparison.OrdinalIgnoreCase) ||
                key.Equals("variableUpdates", StringComparison.OrdinalIgnoreCase);
     }
@@ -752,6 +759,12 @@ public class TaskActivity : WorkflowActivityBase
             : null;
         if (string.IsNullOrWhiteSpace(remark)) remark = null;
 
+        var reasonCodeKey = $"{NormalizeActivityId(context.ActivityId)}_reasonCode";
+        var reasonCode = outputData.TryGetValue(reasonCodeKey, out var reasonCodeValue)
+            ? reasonCodeValue?.ToString()
+            : null;
+        if (string.IsNullOrWhiteSpace(reasonCode)) reasonCode = null;
+
         // Pass CompletedBy for pool task implicit assignment
         var completedBy = context.WorkflowInstance.CurrentAssignee;
 
@@ -783,7 +796,7 @@ public class TaskActivity : WorkflowActivityBase
             new TaskCompletedDomainEvent(correlationGuid, taskName, actionTaken, _dateTimeProvider.ApplicationNow,
                 completedBy,
                 context.WorkflowInstance.Name, remark, appraisalNumber, movement,
-                completedAppraisalId, context.ActivityId),
+                completedAppraisalId, context.ActivityId, reasonCode),
             cancellationToken);
     }
 

--- a/Modules/Workflow/Workflow/Workflow/Events/TaskCompletedDomainEvent.cs
+++ b/Modules/Workflow/Workflow/Workflow/Events/TaskCompletedDomainEvent.cs
@@ -11,5 +11,6 @@ public record TaskCompletedDomainEvent(
     string? AppraisalNumber = null,
     string Movement = "F",
     Guid? AppraisalId = null,
-    string? ActivityId = null
+    string? ActivityId = null,
+    string? ReasonCode = null
 ) : IDomainEvent;

--- a/Modules/Workflow/Workflow/Workflow/Features/GetAppraisalWorkflowProgress/GetAppraisalWorkflowProgressQuery.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/GetAppraisalWorkflowProgress/GetAppraisalWorkflowProgressQuery.cs
@@ -17,7 +17,7 @@ public class GetAppraisalWorkflowProgressResponse
 public class PhaseStepDto
 {
     public string Group { get; set; } = default!;
-    public string Status { get; set; } = default!; // Completed | Current | Pending
+    public string Status { get; set; } = default!; // Completed | Current | Pending | Cancelled
 }
 
 public class ActivityLogItemDto
@@ -36,4 +36,5 @@ public class ActivityLogItemDto
     public string? Group { get; set; }
     public string? ActivityId { get; set; }
     public string? CompanyName { get; set; }
+    public string? Movement { get; set; } // F | C (Cancel) | B (back) — "C" marks the cancelled activity
 }

--- a/Modules/Workflow/Workflow/Workflow/Features/GetAppraisalWorkflowProgress/GetAppraisalWorkflowProgressQueryHandler.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/GetAppraisalWorkflowProgress/GetAppraisalWorkflowProgressQueryHandler.cs
@@ -19,6 +19,7 @@ public class GetAppraisalWorkflowProgressQueryHandler(
         ["appraisal-initiation"] = "Initiation",
         ["appraisal-initiation-check"] = "Initiation",
         ["appraisal-assignment"] = "Assignment",
+        ["int-pma-input"] = "Execution",
         ["ext-appraisal-assignment"] = "Execution",
         ["ext-appraisal-execution"] = "Execution",
         ["ext-appraisal-check"] = "Execution",
@@ -27,6 +28,7 @@ public class GetAppraisalWorkflowProgressQueryHandler(
         ["appraisal-book-verification"] = "Staff",
         ["int-appraisal-check"] = "Checker",
         ["int-appraisal-verification"] = "Verification",
+        ["pending-meeting"] = "Approval",
         ["pending-approval"] = "Approval"
     };
 
@@ -61,7 +63,8 @@ public class GetAppraisalWorkflowProgressQueryHandler(
                                            CAST(NULL AS nvarchar(10))   AS ActionTaken,
                                            CAST(NULL AS nvarchar(1000)) AS Remark,
                                            'Pending'                    AS TaskStatus,
-                                           pt.ActivityId
+                                           pt.ActivityId,
+                                           CAST(NULL AS nvarchar(10))   AS Movement
                                     FROM workflow.PendingTasks pt
                                     WHERE pt.CorrelationId = @RequestId
 
@@ -70,7 +73,8 @@ public class GetAppraisalWorkflowProgressQueryHandler(
                                     SELECT ct.TaskName, ct.TaskDescription, ct.AssignedTo, ct.AssignedType, ct.AssignedAt,
                                            ct.CompletedAt, ct.ActionTaken, ct.Remark,
                                            'Completed' AS TaskStatus,
-                                           ct.ActivityId
+                                           ct.ActivityId,
+                                           ct.Movement
                                     FROM workflow.CompletedTasks ct
                                     WHERE ct.CorrelationId = @RequestId
 
@@ -158,8 +162,21 @@ public class GetAppraisalWorkflowProgressQueryHandler(
         // ── Step building (BFS over workflow definition) ──────────────────────
         var orderedGroups = BuildOrderedGroups(definitionJson, routeType, logger);
 
+        // ── Cancellation point ────────────────────────────────────────────────
+        // Movement="C" on a completed task is the authoritative "cancelled here" marker.
+        // Fallback: a command-path cancel (no such row) leaves the instance Cancelled with
+        // CurrentActivityId pointing at where it stopped.
+        var cancelActivityId =
+            logRows.FirstOrDefault(r => string.Equals(r.Movement, "C", StringComparison.OrdinalIgnoreCase))?.ActivityId
+            ?? (string.Equals(instance?.Status, "Cancelled", StringComparison.OrdinalIgnoreCase)
+                ? instance!.CurrentActivityId
+                : null);
+
+        var cancelledGroup =
+            cancelActivityId is not null && GroupMap.TryGetValue(cancelActivityId, out var cg) ? cg : null;
+
         // ── Step statuses ─────────────────────────────────────────────────────
-        var steps = BuildSteps(orderedGroups, completedActivityIds, instance);
+        var steps = BuildSteps(orderedGroups, completedActivityIds, instance, cancelledGroup);
 
         // ── Activity log with user display names ──────────────────────────────
         var activityLog = await BuildActivityLogAsync(logRows, cancellationToken);
@@ -300,9 +317,23 @@ public class GetAppraisalWorkflowProgressQueryHandler(
     private static List<PhaseStepDto> BuildSteps(
         List<string> orderedGroups,
         List<string> completedActivityIds,
-        WorkflowInstanceRow? instance)
+        WorkflowInstanceRow? instance,
+        string? cancelledGroup)
     {
         if (orderedGroups.Count == 0) return [];
+
+        // Cancelled → mark the cancellation step red, earlier Completed, later Pending.
+        if (cancelledGroup is not null)
+        {
+            var cancelIdx = orderedGroups.IndexOf(cancelledGroup);
+            if (cancelIdx >= 0)
+                return orderedGroups.Select((g, idx) => new PhaseStepDto
+                {
+                    Group = g,
+                    Status = idx < cancelIdx ? "Completed" : idx == cancelIdx ? "Cancelled" : "Pending"
+                }).ToList();
+            // group filtered out of this route → fall through to normal logic
+        }
 
         // Workflow fully completed → all Completed
         if (string.Equals(instance?.Status, "Completed", StringComparison.OrdinalIgnoreCase))
@@ -394,7 +425,8 @@ public class GetAppraisalWorkflowProgressQueryHandler(
                 Status = r.TaskStatus,
                 Group = group,
                 ActivityId = r.ActivityId,
-                CompanyName = companyName
+                CompanyName = companyName,
+                Movement = r.Movement
             };
         }).ToList();
     }
@@ -421,6 +453,7 @@ public class GetAppraisalWorkflowProgressQueryHandler(
         public string? Remark { get; set; }
         public string TaskStatus { get; set; } = default!;
         public string? ActivityId { get; set; }
+        public string? Movement { get; set; }
     }
 
     // ── JSON DTOs for workflow definition ─────────────────────────────────────


### PR DESCRIPTION
## Summary
Persist an optional **ReasonCode** on `CompletedTask`, capturing the coded reason behind a task decision (e.g. a RoutebackReason when `Movement="B"`, a CancelReason when `Movement="C"`). The code is read from the resume-input and threaded through `TaskActivity` → `TaskCompletedDomainEvent` → `TaskCompletedDomainEventHandler` onto the persisted row.

The workflow-progress read model (`GetAppraisalWorkflowProgress`) now:
- marks the cancellation step red (`Cancelled`) using `Movement="C"` as the authoritative marker, with a fallback to the instance's `CurrentActivityId` when the instance is `Cancelled` via the command path;
- exposes `Movement` on activity-log items;
- maps `int-pma-input` → Execution and `pending-meeting` → Approval groups.

## Changes
- EF migration `AddReasonCodeToCompletedTask` (Workflow DbContext) + snapshot
- `CompletedTask` / `CompletedTaskConfiguration`: new nullable `ReasonCode` (max 20)
- `TaskActivity`: capture `reasonCode` from resume-input, reserve the key, pass through on completion
- `TaskCompletedDomainEvent` / handler: carry & persist the reason code
- DbUp seed `20260630000000_UpdateRoutebackReasonParameters.sql`: real bilingual RoutebackReason parameters (dropdown source)

## Migration
Contains an EF migration for the **Workflow** DbContext — independent of other open PRs (separate DbContext/snapshot).

## Test plan
- Apply the Workflow migration and run the DbUp script.
- Complete a task with a routeback/cancel reason; confirm `workflow.CompletedTasks.ReasonCode` is set.
- Confirm the progress endpoint marks the cancelled step and returns `Movement` on log items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGcvtGoPS9RiMyywH6wr13