### PR TITLE
fix(collateral): harden CollateralBackfillJob per-record error handling

### DIFF
--- a/Modules/Collateral/Collateral/CollateralMasters/Services/CollateralBackfillJob.cs
+++ b/Modules/Collateral/Collateral/CollateralMasters/Services/CollateralBackfillJob.cs
@@ -181,6 +181,13 @@ public class CollateralBackfillJob(
                 "CollateralBackfillJob: SkippedMissingKey AppraisalId={AppraisalId} Reason={Reason}",
                 appraisalId, ex.Message);
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // App shutdown — let it propagate so the record is NOT recorded as an error
+            // (it is idempotent and reprocesses cleanly on the next run). RunAsync's outer
+            // catch logs-and-finalizes the job gracefully.
+            throw;
+        }
         catch (Exception ex)
         {
             status = "Error";
@@ -189,10 +196,29 @@ public class CollateralBackfillJob(
             logger.LogError(ex, "CollateralBackfillJob: Error processing AppraisalId={AppraisalId}", appraisalId);
         }
 
-        // Write the report row — use the same scope's DbContext
-        var report = new CollateralBackfillReport(appraisalId, status, message, dateTimeProvider.ApplicationNow);
-        db.CollateralBackfillReports.Add(report);
-        await db.SaveChangesAsync(ct);
+        // Drop any partial tracked entities before writing the report.
+        // db is the SAME scoped DbContext the upsert service writes through, so:
+        //   - a record that threw mid-processing leaves its Added-but-unsaved masters/aliases tracked, and
+        //   - even the idempotent "duplicate engagement" no-op (ProcessAppraisalAsync swallows the
+        //     DbUpdateException internally) leaves its rolled-back Added entities tracked.
+        // Without this clear, the report SaveChangesAsync below would re-attempt (and re-throw on)
+        // those entities, which would propagate to RunAsync's outer catch and abort the WHOLE run.
+        db.ChangeTracker.Clear();
+
+        // Write the report row — use the same scope's DbContext.
+        // Guard it: failing to log a single record's outcome must never abort the run.
+        try
+        {
+            var report = new CollateralBackfillReport(appraisalId, status, message, dateTimeProvider.ApplicationNow);
+            db.CollateralBackfillReports.Add(report);
+            await db.SaveChangesAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "CollateralBackfillJob: failed to write BackfillReport for AppraisalId={AppraisalId} (Status={Status})",
+                appraisalId, status);
+        }
 
         return status;
     }


### PR DESCRIPTION
## Summary
Make `CollateralBackfillJob` resilient so a single record's failure (or app shutdown) can never abort the whole run.

- **Shutdown:** rethrow `OperationCanceledException` when cancellation is requested instead of logging it as a per-record error — the record reprocesses idempotently on the next run, and the outer `RunAsync` catch finalizes the job gracefully.
- **Stale tracked entities:** `ChangeTracker.Clear()` before writing the report row. The report uses the same scoped DbContext as the upsert service, which can hold Added-but-unsaved entities from a record that threw mid-processing, or from the idempotent duplicate-engagement no-op (its `DbUpdateException` is swallowed internally, leaving rolled-back Added entities tracked). Without the clear, the report `SaveChangesAsync` re-attempts those and re-throws, aborting the run.
- **Report-write guard:** wrap the report write so failing to log one record's outcome is logged and swallowed, never aborting the run.

## Migration
None.

## Test plan
- Run the backfill over a batch including a duplicate-engagement no-op; confirm the run completes and report rows are written for all records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGcvtGoPS9RiMyywH6wr13