### PR TITLE
fix(integration): drop stale MarketValue column from appraisal-result query

### DIFF
--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQuery.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQuery.cs
@@ -20,7 +20,6 @@ public record GetAppraisalResultResponse(
     decimal? TotalAppraisalValue,
     decimal? ForceSalePrice,
     decimal? FireInsurance,
-    decimal? MarketValue,
     List<AppraisalResultGroup> Groups,
     List<AppraisalResultDocument> Documents);
 

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQueryHandler.cs
@@ -99,7 +99,7 @@ internal static class GetAppraisalResultSql
                               """;
 
     public const string ValuationTotals = """
-                                          SELECT va.AppraisedValue, va.ForcedSaleValue, va.InsuranceValue, va.MarketValue, va.ValuationDate
+                                          SELECT va.AppraisedValue, va.ForcedSaleValue, va.InsuranceValue, va.ValuationDate
                                           FROM appraisal.ValuationAnalyses va
                                           WHERE va.AppraisalId = @AppraisalId
                                           """;
@@ -205,7 +205,6 @@ internal sealed record ValuationRow(
     decimal? AppraisedValue,
     decimal? ForcedSaleValue,
     decimal? InsuranceValue,
-    decimal? MarketValue,
     DateTime? ValuationDate);
 
 internal sealed record CollateralRow(
@@ -392,7 +391,6 @@ internal static class AppraisalResultBuilder
             TotalAppraisalValue: valuation?.AppraisedValue,
             ForceSalePrice: valuation?.ForcedSaleValue,
             FireInsurance: valuation?.InsuranceValue,
-            MarketValue: valuation?.MarketValue,
             Groups: groups,
             Documents: documents);
     }


### PR DESCRIPTION
## Problem

`GET /api/v1/appraisals/result?externalCaseKey=...` returned **500** `SqlException: Invalid column name 'MarketValue'`. The sibling route `GET /api/v1/appraisals/{appraisalNumber}/result` shares the same handler/SQL and was equally broken.

## Root cause

Migration `20260627165837_RemoveDeadValuationAnalysisStructure` (2026-06-27) dropped `MarketValue` from `appraisal.ValuationAnalyses` as dead structure, but the Integration read-model query still selected `va.MarketValue`.

## Fix

Remove `MarketValue` from the read path entirely:
- `va.MarketValue` from the `ValuationTotals` SQL
- `MarketValue` from the `ValuationRow` Dapper record
- the `MarketValue:` response mapping
- the `decimal? MarketValue` field on `GetAppraisalResultResponse`

## Why dropping is safe

- The AS400 outbound **Collateral Result (202-char)** feed is a separate path and has **no market-value field**.
- No `.http` test pins this endpoint's response shape.
- The concept was folded into `AppraisedValue`, already returned as `totalAppraisalValue` — so no data is lost.

No DB migration needed (column already gone). Integration module builds green.

## Verification

- [x] `dotnet build` — 0 errors
- [ ] Run API, `GET /api/v1/appraisals/result?externalCaseKey=601-003090-2566` → expect 200, `totalAppraisalValue` populated, no `marketValue` key
- [ ] Smoke-test `GET /api/v1/appraisals/{appraisalNumber}/result`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KD3M7wGzbugR3bm4nNZ84S