### PR TITLE
feat(dashboard): live company summary + by-type/segment appraisal counts

### DIFF
--- a/Database/Scripts/Views/Common/vw_CompanyAppraisalSummaryLive.sql
+++ b/Database/Scripts/Views/Common/vw_CompanyAppraisalSummaryLive.sql
@@ -1,0 +1,49 @@
+CREATE
+OR ALTER
+VIEW common.vw_CompanyAppraisalSummaryLive AS
+/*
+ * One row per appraisal (its latest non-cancelled external assignment) classified into
+ * exactly one of three mutually-exclusive buckets. Read live by
+ * GET /dashboard/company-appraisal-summary so Completed + InProgress + Overdue = Assigned
+ * for every company, with no double-counting.
+ *
+ * Grain      — distinct appraisal = latest AppraisalAssignment with AssigneeCompanyId,
+ *              same canonical population as vw_CompanyAppraisalSummariesFromSource.
+ * IsCompleted  — the external company delivered (SubmittedAt set = first hand-off).
+ * IsOverdue    — not yet delivered and past the frozen SLA due date (matches the
+ *                'Breached' rule in appraisal.vw_AssignmentList). SLADueDate NULL ⇒ never overdue.
+ * IsInProgress — not yet delivered and either on-time or with no SLA policy.
+ *
+ * GETDATE() keeps overdue live/point-in-time (local kind, matches SLADueDate).
+ */
+WITH latest_assignment AS (
+    SELECT
+        a.Id                                                AS AppraisalId,
+        a.CreatedAt,
+        TRY_CAST(aa.AssigneeCompanyId AS uniqueidentifier)  AS CompanyId,
+        comp.Name                                           AS CompanyName,
+        aa.SubmittedAt,
+        aa.SLADueDate
+    FROM appraisal.Appraisals a
+    INNER JOIN (
+        SELECT AppraisalId, AssigneeCompanyId, SubmittedAt, SLADueDate,
+               ROW_NUMBER() OVER (PARTITION BY AppraisalId ORDER BY CreatedAt DESC) AS rn
+        FROM appraisal.AppraisalAssignments
+        WHERE AssigneeCompanyId IS NOT NULL
+          AND AssignmentStatus NOT IN ('Rejected', 'Cancelled')
+    ) aa ON aa.AppraisalId = a.Id AND aa.rn = 1
+    LEFT JOIN auth.Companies comp
+        ON comp.Id = TRY_CAST(aa.AssigneeCompanyId AS uniqueidentifier)
+    WHERE a.IsDeleted = 0
+)
+SELECT
+    AppraisalId,
+    CompanyId,
+    CompanyName,
+    CreatedAt,
+    CASE WHEN SubmittedAt IS NOT NULL THEN 1 ELSE 0 END AS IsCompleted,
+    CASE WHEN SubmittedAt IS NULL AND SLADueDate IS NOT NULL
+              AND SLADueDate < GETDATE() THEN 1 ELSE 0 END AS IsOverdue,
+    CASE WHEN SubmittedAt IS NULL AND (SLADueDate IS NULL OR SLADueDate >= GETDATE())
+              THEN 1 ELSE 0 END AS IsInProgress
+FROM latest_assignment;

