### PR TITLE
fix(ca): low-priority defect batch — template management + construction inspection

### DIFF
--- a/Database/Migration/Scripts/20260702120000_SeedData_AddGroundworkConstructionWorkItem.sql
+++ b/Database/Migration/Scripts/20260702120000_SeedData_AddGroundworkConstructionWorkItem.sql
@@ -1,0 +1,37 @@
+-- ============================================================
+-- Seed: Add missing "Groundwork" work item to Building Structure group
+-- Schema: parameter
+-- CA-338: parameter.ConstructionWorkGroups 'BuildingStructure' was seeded
+--         (20260322205700_SeedData_ConstructionWorkGroups.sql) with only 4
+--         items (Pillar, Floor, Stair, RooftopFloor). The authoritative
+--         parameter.Parameters group 'BuildingStructure'
+--         (20260317002600_SeedData_GeneralParameter.sql) has 5 items:
+--         Groundwork (01), Pillar (02), Floor (03), Stair (04),
+--         Rooftop Floor (05). Add the missing Groundwork item as the
+--         first item (DisplayOrder 1) to match that order.
+-- ============================================================
+
+DECLARE @BuildingStructureId UNIQUEIDENTIFIER;
+SELECT @BuildingStructureId = Id FROM parameter.ConstructionWorkGroups WHERE Code = N'BuildingStructure';
+
+IF @BuildingStructureId IS NOT NULL
+   AND NOT EXISTS (
+       SELECT 1 FROM parameter.ConstructionWorkItems
+       WHERE ConstructionWorkGroupId = @BuildingStructureId AND Code = N'Groundwork'
+   )
+BEGIN
+    -- Shift existing items down to make room for Groundwork at position 1
+    UPDATE parameter.ConstructionWorkItems
+    SET DisplayOrder = DisplayOrder + 1
+    WHERE ConstructionWorkGroupId = @BuildingStructureId;
+
+    INSERT INTO parameter.ConstructionWorkItems (Id, ConstructionWorkGroupId, Code, NameTh, NameEn, DisplayOrder, IsActive)
+    VALUES (NEWID(), @BuildingStructureId, N'Groundwork', N'ฐานราก', N'Groundwork', 1, 1);
+
+    PRINT 'Added Groundwork construction work item to Building Structure group';
+END
+ELSE
+BEGIN
+    PRINT 'Groundwork construction work item already present (or Building Structure group missing), skipping...';
+END
+GO

