### PR TITLE
Add village/project name above construction summary table

### DIFF
--- a/Modules/Appraisal/Appraisal/Application/Features/DecisionSummary/GetDecisionSummary/GetDecisionSummaryQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/DecisionSummary/GetDecisionSummary/GetDecisionSummaryQueryHandler.cs
@@ -420,12 +420,24 @@ public class GetDecisionSummaryQueryHandler(
             WHERE ap.AppraisalId = @AppraisalId
             """;
 
+        // ชื่ออาคาร = village name of the first L/LB land property (same source as report RS04)
+        const string villageSql = """
+            SELECT TOP 1 lad.Village
+            FROM appraisal.LandAppraisalDetails lad
+            JOIN appraisal.AppraisalProperties ap ON ap.Id = lad.AppraisalPropertyId
+            WHERE ap.AppraisalId = @AppraisalId
+              AND ap.PropertyType IN ('L', 'LB')
+            ORDER BY ap.SequenceNumber
+            """;
+
         var landValue = await connectionFactory.QueryFirstOrDefaultAsync<decimal>(landValueSql, p);
         var nonCiBuilding = await connectionFactory.QueryFirstOrDefaultAsync<decimal>(nonCiBuildingValueSql, p);
         var ci = await connectionFactory.QueryFirstOrDefaultAsync<CiAggregateRow>(ciAggregateSql, p);
 
         if (ci is null || ci.CITotalValue == 0m)
             return null;
+
+        var village = await connectionFactory.QueryFirstOrDefaultAsync<string?>(villageSql, p);
 
         var ciTotal = ci.CITotalValue;
         var ciPrev = ci.CIPreviousValue;
@@ -470,7 +482,7 @@ public class GetDecisionSummaryQueryHandler(
                 ciTotal),
         };
 
-        return new ConstructionSummaryData(rows);
+        return new ConstructionSummaryData(village, rows);
     }
 
     private record CiAggregateRow(

--- a/Modules/Appraisal/Appraisal/Application/Features/DecisionSummary/GetDecisionSummary/GetDecisionSummaryResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/DecisionSummary/GetDecisionSummary/GetDecisionSummaryResult.cs
@@ -102,6 +102,7 @@ public record BlockModelPriceRow(
 );
 
 public record ConstructionSummaryData(
+    string? Village,
     IReadOnlyList<ConstructionSummaryRow> Rows
 );
 


### PR DESCRIPTION
## What
Adds the **village / project name** (ชื่ออาคาร) as a header above the Construction Summary milestone table on the Decision Summary, so readers see which project the construction milestones belong to.

## Backend changes
- `ConstructionSummaryData` gains a `Village` field.
- `BuildConstructionSummaryAsync` resolves it with the **same query the report uses** (RS04): `TOP 1 lad.Village` from the first L/LB property ordered by `SequenceNumber`. Runs only after the existing CI early-return, so non-CI/block appraisals are unaffected.

No schema change, no migration — read-only addition.

## Verification
- `dotnet build` clean.
- Open a CI / Progressive appraisal's Decision Summary where the first L/LB property has a Village set → value appears and matches the report's ชื่ออาคาร field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmQYBQna3GERaVguFX1L5Y