--- a/Database/Scripts/Views/Common/vw_DailyAppraisalCountsByType.sql
+++ b/Database/Scripts/Views/Common/vw_DailyAppraisalCountsByType.sql
@@ -1,0 +1,57 @@
+CREATE
+OR ALTER
+VIEW common.vw_DailyAppraisalCountsByType AS
+/*
+ * Canonical daily appraisal counts, broken down by AppraisalType and BankingSegment,
+ * derived directly from source tables.
+ *
+ * Backs GET /dashboard/appraisal-counts:
+ *   - Overview mode sums CreatedCount / CompletedCount over all types/segments per period.
+ *   - By-type mode groups additionally by AppraisalType (one series per type).
+ *   - An optional BankingSegment filter narrows to a single segment.
+ *
+ * BankingSegment is normalized with ISNULL(..., 'IBG') so NULL rows count as IBG,
+ * matching the convention used elsewhere in the Appraisal module.
+ *
+ * CreatedCount   — appraisals of that type/segment created on each calendar day.
+ * CompletedCount — appraisals of that type/segment whose CompletedAt falls on that day.
+ */
+SELECT
+    d.Date,
+    d.AppraisalType,
+    d.BankingSegment,
+    ISNULL(c.CreatedCount, 0)   AS CreatedCount,
+    ISNULL(x.CompletedCount, 0) AS CompletedCount
+FROM (
+    -- Union of all distinct (date, type, segment) tuples from both created and completed events
+    SELECT CAST(a.CreatedAt AS DATE) AS Date, a.AppraisalType AS AppraisalType,
+           ISNULL(a.BankingSegment, 'IBG') AS BankingSegment
+    FROM appraisal.Appraisals a
+    WHERE a.IsDeleted = 0
+    UNION
+    SELECT CAST(a.CompletedAt AS DATE) AS Date, a.AppraisalType AS AppraisalType,
+           ISNULL(a.BankingSegment, 'IBG') AS BankingSegment
+    FROM appraisal.Appraisals a
+    WHERE a.IsDeleted = 0 AND a.CompletedAt IS NOT NULL
+) d
+LEFT JOIN (
+    SELECT
+        CAST(a.CreatedAt AS DATE)       AS Date,
+        a.AppraisalType                 AS AppraisalType,
+        ISNULL(a.BankingSegment, 'IBG') AS BankingSegment,
+        COUNT(*)                        AS CreatedCount
+    FROM appraisal.Appraisals a
+    WHERE a.IsDeleted = 0
+    GROUP BY CAST(a.CreatedAt AS DATE), a.AppraisalType, ISNULL(a.BankingSegment, 'IBG')
+) c ON c.Date = d.Date AND c.AppraisalType = d.AppraisalType AND c.BankingSegment = d.BankingSegment
+LEFT JOIN (
+    SELECT
+        CAST(a.CompletedAt AS DATE)     AS Date,
+        a.AppraisalType                 AS AppraisalType,
+        ISNULL(a.BankingSegment, 'IBG') AS BankingSegment,
+        COUNT(*)                        AS CompletedCount
+    FROM appraisal.Appraisals a
+    WHERE a.IsDeleted = 0
+      AND a.CompletedAt IS NOT NULL
+    GROUP BY CAST(a.CompletedAt AS DATE), a.AppraisalType, ISNULL(a.BankingSegment, 'IBG')
+) x ON x.Date = d.Date AND x.AppraisalType = d.AppraisalType AND x.BankingSegment = d.BankingSegment;

--- a/Modules/Common/Common/Application/Features/Dashboard/GetAppraisalCounts/GetAppraisalCountsEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Dashboard/GetAppraisalCounts/GetAppraisalCountsEndpoint.cs
@@ -15,10 +15,13 @@ public class GetAppraisalCountsEndpoint : ICarterModule
                     string? period,
                     DateOnly? from,
                     DateOnly? to,
+                    bool? groupByType,
+                    string? bankingSegment,
                     ISender sender,
                     CancellationToken cancellationToken) =>
                 {
-                    var query = new GetAppraisalCountsQuery(period ?? "monthly", from, to);
+                    var query = new GetAppraisalCountsQuery(
+                        period ?? "monthly", from, to, groupByType ?? false, bankingSegment);
                     var result = await sender.Send(query, cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Dashboard/GetAppraisalCounts/GetAppraisalCountsQuery.cs
+++ b/Modules/Common/Common/Application/Features/Dashboard/GetAppraisalCounts/GetAppraisalCountsQuery.cs
@@ -5,7 +5,9 @@ namespace Common.Application.Features.Dashboard.GetAppraisalCounts;
 public record GetAppraisalCountsQuery(
     string Period,
     DateOnly? From,
-    DateOnly? To
+    DateOnly? To,
+    bool GroupByType = false,
+    string? BankingSegment = null
 ) : IQuery<GetAppraisalCountsResult>;
 
 public record GetAppraisalCountsResult(List<AppraisalCountDto> Items);
@@ -13,6 +15,8 @@ public record GetAppraisalCountsResult(List<AppraisalCountDto> Items);
 public record AppraisalCountDto
 {
     public string? Period { get; init; }
+    // Null in overview mode; carries the appraisal type when GroupByType is requested.
+    public string? AppraisalType { get; init; }
     public int CreatedCount { get; init; }
     public int CompletedCount { get; init; }
 }

--- a/Modules/Common/Common/Application/Features/Dashboard/GetAppraisalCounts/GetAppraisalCountsQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Dashboard/GetAppraisalCounts/GetAppraisalCountsQueryHandler.cs
@@ -25,20 +25,38 @@ public class GetAppraisalCountsQueryHandler(
             _ => ("YEAR(Date), MONTH(Date)", "CONCAT(YEAR(Date), '-', RIGHT('0' + CAST(MONTH(Date) AS varchar), 2))")
         };
 
+        // Read from the view (drops the event-sourced read-model dependency).
+        // In by-type mode we add AppraisalType to the projection and grouping so
+        // the frontend can render one series per appraisal type.
+        var selectType = query.GroupByType ? "AppraisalType," : "";
+        var groupByType = query.GroupByType ? ", AppraisalType" : "";
+
+        // Optional banking-segment filter. The view normalizes NULL → 'IBG', and we
+        // compare case-insensitively so the frontend can pass canonical 'Retail'/'IBG'.
+        var segmentFilter = string.IsNullOrWhiteSpace(query.BankingSegment)
+            ? ""
+            : " AND UPPER(BankingSegment) = UPPER(@BankingSegment)";
+
         var sql = $"""
             SELECT
                 {selectPeriod} AS Period,
+                {selectType}
                 SUM(CreatedCount) AS CreatedCount,
                 SUM(CompletedCount) AS CompletedCount
-            FROM common.DailyAppraisalCounts
-            WHERE Date >= @From AND Date <= @To
-            GROUP BY {groupBy}
-            ORDER BY {groupBy}
+            FROM common.vw_DailyAppraisalCountsByType
+            WHERE Date >= @From AND Date <= @To{segmentFilter}
+            GROUP BY {groupBy}{groupByType}
+            ORDER BY {groupBy}{groupByType}
             """;
 
         // Dapper doesn't support DateOnly — convert to DateTime
         var items = await connection.QueryAsync<AppraisalCountDto>(sql,
-            new { From = from.ToDateTime(TimeOnly.MinValue), To = to.ToDateTime(TimeOnly.MinValue) });
+            new
+            {
+                From = from.ToDateTime(TimeOnly.MinValue),
+                To = to.ToDateTime(TimeOnly.MinValue),
+                query.BankingSegment
+            });
 
         return new GetAppraisalCountsResult(items.ToList());
     }