--- a/Database/Migration/Scripts/20260702120100_SeedData_FixFireProtectionSystemLabel.sql
+++ b/Database/Migration/Scripts/20260702120100_SeedData_FixFireProtectionSystemLabel.sql
@@ -1,0 +1,38 @@
+-- ============================================================
+-- Seed fix: Correct "Fire Protection System" label in Building
+-- Management System group
+-- Schema: parameter
+-- CA-339: parameter.ConstructionWorkGroups 'BuildingManagement' item
+--         Code = 'ProtectionSystem' was seeded
+--         (20260322205700_SeedData_ConstructionWorkGroups.sql) with the
+--         wrong label (NameEn = 'Protection System',
+--         NameTh = 'ระบบป้องกัน'). The authoritative parameter.Parameters
+--         group 'BuildingManagementSystem'
+--         (20260317002600_SeedData_GeneralParameter.sql) item 03 is
+--         "Fire Protection System". Correct the display labels only —
+--         Code and Id are left unchanged so existing per-appraisal
+--         ConstructionWorkDetails snapshots (which reference the item by
+--         Id/name at creation time) are not disturbed.
+-- ============================================================
+
+DECLARE @BuildingManagementId UNIQUEIDENTIFIER;
+SELECT @BuildingManagementId = Id FROM parameter.ConstructionWorkGroups WHERE Code = N'BuildingManagement';
+
+IF @BuildingManagementId IS NOT NULL
+   AND EXISTS (
+       SELECT 1 FROM parameter.ConstructionWorkItems
+       WHERE ConstructionWorkGroupId = @BuildingManagementId AND Code = N'ProtectionSystem'
+   )
+BEGIN
+    UPDATE parameter.ConstructionWorkItems
+    SET NameEn = N'Fire Protection System',
+        NameTh = N'ระบบป้องกันอัคคีภัย'
+    WHERE ConstructionWorkGroupId = @BuildingManagementId AND Code = N'ProtectionSystem';
+
+    PRINT 'Corrected Fire Protection System label in Building Management System group';
+END
+ELSE
+BEGIN
+    PRINT 'ProtectionSystem construction work item not found (or Building Management group missing), skipping...';
+END
+GO

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/ReorderComparativeAnalysisTemplateFactors/ReorderComparativeAnalysisTemplateFactorsCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/ReorderComparativeAnalysisTemplateFactors/ReorderComparativeAnalysisTemplateFactorsCommand.cs
@@ -1,0 +1,9 @@
+using Appraisal.Application.Configurations;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.ComparativeAnalysisTemplates.ReorderComparativeAnalysisTemplateFactors;
+
+public record ReorderComparativeAnalysisTemplateFactorsCommand(
+    Guid TemplateId,
+    List<ReorderFactorItem> Factors
+) : ICommand<ReorderComparativeAnalysisTemplateFactorsResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/ReorderComparativeAnalysisTemplateFactors/ReorderComparativeAnalysisTemplateFactorsCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/ReorderComparativeAnalysisTemplateFactors/ReorderComparativeAnalysisTemplateFactorsCommandHandler.cs
@@ -17,6 +17,9 @@ public class ReorderComparativeAnalysisTemplateFactorsCommandHandler(
         if (template is null)
             throw new NotFoundException("ComparativeAnalysisTemplate", command.TemplateId);
 
+        if (command.Factors is null)
+            throw new BadRequestException("The 'factors' collection is required.");
+
         template.ReorderFactors(command.Factors.Select(f => (f.FactorId, f.DisplaySequence)));
 
         return new ReorderComparativeAnalysisTemplateFactorsResult(true);

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/ReorderComparativeAnalysisTemplateFactors/ReorderComparativeAnalysisTemplateFactorsCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/ReorderComparativeAnalysisTemplateFactors/ReorderComparativeAnalysisTemplateFactorsCommandHandler.cs
@@ -1,0 +1,24 @@
+using Appraisal.Domain.ComparativeAnalysis;
+using Shared.CQRS;
+using Shared.Exceptions;
+
+namespace Appraisal.Application.Features.ComparativeAnalysisTemplates.ReorderComparativeAnalysisTemplateFactors;
+
+public class ReorderComparativeAnalysisTemplateFactorsCommandHandler(
+    IComparativeAnalysisTemplateRepository repository
+) : ICommandHandler<ReorderComparativeAnalysisTemplateFactorsCommand, ReorderComparativeAnalysisTemplateFactorsResult>
+{
+    public async Task<ReorderComparativeAnalysisTemplateFactorsResult> Handle(
+        ReorderComparativeAnalysisTemplateFactorsCommand command,
+        CancellationToken cancellationToken)
+    {
+        var template = await repository.GetByIdWithFactorsAsync(command.TemplateId, cancellationToken);
+
+        if (template is null)
+            throw new NotFoundException("ComparativeAnalysisTemplate", command.TemplateId);
+
+        template.ReorderFactors(command.Factors.Select(f => (f.FactorId, f.DisplaySequence)));
+
+        return new ReorderComparativeAnalysisTemplateFactorsResult(true);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/ReorderComparativeAnalysisTemplateFactors/ReorderComparativeAnalysisTemplateFactorsEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/ReorderComparativeAnalysisTemplateFactors/ReorderComparativeAnalysisTemplateFactorsEndpoint.cs
@@ -1,0 +1,25 @@
+using Carter;
+using MediatR;
+
+namespace Appraisal.Application.Features.ComparativeAnalysisTemplates.ReorderComparativeAnalysisTemplateFactors;
+
+public class ReorderComparativeAnalysisTemplateFactorsEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/comparative-analysis-templates/{templateId:guid}/factors/reorder",
+            async (Guid templateId, ReorderComparativeAnalysisTemplateFactorsRequest request, ISender sender,
+                CancellationToken cancellationToken) =>
+            {
+                var command = new ReorderComparativeAnalysisTemplateFactorsCommand(templateId, request.Factors);
+                await sender.Send(command, cancellationToken);
+                return Results.NoContent();
+            })
+            .WithName("ReorderComparativeAnalysisTemplateFactors")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Reorder comparative analysis template factors")
+            .WithDescription("Persist the display order of factors within a comparative analysis template.")
+            .WithTags("ComparativeAnalysisTemplates");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/ReorderComparativeAnalysisTemplateFactors/ReorderComparativeAnalysisTemplateFactorsRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/ReorderComparativeAnalysisTemplateFactors/ReorderComparativeAnalysisTemplateFactorsRequest.cs
@@ -1,0 +1,5 @@
+namespace Appraisal.Application.Features.ComparativeAnalysisTemplates.ReorderComparativeAnalysisTemplateFactors;
+
+public record ReorderComparativeAnalysisTemplateFactorsRequest(List<ReorderFactorItem> Factors);
+
+public record ReorderFactorItem(Guid FactorId, int DisplaySequence);

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/ReorderComparativeAnalysisTemplateFactors/ReorderComparativeAnalysisTemplateFactorsResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/ReorderComparativeAnalysisTemplateFactors/ReorderComparativeAnalysisTemplateFactorsResult.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.ComparativeAnalysisTemplates.ReorderComparativeAnalysisTemplateFactors;
+
+public record ReorderComparativeAnalysisTemplateFactorsResult(bool Success);

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/SetComparativeAnalysisTemplateStatus/SetComparativeAnalysisTemplateStatusCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/SetComparativeAnalysisTemplateStatus/SetComparativeAnalysisTemplateStatusCommand.cs
@@ -1,0 +1,9 @@
+using Appraisal.Application.Configurations;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.ComparativeAnalysisTemplates.SetComparativeAnalysisTemplateStatus;
+
+public record SetComparativeAnalysisTemplateStatusCommand(
+    Guid Id,
+    bool IsActive
+) : ICommand<SetComparativeAnalysisTemplateStatusResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/SetComparativeAnalysisTemplateStatus/SetComparativeAnalysisTemplateStatusCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/SetComparativeAnalysisTemplateStatus/SetComparativeAnalysisTemplateStatusCommandHandler.cs
@@ -14,7 +14,7 @@ public class SetComparativeAnalysisTemplateStatusCommandHandler(
         var template = await templateRepository.GetByIdAsync(command.Id, cancellationToken);
 
         if (template is null)
-            throw new InvalidOperationException($"Template {command.Id} not found");
+            throw new NotFoundException("ComparativeAnalysisTemplate", command.Id);
 
         if (command.IsActive)
             template.Activate();

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/SetComparativeAnalysisTemplateStatus/SetComparativeAnalysisTemplateStatusCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/SetComparativeAnalysisTemplateStatus/SetComparativeAnalysisTemplateStatusCommandHandler.cs
@@ -1,0 +1,28 @@
+using Appraisal.Domain.ComparativeAnalysis;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.ComparativeAnalysisTemplates.SetComparativeAnalysisTemplateStatus;
+
+public class SetComparativeAnalysisTemplateStatusCommandHandler(
+    IComparativeAnalysisTemplateRepository templateRepository
+) : ICommandHandler<SetComparativeAnalysisTemplateStatusCommand, SetComparativeAnalysisTemplateStatusResult>
+{
+    public async Task<SetComparativeAnalysisTemplateStatusResult> Handle(
+        SetComparativeAnalysisTemplateStatusCommand command,
+        CancellationToken cancellationToken)
+    {
+        var template = await templateRepository.GetByIdAsync(command.Id, cancellationToken);
+
+        if (template is null)
+            throw new InvalidOperationException($"Template {command.Id} not found");
+
+        if (command.IsActive)
+            template.Activate();
+        else
+            template.Deactivate();
+
+        templateRepository.Update(template);
+
+        return new SetComparativeAnalysisTemplateStatusResult(true);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/SetComparativeAnalysisTemplateStatus/SetComparativeAnalysisTemplateStatusEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/SetComparativeAnalysisTemplateStatus/SetComparativeAnalysisTemplateStatusEndpoint.cs
@@ -1,0 +1,34 @@
+using Carter;
+using MediatR;
+
+namespace Appraisal.Application.Features.ComparativeAnalysisTemplates.SetComparativeAnalysisTemplateStatus;
+
+public class SetComparativeAnalysisTemplateStatusEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/comparative-analysis-templates/{id:guid}/activate",
+            async (Guid id, ISender sender, CancellationToken cancellationToken) =>
+            {
+                await sender.Send(new SetComparativeAnalysisTemplateStatusCommand(id, true), cancellationToken);
+                return Results.NoContent();
+            })
+            .WithName("ActivateComparativeAnalysisTemplate")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Activate a comparative analysis template")
+            .WithTags("ComparativeAnalysisTemplates");
+
+        app.MapPost("/comparative-analysis-templates/{id:guid}/deactivate",
+            async (Guid id, ISender sender, CancellationToken cancellationToken) =>
+            {
+                await sender.Send(new SetComparativeAnalysisTemplateStatusCommand(id, false), cancellationToken);
+                return Results.NoContent();
+            })
+            .WithName("DeactivateComparativeAnalysisTemplate")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Deactivate a comparative analysis template")
+            .WithTags("ComparativeAnalysisTemplates");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/SetComparativeAnalysisTemplateStatus/SetComparativeAnalysisTemplateStatusResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/SetComparativeAnalysisTemplateStatus/SetComparativeAnalysisTemplateStatusResult.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.ComparativeAnalysisTemplates.SetComparativeAnalysisTemplateStatus;
+
+public record SetComparativeAnalysisTemplateStatusResult(bool Success);

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/UpdateFactorInTemplate/UpdateFactorInTemplateCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/UpdateFactorInTemplate/UpdateFactorInTemplateCommand.cs
@@ -1,0 +1,13 @@
+using Appraisal.Application.Configurations;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.ComparativeAnalysisTemplates.UpdateFactorInTemplate;
+
+public record UpdateFactorInTemplateCommand(
+    Guid TemplateId,
+    Guid FactorId,
+    bool IsMandatory = false,
+    decimal? DefaultWeight = null,
+    decimal? DefaultIntensity = null,
+    bool IsCalculationFactor = false
+) : ICommand<UpdateFactorInTemplateResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/UpdateFactorInTemplate/UpdateFactorInTemplateCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/UpdateFactorInTemplate/UpdateFactorInTemplateCommandHandler.cs
@@ -1,0 +1,31 @@
+using Appraisal.Domain.ComparativeAnalysis;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.ComparativeAnalysisTemplates.UpdateFactorInTemplate;
+
+public class UpdateFactorInTemplateCommandHandler(
+    IComparativeAnalysisTemplateRepository templateRepository
+) : ICommandHandler<UpdateFactorInTemplateCommand, UpdateFactorInTemplateResult>
+{
+    public async Task<UpdateFactorInTemplateResult> Handle(
+        UpdateFactorInTemplateCommand command,
+        CancellationToken cancellationToken)
+    {
+        var template = await templateRepository.GetByIdWithFactorsAsync(command.TemplateId, cancellationToken);
+
+        if (template is null)
+            throw new InvalidOperationException($"Template {command.TemplateId} not found");
+
+        template.UpdateFactor(
+            command.FactorId,
+            command.IsMandatory,
+            command.DefaultWeight,
+            command.DefaultIntensity,
+            command.IsCalculationFactor
+        );
+
+        templateRepository.Update(template);
+
+        return new UpdateFactorInTemplateResult(true);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/UpdateFactorInTemplate/UpdateFactorInTemplateCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/UpdateFactorInTemplate/UpdateFactorInTemplateCommandHandler.cs
@@ -14,7 +14,7 @@ public class UpdateFactorInTemplateCommandHandler(
         var template = await templateRepository.GetByIdWithFactorsAsync(command.TemplateId, cancellationToken);
 
         if (template is null)
-            throw new InvalidOperationException($"Template {command.TemplateId} not found");
+            throw new NotFoundException("ComparativeAnalysisTemplate", command.TemplateId);
 
         template.UpdateFactor(
             command.FactorId,

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/UpdateFactorInTemplate/UpdateFactorInTemplateEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/UpdateFactorInTemplate/UpdateFactorInTemplateEndpoint.cs
@@ -1,0 +1,36 @@
+using Carter;
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Appraisal.Application.Features.ComparativeAnalysisTemplates.UpdateFactorInTemplate;
+
+public class UpdateFactorInTemplateEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/comparative-analysis-templates/{templateId:guid}/factors/{factorId:guid}",
+                async (Guid templateId, Guid factorId, UpdateFactorInTemplateRequest request, ISender sender, CancellationToken cancellationToken) =>
+                {
+                    var command = new UpdateFactorInTemplateCommand(
+                        templateId,
+                        factorId,
+                        request.IsMandatory,
+                        request.DefaultWeight,
+                        request.DefaultIntensity,
+                        request.IsCalculationFactor
+                    );
+
+                    await sender.Send(command, cancellationToken);
+                    return Results.NoContent();
+                })
+            .WithName("UpdateFactorInComparativeAnalysisTemplate")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Update a factor within a template")
+            .WithDescription("Updates a factor's mandatory / calculation / default weight / default intensity in place without altering its display order.")
+            .WithTags("ComparativeAnalysisTemplates");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/UpdateFactorInTemplate/UpdateFactorInTemplateRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/UpdateFactorInTemplate/UpdateFactorInTemplateRequest.cs
@@ -1,0 +1,8 @@
+namespace Appraisal.Application.Features.ComparativeAnalysisTemplates.UpdateFactorInTemplate;
+
+public record UpdateFactorInTemplateRequest(
+    bool IsMandatory = false,
+    decimal? DefaultWeight = null,
+    decimal? DefaultIntensity = null,
+    bool IsCalculationFactor = false
+);

--- a/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/UpdateFactorInTemplate/UpdateFactorInTemplateResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/ComparativeAnalysisTemplates/UpdateFactorInTemplate/UpdateFactorInTemplateResult.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.ComparativeAnalysisTemplates.UpdateFactorInTemplate;
+
+public record UpdateFactorInTemplateResult(bool Success);

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/DeleteMarketComparableFactor/DeleteMarketComparableFactorCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/DeleteMarketComparableFactor/DeleteMarketComparableFactorCommandHandler.cs
@@ -4,20 +4,25 @@ using Shared.CQRS;
 namespace Appraisal.Application.Features.MarketComparableFactors.DeleteMarketComparableFactor;
 
 /// <summary>
-/// Handles soft deletion of a market comparable factor.
+/// Handles permanent deletion of a market comparable factor.
+/// Blocked with a 409 when the factor is still referenced by a template
+/// (use deactivate instead in that case).
 /// </summary>
 internal sealed class DeleteMarketComparableFactorCommandHandler :
     ICommandHandler<DeleteMarketComparableFactorCommand, DeleteMarketComparableFactorResult>
 {
     private readonly IMarketComparableFactorRepository _repository;
     private readonly IAppraisalUnitOfWork _unitOfWork;
+    private readonly AppraisalDbContext _dbContext;
 
     public DeleteMarketComparableFactorCommandHandler(
         IMarketComparableFactorRepository repository,
-        IAppraisalUnitOfWork unitOfWork)
+        IAppraisalUnitOfWork unitOfWork,
+        AppraisalDbContext dbContext)
     {
         _repository = repository;
         _unitOfWork = unitOfWork;
+        _dbContext = dbContext;
     }
 
     public async Task<DeleteMarketComparableFactorResult> Handle(
@@ -25,12 +30,19 @@ internal sealed class DeleteMarketComparableFactorCommandHandler :
         CancellationToken cancellationToken)
     {
         var factor = await _repository.GetByIdAsync(command.Id, cancellationToken)
-            ?? throw new InvalidOperationException($"Market comparable factor with ID '{command.Id}' not found.");
+            ?? throw new NotFoundException("MarketComparableFactor", command.Id);
 
-        // Soft delete using domain method
-        factor.Deactivate();
+        var isUsedInTemplate = await _dbContext.MarketComparableTemplateFactors
+            .AnyAsync(tf => tf.FactorId == command.Id, cancellationToken);
 
-        await _repository.UpdateAsync(factor, cancellationToken);
+        var isUsedInData = await _dbContext.MarketComparableData
+            .AnyAsync(d => d.FactorId == command.Id, cancellationToken);
+
+        if (isUsedInTemplate || isUsedInData)
+            throw new ConflictException(
+                "This factor is in use (by a template or existing market comparable data) and cannot be deleted. Deactivate it instead.");
+
+        await _repository.DeleteAsync(factor, cancellationToken);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 
         return new DeleteMarketComparableFactorResult(true);

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/DeleteMarketComparableFactor/DeleteMarketComparableFactorEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/DeleteMarketComparableFactor/DeleteMarketComparableFactorEndpoint.cs
@@ -26,9 +26,10 @@ public class DeleteMarketComparableFactorEndpoint : ICarterModule
             })
             .WithName("DeleteMarketComparableFactor")
             .WithSummary("Delete a market comparable factor")
-            .WithDescription("Soft deletes a market comparable factor by setting IsActive to false.")
+            .WithDescription("Permanently deletes a market comparable factor. Returns 409 if the factor is still used by a template or has existing market comparable data (deactivate it instead).")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
             .WithTags("MarketComparableFactors");
     }
 }

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/SetMarketComparableFactorStatus/SetMarketComparableFactorStatusCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/SetMarketComparableFactorStatus/SetMarketComparableFactorStatusCommand.cs
@@ -1,0 +1,8 @@
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.MarketComparableFactors.SetMarketComparableFactorStatus;
+
+public record SetMarketComparableFactorStatusCommand(
+    Guid Id,
+    bool IsActive
+) : ICommand<SetMarketComparableFactorStatusResult>;

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/SetMarketComparableFactorStatus/SetMarketComparableFactorStatusCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/SetMarketComparableFactorStatus/SetMarketComparableFactorStatusCommandHandler.cs
@@ -25,7 +25,7 @@ internal sealed class SetMarketComparableFactorStatusCommandHandler :
         CancellationToken cancellationToken)
     {
         var factor = await _repository.GetByIdAsync(command.Id, cancellationToken)
-            ?? throw new InvalidOperationException($"Market comparable factor with ID '{command.Id}' not found.");
+            ?? throw new NotFoundException("MarketComparableFactor", command.Id);
 
         if (command.IsActive)
             factor.Activate();

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/SetMarketComparableFactorStatus/SetMarketComparableFactorStatusCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/SetMarketComparableFactorStatus/SetMarketComparableFactorStatusCommandHandler.cs
@@ -1,0 +1,40 @@
+using Appraisal.Domain.MarketComparables;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.MarketComparableFactors.SetMarketComparableFactorStatus;
+
+/// <summary>
+/// Handles activating / deactivating a market comparable factor.
+/// </summary>
+internal sealed class SetMarketComparableFactorStatusCommandHandler :
+    ICommandHandler<SetMarketComparableFactorStatusCommand, SetMarketComparableFactorStatusResult>
+{
+    private readonly IMarketComparableFactorRepository _repository;
+    private readonly IAppraisalUnitOfWork _unitOfWork;
+
+    public SetMarketComparableFactorStatusCommandHandler(
+        IMarketComparableFactorRepository repository,
+        IAppraisalUnitOfWork unitOfWork)
+    {
+        _repository = repository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<SetMarketComparableFactorStatusResult> Handle(
+        SetMarketComparableFactorStatusCommand command,
+        CancellationToken cancellationToken)
+    {
+        var factor = await _repository.GetByIdAsync(command.Id, cancellationToken)
+            ?? throw new InvalidOperationException($"Market comparable factor with ID '{command.Id}' not found.");
+
+        if (command.IsActive)
+            factor.Activate();
+        else
+            factor.Deactivate();
+
+        await _repository.UpdateAsync(factor, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return new SetMarketComparableFactorStatusResult(true);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/SetMarketComparableFactorStatus/SetMarketComparableFactorStatusEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/SetMarketComparableFactorStatus/SetMarketComparableFactorStatusEndpoint.cs
@@ -1,0 +1,34 @@
+using Carter;
+using MediatR;
+
+namespace Appraisal.Application.Features.MarketComparableFactors.SetMarketComparableFactorStatus;
+
+public class SetMarketComparableFactorStatusEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/market-comparable-factors/{id:guid}/activate",
+            async (Guid id, ISender sender, CancellationToken cancellationToken) =>
+            {
+                await sender.Send(new SetMarketComparableFactorStatusCommand(id, true), cancellationToken);
+                return Results.NoContent();
+            })
+            .WithName("ActivateMarketComparableFactor")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Activate a market comparable factor")
+            .WithTags("MarketComparableFactors");
+
+        app.MapPost("/market-comparable-factors/{id:guid}/deactivate",
+            async (Guid id, ISender sender, CancellationToken cancellationToken) =>
+            {
+                await sender.Send(new SetMarketComparableFactorStatusCommand(id, false), cancellationToken);
+                return Results.NoContent();
+            })
+            .WithName("DeactivateMarketComparableFactor")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Deactivate a market comparable factor")
+            .WithTags("MarketComparableFactors");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/SetMarketComparableFactorStatus/SetMarketComparableFactorStatusResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/SetMarketComparableFactorStatus/SetMarketComparableFactorStatusResult.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.MarketComparableFactors.SetMarketComparableFactorStatus;
+
+public record SetMarketComparableFactorStatusResult(bool Success);

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/UpdateMarketComparableFactor/UpdateMarketComparableFactorCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/UpdateMarketComparableFactor/UpdateMarketComparableFactorCommand.cs
@@ -13,4 +13,5 @@ public sealed record UpdateMarketComparableFactorCommand(
     int? FieldLength,
     int? FieldDecimal,
     string? ParameterGroup,
-    IReadOnlyList<(string Language, string FactorName)> Translations) : ICommand<UpdateMarketComparableFactorResult>;
+    IReadOnlyList<(string Language, string FactorName)> Translations,
+    bool? IsActive) : ICommand<UpdateMarketComparableFactorResult>;

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/UpdateMarketComparableFactor/UpdateMarketComparableFactorCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/UpdateMarketComparableFactor/UpdateMarketComparableFactorCommandHandler.cs
@@ -41,6 +41,13 @@ internal sealed class UpdateMarketComparableFactorCommandHandler :
             command.ParameterGroup,
             command.Translations);
 
+        // Only change active state when the caller explicitly supplies it; a partial payload
+        // that omits IsActive (null) must leave the factor's current state untouched.
+        if (command.IsActive is true)
+            factor.Activate();
+        else if (command.IsActive is false)
+            factor.Deactivate();
+
         await _repository.UpdateAsync(factor, cancellationToken);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/UpdateMarketComparableFactor/UpdateMarketComparableFactorEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/UpdateMarketComparableFactor/UpdateMarketComparableFactorEndpoint.cs
@@ -28,7 +28,8 @@ public class UpdateMarketComparableFactorEndpoint : ICarterModule
                     request.FieldLength,
                     request.FieldDecimal,
                     request.ParameterGroup,
-                    request.Translations.Select(t => (t.Language, t.FactorName)).ToList());
+                    request.Translations.Select(t => (t.Language, t.FactorName)).ToList(),
+                    request.IsActive);
 
                 var result = await sender.Send(command, cancellationToken);
 

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/UpdateMarketComparableFactor/UpdateMarketComparableFactorRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableFactors/UpdateMarketComparableFactor/UpdateMarketComparableFactorRequest.cs
@@ -10,6 +10,7 @@ public sealed record UpdateMarketComparableFactorRequest(
     int? FieldLength,
     int? FieldDecimal,
     string? ParameterGroup,
-    List<FactorTranslationRequest> Translations);
+    List<FactorTranslationRequest> Translations,
+    bool? IsActive = null);
 
 public sealed record FactorTranslationRequest(string Language, string FactorName);

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/GetMarketComparableTemplates/GetMarketComparableTemplatesQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/GetMarketComparableTemplates/GetMarketComparableTemplatesQueryHandler.cs
@@ -13,17 +13,19 @@ public class GetMarketComparableTemplatesQueryHandler(
     {
         IEnumerable<MarketComparableTemplate> templates;
 
+        // Default to returning all statuses (active + inactive) so the admin list can
+        // show and reactivate inactive templates; the UI filters by status client-side.
         if (!string.IsNullOrWhiteSpace(query.PropertyType))
             templates = await repository.GetByPropertyTypeAsync(
                 query.PropertyType,
-                query.IsActive ?? true,
+                query.IsActive ?? false,
                 cancellationToken);
         else
             templates = await repository.GetAllAsync(
-                query.IsActive ?? true,
+                query.IsActive ?? false,
                 cancellationToken);
 
-        var dtos = templates.Select(t => new MarketComparableTemplateDto(
+        var dtos = templates.OrderBy(t => t.CreatedAt).Select(t => new MarketComparableTemplateDto(
             t.Id,
             t.TemplateCode,
             t.TemplateName,
@@ -31,7 +33,8 @@ public class GetMarketComparableTemplatesQueryHandler(
             t.Description,
             t.IsActive,
             t.CreatedAt,
-            t.UpdatedAt
+            t.UpdatedAt,
+            t.TemplateFactors.Count
         )).ToList();
 
         return new GetMarketComparableTemplatesResult(dtos);

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/GetMarketComparableTemplates/GetMarketComparableTemplatesResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/GetMarketComparableTemplates/GetMarketComparableTemplatesResult.cs
@@ -10,5 +10,6 @@ public record MarketComparableTemplateDto(
     string? Description,
     bool IsActive,
     DateTime? CreatedOn,
-    DateTime? UpdatedOn
+    DateTime? UpdatedOn,
+    int FactorCount
 );

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/ReorderTemplateFactors/ReorderTemplateFactorsCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/ReorderTemplateFactors/ReorderTemplateFactorsCommand.cs
@@ -1,0 +1,9 @@
+using Appraisal.Application.Configurations;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.MarketComparableTemplates.ReorderTemplateFactors;
+
+public record ReorderTemplateFactorsCommand(
+    Guid TemplateId,
+    List<ReorderFactorItem> Factors
+) : ICommand<ReorderTemplateFactorsResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/ReorderTemplateFactors/ReorderTemplateFactorsCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/ReorderTemplateFactors/ReorderTemplateFactorsCommandHandler.cs
@@ -1,0 +1,24 @@
+using Appraisal.Domain.MarketComparables;
+using Shared.CQRS;
+using Shared.Exceptions;
+
+namespace Appraisal.Application.Features.MarketComparableTemplates.ReorderTemplateFactors;
+
+public class ReorderTemplateFactorsCommandHandler(
+    IMarketComparableTemplateRepository repository
+) : ICommandHandler<ReorderTemplateFactorsCommand, ReorderTemplateFactorsResult>
+{
+    public async Task<ReorderTemplateFactorsResult> Handle(
+        ReorderTemplateFactorsCommand command,
+        CancellationToken cancellationToken)
+    {
+        var template = await repository.GetByIdWithFactorsAsync(command.TemplateId, cancellationToken);
+
+        if (template is null)
+            throw new NotFoundException("MarketComparableTemplate", command.TemplateId);
+
+        template.ReorderFactors(command.Factors.Select(f => (f.FactorId, f.DisplaySequence)));
+
+        return new ReorderTemplateFactorsResult(true);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/ReorderTemplateFactors/ReorderTemplateFactorsCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/ReorderTemplateFactors/ReorderTemplateFactorsCommandHandler.cs
@@ -17,6 +17,9 @@ public class ReorderTemplateFactorsCommandHandler(
         if (template is null)
             throw new NotFoundException("MarketComparableTemplate", command.TemplateId);
 
+        if (command.Factors is null)
+            throw new BadRequestException("The 'factors' collection is required.");
+
         template.ReorderFactors(command.Factors.Select(f => (f.FactorId, f.DisplaySequence)));
 
         return new ReorderTemplateFactorsResult(true);

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/ReorderTemplateFactors/ReorderTemplateFactorsEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/ReorderTemplateFactors/ReorderTemplateFactorsEndpoint.cs
@@ -1,0 +1,24 @@
+using Carter;
+using MediatR;
+
+namespace Appraisal.Application.Features.MarketComparableTemplates.ReorderTemplateFactors;
+
+public class ReorderTemplateFactorsEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/market-comparable-templates/{templateId:guid}/factors/reorder",
+            async (Guid templateId, ReorderTemplateFactorsRequest request, ISender sender, CancellationToken cancellationToken) =>
+            {
+                var command = new ReorderTemplateFactorsCommand(templateId, request.Factors);
+                await sender.Send(command, cancellationToken);
+                return Results.NoContent();
+            })
+            .WithName("ReorderTemplateFactors")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Reorder template factors")
+            .WithDescription("Persist the display order of factors within a market comparable template.")
+            .WithTags("MarketComparableTemplates");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/ReorderTemplateFactors/ReorderTemplateFactorsRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/ReorderTemplateFactors/ReorderTemplateFactorsRequest.cs
@@ -1,0 +1,5 @@
+namespace Appraisal.Application.Features.MarketComparableTemplates.ReorderTemplateFactors;
+
+public record ReorderTemplateFactorsRequest(List<ReorderFactorItem> Factors);
+
+public record ReorderFactorItem(Guid FactorId, int DisplaySequence);

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/ReorderTemplateFactors/ReorderTemplateFactorsResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/ReorderTemplateFactors/ReorderTemplateFactorsResult.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.MarketComparableTemplates.ReorderTemplateFactors;
+
+public record ReorderTemplateFactorsResult(bool Success);

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetMarketComparableTemplateStatus/SetMarketComparableTemplateStatusCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetMarketComparableTemplateStatus/SetMarketComparableTemplateStatusCommand.cs
@@ -1,0 +1,9 @@
+using Appraisal.Application.Configurations;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.MarketComparableTemplates.SetMarketComparableTemplateStatus;
+
+public record SetMarketComparableTemplateStatusCommand(
+    Guid Id,
+    bool IsActive
+) : ICommand<SetMarketComparableTemplateStatusResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetMarketComparableTemplateStatus/SetMarketComparableTemplateStatusCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetMarketComparableTemplateStatus/SetMarketComparableTemplateStatusCommandHandler.cs
@@ -14,7 +14,7 @@ public class SetMarketComparableTemplateStatusCommandHandler(
         var template = await repository.GetByIdAsync(command.Id, cancellationToken);
 
         if (template is null)
-            throw new InvalidOperationException($"Market comparable template with ID {command.Id} not found.");
+            throw new NotFoundException("MarketComparableTemplate", command.Id);
 
         if (command.IsActive)
             template.Activate();

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetMarketComparableTemplateStatus/SetMarketComparableTemplateStatusCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetMarketComparableTemplateStatus/SetMarketComparableTemplateStatusCommandHandler.cs
@@ -1,0 +1,28 @@
+using Appraisal.Domain.MarketComparables;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.MarketComparableTemplates.SetMarketComparableTemplateStatus;
+
+public class SetMarketComparableTemplateStatusCommandHandler(
+    IMarketComparableTemplateRepository repository
+) : ICommandHandler<SetMarketComparableTemplateStatusCommand, SetMarketComparableTemplateStatusResult>
+{
+    public async Task<SetMarketComparableTemplateStatusResult> Handle(
+        SetMarketComparableTemplateStatusCommand command,
+        CancellationToken cancellationToken)
+    {
+        var template = await repository.GetByIdAsync(command.Id, cancellationToken);
+
+        if (template is null)
+            throw new InvalidOperationException($"Market comparable template with ID {command.Id} not found.");
+
+        if (command.IsActive)
+            template.Activate();
+        else
+            template.Deactivate();
+
+        await repository.UpdateAsync(template, cancellationToken);
+
+        return new SetMarketComparableTemplateStatusResult(true);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetMarketComparableTemplateStatus/SetMarketComparableTemplateStatusEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetMarketComparableTemplateStatus/SetMarketComparableTemplateStatusEndpoint.cs
@@ -1,0 +1,34 @@
+using Carter;
+using MediatR;
+
+namespace Appraisal.Application.Features.MarketComparableTemplates.SetMarketComparableTemplateStatus;
+
+public class SetMarketComparableTemplateStatusEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/market-comparable-templates/{id:guid}/activate",
+            async (Guid id, ISender sender, CancellationToken cancellationToken) =>
+            {
+                await sender.Send(new SetMarketComparableTemplateStatusCommand(id, true), cancellationToken);
+                return Results.NoContent();
+            })
+            .WithName("ActivateMarketComparableTemplate")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Activate a market comparable template")
+            .WithTags("MarketComparableTemplates");
+
+        app.MapPost("/market-comparable-templates/{id:guid}/deactivate",
+            async (Guid id, ISender sender, CancellationToken cancellationToken) =>
+            {
+                await sender.Send(new SetMarketComparableTemplateStatusCommand(id, false), cancellationToken);
+                return Results.NoContent();
+            })
+            .WithName("DeactivateMarketComparableTemplate")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Deactivate a market comparable template")
+            .WithTags("MarketComparableTemplates");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetMarketComparableTemplateStatus/SetMarketComparableTemplateStatusResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetMarketComparableTemplateStatus/SetMarketComparableTemplateStatusResult.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.MarketComparableTemplates.SetMarketComparableTemplateStatus;
+
+public record SetMarketComparableTemplateStatusResult(bool Success);

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetTemplateFactorMandatory/SetTemplateFactorMandatoryCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetTemplateFactorMandatory/SetTemplateFactorMandatoryCommand.cs
@@ -1,0 +1,10 @@
+using Appraisal.Application.Configurations;
+using Shared.CQRS;
+
+namespace Appraisal.Application.Features.MarketComparableTemplates.SetTemplateFactorMandatory;
+
+public record SetTemplateFactorMandatoryCommand(
+    Guid TemplateId,
+    Guid FactorId,
+    bool IsMandatory
+) : ICommand<SetTemplateFactorMandatoryResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetTemplateFactorMandatory/SetTemplateFactorMandatoryCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetTemplateFactorMandatory/SetTemplateFactorMandatoryCommandHandler.cs
@@ -1,0 +1,24 @@
+using Appraisal.Domain.MarketComparables;
+using Shared.CQRS;
+using Shared.Exceptions;
+
+namespace Appraisal.Application.Features.MarketComparableTemplates.SetTemplateFactorMandatory;
+
+public class SetTemplateFactorMandatoryCommandHandler(
+    IMarketComparableTemplateRepository repository
+) : ICommandHandler<SetTemplateFactorMandatoryCommand, SetTemplateFactorMandatoryResult>
+{
+    public async Task<SetTemplateFactorMandatoryResult> Handle(
+        SetTemplateFactorMandatoryCommand command,
+        CancellationToken cancellationToken)
+    {
+        var template = await repository.GetByIdWithFactorsAsync(command.TemplateId, cancellationToken);
+
+        if (template is null)
+            throw new NotFoundException("MarketComparableTemplate", command.TemplateId);
+
+        template.SetFactorMandatory(command.FactorId, command.IsMandatory);
+
+        return new SetTemplateFactorMandatoryResult(true);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetTemplateFactorMandatory/SetTemplateFactorMandatoryEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetTemplateFactorMandatory/SetTemplateFactorMandatoryEndpoint.cs
@@ -1,0 +1,24 @@
+using Carter;
+using MediatR;
+
+namespace Appraisal.Application.Features.MarketComparableTemplates.SetTemplateFactorMandatory;
+
+public class SetTemplateFactorMandatoryEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/market-comparable-templates/{templateId:guid}/factors/{factorId:guid}/mandatory",
+            async (Guid templateId, Guid factorId, SetTemplateFactorMandatoryRequest request, ISender sender, CancellationToken cancellationToken) =>
+            {
+                var command = new SetTemplateFactorMandatoryCommand(templateId, factorId, request.IsMandatory);
+                await sender.Send(command, cancellationToken);
+                return Results.NoContent();
+            })
+            .WithName("SetTemplateFactorMandatory")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Set whether a template factor is mandatory")
+            .WithDescription("Update a factor's mandatory flag within a market comparable template without altering its display order.")
+            .WithTags("MarketComparableTemplates");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetTemplateFactorMandatory/SetTemplateFactorMandatoryRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetTemplateFactorMandatory/SetTemplateFactorMandatoryRequest.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.MarketComparableTemplates.SetTemplateFactorMandatory;
+
+public record SetTemplateFactorMandatoryRequest(bool IsMandatory);

--- a/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetTemplateFactorMandatory/SetTemplateFactorMandatoryResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/MarketComparableTemplates/SetTemplateFactorMandatory/SetTemplateFactorMandatoryResult.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.MarketComparableTemplates.SetTemplateFactorMandatory;
+
+public record SetTemplateFactorMandatoryResult(bool Success);

--- a/Modules/Appraisal/Appraisal/Domain/ComparativeAnalysis/ComparativeAnalysisTemplate.cs
+++ b/Modules/Appraisal/Appraisal/Domain/ComparativeAnalysis/ComparativeAnalysisTemplate.cs
@@ -91,7 +91,7 @@ public class ComparativeAnalysisTemplate : Entity<Guid>
     public void UpdateFactorSequence(Guid factorId, int newSequence)
     {
         var factor = _factors.FirstOrDefault(f => f.FactorId == factorId)
-                     ?? throw new InvalidOperationException($"Factor {factorId} not found in this template");
+                     ?? throw new NotFoundException("ComparativeAnalysisTemplateFactor", factorId);
 
         factor.UpdateSequence(newSequence);
     }
@@ -109,7 +109,7 @@ public class ComparativeAnalysisTemplate : Entity<Guid>
         bool isCalculationFactor)
     {
         var factor = _factors.FirstOrDefault(f => f.FactorId == factorId)
-                     ?? throw new InvalidOperationException($"Factor {factorId} not found in this template");
+                     ?? throw new NotFoundException("ComparativeAnalysisTemplateFactor", factorId);
 
         // In-place field update — never touches DisplaySequence, so it cannot collide with
         // the resequencing done by RemoveFactor (unlike the old remove+add toggle flow).

--- a/Modules/Appraisal/Appraisal/Domain/ComparativeAnalysis/ComparativeAnalysisTemplate.cs
+++ b/Modules/Appraisal/Appraisal/Domain/ComparativeAnalysis/ComparativeAnalysisTemplate.cs
@@ -95,4 +95,24 @@ public class ComparativeAnalysisTemplate : Entity<Guid>
 
         factor.UpdateSequence(newSequence);
     }
+
+    public void ReorderFactors(IEnumerable<(Guid FactorId, int NewSequence)> reorderCommands)
+    {
+        TemplateFactorOrdering.Reorder(_factors, reorderCommands);
+    }
+
+    public void UpdateFactor(
+        Guid factorId,
+        bool isMandatory,
+        decimal? defaultWeight,
+        decimal? defaultIntensity,
+        bool isCalculationFactor)
+    {
+        var factor = _factors.FirstOrDefault(f => f.FactorId == factorId)
+                     ?? throw new InvalidOperationException($"Factor {factorId} not found in this template");
+
+        // In-place field update — never touches DisplaySequence, so it cannot collide with
+        // the resequencing done by RemoveFactor (unlike the old remove+add toggle flow).
+        factor.Update(isMandatory, defaultWeight, defaultIntensity, isCalculationFactor);
+    }
 }

--- a/Modules/Appraisal/Appraisal/Domain/ComparativeAnalysis/ComparativeAnalysisTemplateFactor.cs
+++ b/Modules/Appraisal/Appraisal/Domain/ComparativeAnalysis/ComparativeAnalysisTemplateFactor.cs
@@ -4,7 +4,7 @@ namespace Appraisal.Domain.ComparativeAnalysis;
 /// Junction entity linking a template to its factors.
 /// References the existing MarketComparableFactor entity.
 /// </summary>
-public class ComparativeAnalysisTemplateFactor : Entity<Guid>
+public class ComparativeAnalysisTemplateFactor : Entity<Guid>, ISequencedTemplateFactor
 {
     public Guid TemplateId { get; private set; }
     public Guid FactorId { get; private set; } // FK → MarketComparableFactor
@@ -25,7 +25,7 @@ public class ComparativeAnalysisTemplateFactor : Entity<Guid>
         decimal? defaultIntensity = null,
         bool isCalculationFactor = false)
     {
-        if (defaultWeight.HasValue && (defaultWeight < 0 || defaultWeight > 100))
+        if (isCalculationFactor && defaultWeight.HasValue && (defaultWeight < 0 || defaultWeight > 100))
             throw new ArgumentException("DefaultWeight must be between 0 and 100");
 
         return new ComparativeAnalysisTemplateFactor
@@ -34,8 +34,9 @@ public class ComparativeAnalysisTemplateFactor : Entity<Guid>
             FactorId = factorId,
             DisplaySequence = displaySequence,
             IsMandatory = isMandatory,
-            DefaultWeight = defaultWeight,
-            DefaultIntensity = defaultIntensity,
+            // Weight/intensity only apply to calculation factors; keep them null otherwise.
+            DefaultWeight = isCalculationFactor ? defaultWeight : null,
+            DefaultIntensity = isCalculationFactor ? defaultIntensity : null,
             IsCalculationFactor = isCalculationFactor
         };
     }
@@ -47,12 +48,15 @@ public class ComparativeAnalysisTemplateFactor : Entity<Guid>
 
     public void Update(bool isMandatory, decimal? defaultWeight, decimal? defaultIntensity = null, bool isCalculationFactor = false)
     {
-        if (defaultWeight.HasValue && (defaultWeight < 0 || defaultWeight > 100))
+        if (isCalculationFactor && defaultWeight.HasValue && (defaultWeight < 0 || defaultWeight > 100))
             throw new ArgumentException("DefaultWeight must be between 0 and 100");
 
         IsMandatory = isMandatory;
-        DefaultWeight = defaultWeight;
-        DefaultIntensity = defaultIntensity;
         IsCalculationFactor = isCalculationFactor;
+
+        // Weight and intensity only apply to calculation factors. Clear the stored values when a
+        // factor is not (or no longer) a calculation factor so no stale data is left behind.
+        DefaultWeight = isCalculationFactor ? defaultWeight : null;
+        DefaultIntensity = isCalculationFactor ? defaultIntensity : null;
     }
 }

--- a/Modules/Appraisal/Appraisal/Domain/ISequencedTemplateFactor.cs
+++ b/Modules/Appraisal/Appraisal/Domain/ISequencedTemplateFactor.cs
@@ -1,0 +1,14 @@
+namespace Appraisal.Domain;
+
+/// <summary>
+/// A template factor that carries a display ordering and can be resequenced. Implemented by both
+/// <see cref="ComparativeAnalysis.ComparativeAnalysisTemplateFactor"/> and
+/// <see cref="MarketComparables.MarketComparableTemplateFactor"/> so the shared reorder algorithm
+/// (<see cref="TemplateFactorOrdering"/>) can be written once.
+/// </summary>
+public interface ISequencedTemplateFactor
+{
+    Guid FactorId { get; }
+    int DisplaySequence { get; }
+    void UpdateSequence(int sequence);
+}

--- a/Modules/Appraisal/Appraisal/Domain/MarketComparables/MarketComparableTemplate.cs
+++ b/Modules/Appraisal/Appraisal/Domain/MarketComparables/MarketComparableTemplate.cs
@@ -62,17 +62,30 @@ public class MarketComparableTemplate : Entity<Guid>
     public void RemoveFactor(Guid factorId)
     {
         var factor = _templateFactors.FirstOrDefault(tf => tf.FactorId == factorId);
-        if (factor != null)
-            _templateFactors.Remove(factor);
+        if (factor is null)
+            return;
+
+        _templateFactors.Remove(factor);
+        Renumber();
     }
 
     public void ReorderFactors(IEnumerable<(Guid FactorId, int NewSequence)> reorderCommands)
     {
-        foreach (var (factorId, newSequence) in reorderCommands)
-        {
-            var factor = _templateFactors.FirstOrDefault(tf => tf.FactorId == factorId);
-            factor?.UpdateSequence(newSequence);
-        }
+        TemplateFactorOrdering.Reorder(_templateFactors, reorderCommands);
+    }
+
+    // Reassigns a contiguous 1..n ordering (by current sequence) so no gaps or duplicates remain.
+    private void Renumber()
+    {
+        var ordered = _templateFactors.OrderBy(tf => tf.DisplaySequence).ToList();
+        for (var i = 0; i < ordered.Count; i++)
+            ordered[i].UpdateSequence(i + 1);
+    }
+
+    public void SetFactorMandatory(Guid factorId, bool isMandatory)
+    {
+        var factor = _templateFactors.FirstOrDefault(tf => tf.FactorId == factorId);
+        factor?.SetMandatory(isMandatory);
     }
 
     public void Activate() => IsActive = true;

--- a/Modules/Appraisal/Appraisal/Domain/MarketComparables/MarketComparableTemplate.cs
+++ b/Modules/Appraisal/Appraisal/Domain/MarketComparables/MarketComparableTemplate.cs
@@ -84,8 +84,9 @@ public class MarketComparableTemplate : Entity<Guid>
 
     public void SetFactorMandatory(Guid factorId, bool isMandatory)
     {
-        var factor = _templateFactors.FirstOrDefault(tf => tf.FactorId == factorId);
-        factor?.SetMandatory(isMandatory);
+        var factor = _templateFactors.FirstOrDefault(tf => tf.FactorId == factorId)
+                     ?? throw new NotFoundException("MarketComparableTemplateFactor", factorId);
+        factor.SetMandatory(isMandatory);
     }
 
     public void Activate() => IsActive = true;

--- a/Modules/Appraisal/Appraisal/Domain/MarketComparables/MarketComparableTemplateFactor.cs
+++ b/Modules/Appraisal/Appraisal/Domain/MarketComparables/MarketComparableTemplateFactor.cs
@@ -4,7 +4,7 @@ namespace Appraisal.Domain.MarketComparables;
 /// Junction entity linking templates to factors with display ordering.
 /// Managed as a child of MarketComparableTemplate.
 /// </summary>
-public class MarketComparableTemplateFactor : Entity<Guid>
+public class MarketComparableTemplateFactor : Entity<Guid>, ISequencedTemplateFactor
 {
     public Guid TemplateId { get; private set; }
     public Guid FactorId { get; private set; }
@@ -38,6 +38,10 @@ public class MarketComparableTemplateFactor : Entity<Guid>
     {
         DisplaySequence = newSequence;
     }
+
+    // Explicit interface implementation delegates to the internal method so the shared reorder
+    // helper can resequence factors without widening UpdateSequence's accessibility.
+    void ISequencedTemplateFactor.UpdateSequence(int sequence) => UpdateSequence(sequence);
 
     internal void SetMandatory(bool isMandatory)
     {

--- a/Modules/Appraisal/Appraisal/Domain/TemplateFactorOrdering.cs
+++ b/Modules/Appraisal/Appraisal/Domain/TemplateFactorOrdering.cs
@@ -1,0 +1,43 @@
+namespace Appraisal.Domain;
+
+/// <summary>
+/// Shared reordering for template factors. Extracted so ComparativeAnalysisTemplate and
+/// MarketComparableTemplate share one implementation instead of duplicating it.
+/// </summary>
+public static class TemplateFactorOrdering
+{
+    /// <summary>
+    /// Treats the payload as an ordering intent, not literal sequence numbers. Orders factors by
+    /// the requested sequence, appends any factors missing from the payload (by current order),
+    /// then reassigns a contiguous 1..n. Duplicate or partial payloads still yield a clean set.
+    /// </summary>
+    public static void Reorder<T>(
+        IList<T> factors,
+        IEnumerable<(Guid FactorId, int NewSequence)> reorderCommands)
+        where T : class, ISequencedTemplateFactor
+    {
+        var requestedOrder = reorderCommands
+            .GroupBy(c => c.FactorId)
+            .Select(g => (FactorId: g.Key, NewSequence: g.Last().NewSequence))
+            .OrderBy(c => c.NewSequence)
+            .Select(c => c.FactorId)
+            .ToList();
+
+        var ordered = new List<T>();
+        foreach (var factorId in requestedOrder)
+        {
+            var factor = factors.FirstOrDefault(f => f.FactorId == factorId);
+            if (factor is not null && !ordered.Contains(factor))
+                ordered.Add(factor);
+        }
+
+        foreach (var factor in factors.OrderBy(f => f.DisplaySequence))
+        {
+            if (!ordered.Contains(factor))
+                ordered.Add(factor);
+        }
+
+        for (var i = 0; i < ordered.Count; i++)
+            ordered[i].UpdateSequence(i + 1);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Infrastructure/Repositories/ComparativeAnalysisTemplateRepository.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Repositories/ComparativeAnalysisTemplateRepository.cs
@@ -45,7 +45,7 @@ public class ComparativeAnalysisTemplateRepository(AppraisalDbContext dbContext)
     {
         return await _dbContext.ComparativeAnalysisTemplates
             .Include(t => t.Factors)
-            .OrderBy(t => t.PropertyType)
+            .OrderBy(t => t.CreatedAt)
             .ThenBy(t => t.TemplateName)
             .ToListAsync(cancellationToken);
     }
@@ -56,7 +56,7 @@ public class ComparativeAnalysisTemplateRepository(AppraisalDbContext dbContext)
         return await _dbContext.ComparativeAnalysisTemplates
             .Include(t => t.Factors)
             .Where(t => t.IsActive)
-            .OrderBy(t => t.PropertyType)
+            .OrderBy(t => t.CreatedAt)
             .ThenBy(t => t.TemplateName)
             .ToListAsync(cancellationToken);
     }


### PR DESCRIPTION
Batches already-actioned CA-board low-priority defects from `CA-lowpriority-defect-triage.md` (backend side). Pairs with the app repo PR of the same branch name.

## CA tickets resolved
- **Template Management** — CA-448, CA-449 (delete-factor confirmation), CA-450, CA-451 (single Edit button), CA-459 (activate/deactivate status), CA-460 (Factors count column), CA-461 (in-place factor edit → fixes duplicate running number)
- **Construction Inspection** — CA-338 (seed "Groundwork" Building Structure item), CA-339 (relabel "Protection System" → "Fire Protection System")

## Extra scope (not separately ticketed)
Bundled with the template work: drag-to-reorder factors, set-mandatory toggle, and delete hardening (hard-delete + 409 conflict guard when a factor is still referenced).

## Notes
- Two new DbUp seed scripts run on next deploy.
- No EF schema migration in this PR (template changes add no columns).
- `dotnet build` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpPDZpdFipoSk8ev5QQXF