### PR TITLE
fix(ca): quotation submit guard + reappraisal Send-to-RM gate + meeting attachment validation (CA-380, CA-444, CA-322)

### DIFF
--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotationById/GetQuotationByIdQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotationById/GetQuotationByIdQueryHandler.cs
@@ -140,7 +140,8 @@ public class GetQuotationByIdQueryHandler(
                     LoanType: quotation.BankingSegment,
                     RequestId: meta.RequestId == Guid.Empty ? null : meta.RequestId,
                     CustomerName: customerName,
-                    MaxAppraisalDays: item?.MaxAppraisalDays);
+                    MaxAppraisalDays: item?.MaxAppraisalDays,
+                    AppraisalType: meta.AppraisalType);
             })
             .ToList();
 
@@ -272,13 +273,13 @@ public class GetQuotationByIdQueryHandler(
         _ => code,
     };
 
-    private async Task<Dictionary<Guid, (Guid RequestId, string? AppraisalNumber, string? CollateralType)>> ResolveAppraisalMetaAsync(Guid[] appraisalIds)
+    private async Task<Dictionary<Guid, (Guid RequestId, string? AppraisalNumber, string? CollateralType, string? AppraisalType)>> ResolveAppraisalMetaAsync(Guid[] appraisalIds)
     {
         if (appraisalIds.Length == 0)
-            return new Dictionary<Guid, (Guid, string?, string?)>();
+            return new Dictionary<Guid, (Guid, string?, string?, string?)>();
 
         var connection = connectionFactory.GetOpenConnection();
-        var rows = await connection.QueryAsync<(Guid AppraisalId, Guid RequestId, string? AppraisalNumber, string? CollateralType)>(
+        var rows = await connection.QueryAsync<(Guid AppraisalId, Guid RequestId, string? AppraisalNumber, string? CollateralType, string? AppraisalType)>(
             """
             SELECT a.Id AS AppraisalId,
                    a.RequestId,
@@ -286,7 +287,8 @@ public class GetQuotationByIdQueryHandler(
                    (SELECT TOP 1 rp.PropertyType
                     FROM [request].[RequestProperties] rp
                     WHERE rp.RequestId = a.RequestId
-                    ORDER BY rp.Id) AS CollateralType
+                    ORDER BY rp.Id) AS CollateralType,
+                   a.AppraisalType
             FROM [appraisal].[Appraisals] a
             WHERE a.Id IN @AppraisalIds
             """,
@@ -294,7 +296,7 @@ public class GetQuotationByIdQueryHandler(
 
         return rows.ToDictionary(
             r => r.AppraisalId,
-            r => (r.RequestId, r.AppraisalNumber, r.CollateralType));
+            r => (r.RequestId, r.AppraisalNumber, r.CollateralType, r.AppraisalType));
     }
 
     private async Task<Dictionary<Guid, string?>> ResolveAppraisalCustomerNamesAsync(Guid[] appraisalIds)

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotationById/GetQuotationByIdResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotationById/GetQuotationByIdResult.cs
@@ -110,7 +110,9 @@ public record QuotationAppraisalResult(
     Guid? RequestId,
     string? CustomerName,
     // Admin-set maximum allowed duration in days (nullable — null means no cap set)
-    int? MaxAppraisalDays
+    int? MaxAppraisalDays,
+    // Appraisal type (New, ReAppraisal, Progressive, PreAppraisal). FE gates Send-to-RM on ReAppraisal.
+    string? AppraisalType
 );
 
 public record CompanyQuotationResult(

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/SubmitDraftToChecker/SubmitDraftToCheckerCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/SubmitDraftToChecker/SubmitDraftToCheckerCommandHandler.cs
@@ -53,6 +53,15 @@ public class SubmitDraftToCheckerCommandHandler(
             throw new BadRequestException(
                 $"Cannot submit to checker: existing quotation is in status '{companyQuotation.Status}'");
 
+        // Completeness guard: Fee Amount and Estimated Days are mandatory per item. The draft may be
+        // saved incomplete, but promoting it to Checker review requires every item to be fully priced.
+        if (companyQuotation.Items.Count == 0)
+            throw new BadRequestException("Cannot submit to checker: the quotation has no items");
+
+        if (companyQuotation.Items.Any(i => i.FeeAmount <= 0 || i.EstimatedDays <= 0))
+            throw new BadRequestException(
+                "Cannot submit to checker: every item must have a Fee Amount and Estimated Days greater than zero");
+
         var makerUsername = currentUser.Username
             ?? currentUser.UserId?.ToString()
             ?? throw new UnauthorizedAccessException("Cannot resolve the current user identity for maker attribution");

--- a/Modules/Workflow/Workflow/Meetings/Features/SendInvitation/SendInvitationEndpoint.cs
+++ b/Modules/Workflow/Workflow/Meetings/Features/SendInvitation/SendInvitationEndpoint.cs
@@ -75,6 +75,8 @@ public class SendInvitationCommandValidator : AbstractValidator<SendInvitationCo
         RuleForEach(x => x.Attachments).MaximumLength(200).When(x => x.Attachments is not null);
         RuleFor(x => x.Attachments).Must(a => a is null || a.Length <= 10)
             .WithMessage("Maximum 10 attachments allowed.");
+        RuleFor(x => x.Attachments).Must(a => a is not null && a.Any(d => !string.IsNullOrWhiteSpace(d)))
+            .WithMessage("At least one attachment is required.");
     }
 }
 
@@ -82,7 +84,6 @@ public record SendInvitationResponse(Guid MeetingId, string? MeetingNo, DateTime
 
 public class SendInvitationCommandHandler(
     IMeetingRepository meetingRepository,
-    IMeetingDocumentGenerator meetingDocumentGenerator,
     IDateTimeProvider dateTimeProvider,
     WorkflowDbContext dbContext,
     IIntegrationEventOutbox outbox)
@@ -99,45 +100,16 @@ public class SendInvitationCommandHandler(
             .Select(d => d.Trim())
             .ToList();
 
-        var pickedSet = pickedDocIds.ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        // Determine whether the user already picked a meeting Invitation document.
-        // If so, skip generation to avoid attaching it twice.
-        var invitationAlreadyPicked = meeting.Documents.Any(d =>
-            d.DocumentType == "Invitation" && pickedSet.Contains(d.DocumentId.ToString()));
-
         // Build attachment refs — all as ("document", id) so the email consumer
         // always resolves a real persisted document (no async report rendering after send).
-        var attachmentRefs = new List<EmailAttachmentRefData>();
-
-        if (!invitationAlreadyPicked)
-        {
-            // Generate the invitation PDF synchronously NOW. If it fails, surface an actionable
-            // error and send nothing — the admin can generate/upload the invitation in Documents,
-            // attach it, and resend (which then skips this generation step).
-            MeetingDocument generatedDoc;
-            try
-            {
-                generatedDoc = await meetingDocumentGenerator.GenerateAndLinkAsync(meeting, "Invitation", ct);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                throw new BadRequestException(
-                    "Could not generate the meeting invitation PDF, so the invitation was not sent. " +
-                    "Generate or upload the invitation in Documents, attach it, and try again.",
-                    ex.Message);
-            }
-
-            attachmentRefs.Add(new EmailAttachmentRefData("document", generatedDoc.DocumentId.ToString()));
-        }
-
-        foreach (var docId in pickedDocIds)
-            attachmentRefs.Add(new EmailAttachmentRefData("document", docId));
+        // The email carries exactly what the user attached; nothing is auto-generated here.
+        var attachmentRefs = pickedDocIds
+            .Select(docId => new EmailAttachmentRefData("document", docId))
+            .ToList();
 
         meeting.SendInvitation(dateTimeProvider.ApplicationNow);
 
-        // Audit log records every document actually attached (the auto-generated invitation + picked docs),
-        // not just the user-picked ones.
+        // Audit log records every document actually attached.
         var attachedDocumentIds = attachmentRefs.Select(r => r.Value).ToArray();
 
         var emailLog = MeetingInvitationEmail.Create(

--- a/Modules/Workflow/Workflow/Meetings/Features/SendInvitation/SendInvitationEndpoint.cs
+++ b/Modules/Workflow/Workflow/Meetings/Features/SendInvitation/SendInvitationEndpoint.cs
@@ -73,7 +73,7 @@ public class SendInvitationCommandValidator : AbstractValidator<SendInvitationCo
         RuleFor(x => x.Subject).NotEmpty().MaximumLength(500);
         RuleFor(x => x.Content).MaximumLength(4000).When(x => x.Content is not null);
         RuleForEach(x => x.Attachments).MaximumLength(200).When(x => x.Attachments is not null);
-        RuleFor(x => x.Attachments).Must(a => a is null || a.Length <= 10)
+        RuleFor(x => x.Attachments).Must(a => a is null || a.Count(d => !string.IsNullOrWhiteSpace(d)) <= 10)
             .WithMessage("Maximum 10 attachments allowed.");
         RuleFor(x => x.Attachments).Must(a => a is not null && a.Any(d => !string.IsNullOrWhiteSpace(d)))
             .WithMessage("At least one attachment is required.");


### PR DESCRIPTION
Fixes three low-priority CA-board defects (all in the *Reviewed / actioned* set of the low-priority triage). Backend-only.

## Change → CA mapping

| CA | Fix | Files |
|----|-----|-------|
| **CA-380** — External quotation submit allowed without service fee | Completeness guard in submit-to-checker: rejects an empty item list and any item with `FeeAmount <= 0` or `EstimatedDays <= 0`. | `SubmitDraftToCheckerCommandHandler.cs` |
| **CA-444** — Disable "Send to RM" on Quotation for reappraisal | Surfaces `AppraisalType` from `appraisal.Appraisals` through `ResolveAppraisalMetaAsync` into `QuotationAppraisalResult`, so the FE can gate Send-to-RM on ReAppraisal. | `GetQuotationByIdQueryHandler.cs`, `GetQuotationByIdResult.cs` |
| **CA-322** — Meeting e-mail attachment missing mandatory validation | Adds a "≥1 attachment required" validator rule counting **non-blank** entries (matches the handler's `IsNullOrWhiteSpace` filter); removes the synchronous auto-generated invitation PDF so the email carries exactly what the user attached. | `SendInvitationEndpoint.cs` |

## Known considerations for reviewers

- **CA-380 zero-fee guard** — this hard-blocks promoting a draft that contains an intentionally zero-fee / bank-absorbed line item. Proceeding per the defect's intent ("submit must require a service fee"); please confirm zero-fee line items are never legitimate at this stage.
- **CA-322 auto-generate removal** — dropping the synchronous invitation PDF is a deliberate breaking change: every caller must now attach ≥1 document (consistent with the user-driven, no-auto-generate invitation redesign).

## Verification

- `dotnet build` on both touched modules (Appraisal, Workflow): **0 errors**.
- A `/code-review` high pass ran on the diff; its one CONFIRMED bug (blank-string attachments bypassing the ≥1 rule) is fixed in this branch by counting non-blank entries in the validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CGqiBsRDQX3aPVoJAxaEf