--- a/Modules/Common/Common/Application/Features/Dashboard/GetAppraisalStatusSummary/GetAppraisalStatusSummaryQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Dashboard/GetAppraisalStatusSummary/GetAppraisalStatusSummaryQueryHandler.cs
@@ -49,7 +49,9 @@ public class GetAppraisalStatusSummaryQueryHandler(
 
         if (!string.IsNullOrWhiteSpace(query.BankingSegment))
         {
-            conditions.Add("a.BankingSegment = @BankingSegment");
+            // Compare case-insensitively and treat NULL as 'IBG' so the dashboard's
+            // canonical 'Retail'/'IBG' dropdown values match reliably.
+            conditions.Add("UPPER(ISNULL(a.BankingSegment, 'IBG')) = UPPER(@BankingSegment)");
             parameters.Add("BankingSegment", query.BankingSegment);
         }
 

--- a/Modules/Common/Common/Application/Features/Dashboard/GetCompanyAppraisalSummary/GetCompanyAppraisalSummaryQuery.cs
+++ b/Modules/Common/Common/Application/Features/Dashboard/GetCompanyAppraisalSummary/GetCompanyAppraisalSummaryQuery.cs
@@ -15,7 +15,6 @@ public record CompanyAppraisalSummaryDto
     public string CompanyName { get; init; } = default!;
     public int AssignedCount { get; init; }
     public int CompletedCount { get; init; }
-    public int SubmissionCount { get; init; }
-    public long TotalBusinessMinutes { get; init; }
-    public decimal? AverageBusinessMinutes { get; init; }
+    public int OverdueCount { get; init; }
+    public int InProgressCount { get; init; }
 }

