### PR TITLE
feat(appraisal): expose AppraisalValue on GetAppraisalById

### DIFF
--- a/Database/Scripts/Views/Appraisal/vw_AppraisalDetail.sql
+++ b/Database/Scripts/Views/Appraisal/vw_AppraisalDetail.sql
@@ -46,6 +46,8 @@ SELECT a.Id,
        NULLIF(LTRIM(RTRIM(CONCAT(NULLIF(u.FirstName, N''), N' ', NULLIF(u.LastName, N'')))), N'')
                                                                                            AS AppraiserName,
        COALESCE(lap.AppointmentDateTime, a.CompletedAt, la.CompletedAt)                    AS AppraisalDate,
+       -- Final appraised value (same source as vw_AppraisalList.AppraisalValue).
+       va.AppraisedValue                                                                   AS AppraisalValue,
        -- Committee approval tier + meeting linkage. Tier derives from the approving committee
        -- CODE stored on the appraisal (1 = sub-committee, 2 = committee without meeting,
        -- 3 = committee with meeting) — robust even when the Committees table lacks that code.
@@ -94,8 +96,11 @@ FROM appraisal.Appraisals a
          LEFT JOIN auth.Companies c
                 ON c.Id = TRY_CAST(la.AssigneeCompanyId AS UNIQUEIDENTIFIER)
                AND c.IsDeleted = 0
+         -- AssigneeUserId / InternalAppraiserId hold the UserName (bank code), NOT the user Id —
+         -- join on UserName. (A TRY_CAST-to-uniqueidentifier on Id silently misses and yields NULL.)
          LEFT JOIN auth.AspNetUsers u
-                ON u.Id = TRY_CAST(CASE WHEN la.AssigneeCompanyId IS NOT NULL
-                                        THEN la.InternalAppraiserId
-                                        ELSE la.AssigneeUserId
-                                   END AS UNIQUEIDENTIFIER)
+                ON u.UserName = CASE WHEN la.AssigneeCompanyId IS NOT NULL
+                                     THEN la.InternalAppraiserId
+                                     ELSE la.AssigneeUserId
+                                END
+         LEFT JOIN appraisal.ValuationAnalyses va ON va.AppraisalId = a.Id

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalById/GetAppraisalByIdResponse.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalById/GetAppraisalByIdResponse.cs
@@ -27,6 +27,7 @@ public record GetAppraisalByIdResponse
     public string? CompanyName { get; set; }
     public string? AppraiserName { get; set; }
     public DateTime? AppraisalDate { get; set; }
+    public decimal? AppraisalValue { get; set; }
     public DateTime? CreatedOn { get; set; }
     public string? CreatedBy { get; set; }
     public DateTime? UpdatedOn { get; set; }

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalById/GetAppraisalByIdResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalById/GetAppraisalByIdResult.cs
@@ -30,6 +30,7 @@ public record GetAppraisalByIdResult
     public string? CompanyName { get; set; }
     public string? AppraiserName { get; set; }
     public DateTime? AppraisalDate { get; set; }
+    public decimal? AppraisalValue { get; set; }
     public DateTime? CreatedOn { get; set; }
     public string? CreatedBy { get; set; }
     public DateTime? UpdatedOn { get; set; }


### PR DESCRIPTION
## Summary
Surface the final appraised value on the appraisal detail read model.

- `vw_AppraisalDetail` now joins `appraisal.ValuationAnalyses` and exposes `va.AppraisedValue AS AppraisalValue` (same source as `vw_AppraisalList.AppraisalValue`).
- `GetAppraisalByIdResult` / `GetAppraisalByIdResponse` expose `decimal? AppraisalValue`.
- **Bug fix in the same view:** the `auth.AspNetUsers` join keyed on `TRY_CAST(... AS uniqueidentifier)`, but `AssigneeUserId` / `InternalAppraiserId` store the **UserName** (bank code), not the user Id — so the join silently returned NULL. Now joins on `u.UserName`.

## Migration
None — `vw_AppraisalDetail.sql` is a wildcard-included view script applied outside EF.

## Test plan
- Refresh the view; GET an appraisal by id.
- Confirm `appraisalValue` is populated and the appraiser display name resolves (no NULL from the join fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGcvtGoPS9RiMyywH6wr13