--- a/Modules/Common/Common/Application/Features/Dashboard/GetCompanyAppraisalSummary/GetCompanyAppraisalSummaryQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Dashboard/GetCompanyAppraisalSummary/GetCompanyAppraisalSummaryQueryHandler.cs
@@ -18,15 +18,16 @@ public class GetCompanyAppraisalSummaryQueryHandler(
         var parameters = new DynamicParameters();
         var conditions = new List<string>();
 
+        // Filter on the appraisal's CreatedAt (the canonical "Assigned" date axis).
         if (query.From.HasValue)
         {
-            conditions.Add("Date >= @From");
+            conditions.Add("CreatedAt >= @From");
             parameters.Add("From", query.From.Value.ToDateTime(TimeOnly.MinValue));
         }
 
         if (query.To.HasValue)
         {
-            conditions.Add("Date <= @To");
+            conditions.Add("CreatedAt <= @To");
             parameters.Add("To", query.To.Value.ToDateTime(TimeOnly.MinValue));
         }
 
@@ -39,16 +40,16 @@ public class GetCompanyAppraisalSummaryQueryHandler(
 
         var where = conditions.Count > 0 ? "WHERE " + string.Join(" AND ", conditions) : "";
 
+        // All four counts come from one live source at the appraisal grain, so
+        // CompletedCount + InProgressCount + OverdueCount == AssignedCount for every company.
         var sql = $"""
             SELECT CompanyId,
-                   COALESCE(MAX(CASE WHEN CompanyName <> N'(pending)' THEN CompanyName END), N'(pending)') AS CompanyName,
-                   SUM(AssignedCount)       AS AssignedCount,
-                   SUM(CompletedCount)      AS CompletedCount,
-                   SUM(SubmissionCount)     AS SubmissionCount,
-                   SUM(TotalBusinessMinutes) AS TotalBusinessMinutes,
-                   CASE WHEN SUM(SubmissionCount) = 0 THEN NULL
-                        ELSE CAST(SUM(TotalBusinessMinutes) AS decimal(18,2)) / SUM(SubmissionCount) END AS AverageBusinessMinutes
-            FROM common.CompanyAppraisalSummaries
+                   COALESCE(MAX(NULLIF(CompanyName, N'')), N'(pending)') AS CompanyName,
+                   COUNT(*)          AS AssignedCount,
+                   SUM(IsCompleted)  AS CompletedCount,
+                   SUM(IsOverdue)    AS OverdueCount,
+                   SUM(IsInProgress) AS InProgressCount
+            FROM common.vw_CompanyAppraisalSummaryLive
             {where}
             GROUP BY CompanyId
             ORDER BY AssignedCount DESC

--- a/Modules/Common/Common/Application/Features/Dashboard/GetCompanyAppraisalSummary/GetCompanyAppraisalSummaryQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Dashboard/GetCompanyAppraisalSummary/GetCompanyAppraisalSummaryQueryHandler.cs
@@ -27,7 +27,9 @@ public class GetCompanyAppraisalSummaryQueryHandler(
 
         if (query.To.HasValue)
         {
-            conditions.Add("CreatedAt <= @To");
+            // Exclusive upper bound + 1 day so the whole To-day is included
+            // (CreatedAt is a datetime; <= midnight would drop same-day rows).
+            conditions.Add("CreatedAt < DATEADD(day, 1, @To)");
             parameters.Add("To", query.To.Value.ToDateTime(TimeOnly.MinValue));
         }
 

--- a/Modules/Common/Common/Application/Features/Dashboard/GetQuotationTaskSummary/GetQuotationTaskSummaryQuery.cs
+++ b/Modules/Common/Common/Application/Features/Dashboard/GetQuotationTaskSummary/GetQuotationTaskSummaryQuery.cs
@@ -7,5 +7,6 @@ public record GetQuotationTaskSummaryQuery : IQuery<GetQuotationTaskSummaryResul
 public record GetQuotationTaskSummaryResult(
     int PendingQuotationCreation,
     int WaitingCompanySubmission,
-    int WaitingRmSelection
+    int WaitingRmSelection,
+    int PendingApprovals
 );

--- a/Modules/Common/Common/Application/Features/Dashboard/GetQuotationTaskSummary/GetQuotationTaskSummaryQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Dashboard/GetQuotationTaskSummary/GetQuotationTaskSummaryQueryHandler.cs
@@ -29,12 +29,19 @@ public class GetQuotationTaskSummaryQueryHandler(
                     SELECT COUNT(*)
                     FROM appraisal.QuotationRequests
                     WHERE Status = 'PendingRmSelection'
-                ) AS WaitingRmSelection
+                ) AS WaitingRmSelection,
+                (
+                    -- One Open FeeAppointmentApproval = one pending approver task
+                    -- (may bundle a fee line and/or a reschedule line).
+                    SELECT COUNT(*)
+                    FROM workflow.FeeAppointmentApprovals
+                    WHERE Status = 'Open'
+                ) AS PendingApprovals
             """;
 
         var connection = connectionFactory.GetOpenConnection();
         var row = await connection.QuerySingleOrDefaultAsync<GetQuotationTaskSummaryResult>(sql);
 
-        return row ?? new GetQuotationTaskSummaryResult(0, 0, 0);
+        return row ?? new GetQuotationTaskSummaryResult(0, 0, 0, 0);
     }
 }


### PR DESCRIPTION
## Summary
Reworks the dashboard read side to source from live SQL views and adds new breakdowns.

- **Appraisal counts** (`GetAppraisalCounts`) now read from `common.vw_DailyAppraisalCountsByType` with optional `GroupByType` (per-appraisal-type series) and `BankingSegment` filters. Segment comparison is case-insensitive and treats `NULL` as `IBG`.
- **Company summary** (`GetCompanyAppraisalSummary`) switches to `common.vw_CompanyAppraisalSummaryLive`, returning Assigned / Completed / InProgress / Overdue counts at the appraisal grain (drops the old submission/business-minutes columns).
- **Quotation task summary** adds `PendingApprovals` (count of Open `FeeAppointmentApprovals`).
- **Status summary** segment filter hardened (case-insensitive, NULL→IBG).

## New DB objects
- `Database/Scripts/Views/Common/vw_DailyAppraisalCountsByType.sql`
- `Database/Scripts/Views/Common/vw_CompanyAppraisalSummaryLive.sql`

Both deploy via the wildcard `Database` project — apply to the target DB before this ships.

## Notes
- Pairs with the frontend dashboard PR (widgets consuming the new params/fields).
- No migration; read-side only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)