### PR TITLE
fix(quotation): hydrate AddAppraisalToDraft item server-side from summary

### DIFF
--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/AddAppraisalToDraft/AddAppraisalToDraftCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/AddAppraisalToDraft/AddAppraisalToDraftCommand.cs
@@ -9,9 +9,5 @@ namespace Appraisal.Application.Features.Quotations.AddAppraisalToDraft;
 public record AddAppraisalToDraftCommand(
     Guid QuotationRequestId,
     Guid AppraisalId,
-    string AppraisalNumber,
-    string PropertyType,
-    string? PropertyLocation = null,
-    decimal? EstimatedValue = null,
     int? MaxAppraisalDays = null
 ) : ICommand<AddAppraisalToDraftResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/AddAppraisalToDraft/AddAppraisalToDraftCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/AddAppraisalToDraft/AddAppraisalToDraftCommandHandler.cs
@@ -8,6 +8,7 @@ namespace Appraisal.Application.Features.Quotations.AddAppraisalToDraft;
 
 public class AddAppraisalToDraftCommandHandler(
     IQuotationRepository quotationRepository,
+    IAppraisalRepository appraisalRepository,
     ICurrentUserService currentUser,
     IIntegrationEventOutbox outbox,
     IDateTimeProvider dateTimeProvider)
@@ -45,13 +46,19 @@ public class AddAppraisalToDraftCommandHandler(
 
         quotation.AddAppraisal(command.AppraisalId, addedBy: adminUsername, addedAt: dateTimeProvider.ApplicationNow);
 
+        // Hydrate the display item from the appraisal summary server-side — the FE only sends AppraisalId.
+        // Mirrors CreateQuotation / StartQuotationFromTask so the NOT NULL AppraisalNumber column is populated.
+        var summaries = await appraisalRepository.GetSummariesAsync(new[] { command.AppraisalId }, cancellationToken);
+        var summary = summaries.FirstOrDefault()
+            ?? throw new NotFoundException($"Appraisal '{command.AppraisalId}' not found.");
+
         // Add display item for admin review panel
         quotation.AddItem(
             appraisalId: command.AppraisalId,
-            appraisalNumber: command.AppraisalNumber,
-            propertyType: command.PropertyType,
-            propertyLocation: command.PropertyLocation,
-            estimatedValue: command.EstimatedValue,
+            appraisalNumber: summary.AppraisalNumber ?? string.Empty,
+            propertyType: summary.PropertyType ?? "Unknown",
+            propertyLocation: summary.PropertyLocation,
+            estimatedValue: summary.EstimatedValue,
             maxAppraisalDays: command.MaxAppraisalDays);
 
         quotationRepository.Update(quotation);

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/AddAppraisalToDraft/AddAppraisalToDraftEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/AddAppraisalToDraft/AddAppraisalToDraftEndpoint.cs
@@ -16,10 +16,6 @@ public class AddAppraisalToDraftEndpoint : ICarterModule
                     var command = new AddAppraisalToDraftCommand(
                         QuotationRequestId: id,
                         AppraisalId: request.AppraisalId,
-                        AppraisalNumber: request.AppraisalNumber,
-                        PropertyType: request.PropertyType,
-                        PropertyLocation: request.PropertyLocation,
-                        EstimatedValue: request.EstimatedValue,
                         MaxAppraisalDays: request.MaxAppraisalDays);
 
                     var result = await sender.Send(command, cancellationToken);

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/AddAppraisalToDraft/AddAppraisalToDraftRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/AddAppraisalToDraft/AddAppraisalToDraftRequest.cs
@@ -2,8 +2,4 @@ namespace Appraisal.Application.Features.Quotations.AddAppraisalToDraft;
 
 public record AddAppraisalToDraftRequest(
     Guid AppraisalId,
-    string AppraisalNumber,
-    string PropertyType,
-    string? PropertyLocation = null,
-    decimal? EstimatedValue = null,
     int? MaxAppraisalDays = null);


### PR DESCRIPTION
## Summary
`AddAppraisalToDraft` now hydrates the display item from the appraisal summary server-side instead of trusting client-supplied fields.

- Handler resolves `AppraisalNumber` / `PropertyType` / `PropertyLocation` / `EstimatedValue` via `IAppraisalRepository.GetSummariesAsync(AppraisalId)` (throws `NotFoundException` if the appraisal is missing), so the `NOT NULL` `AppraisalNumber` column is always populated. Mirrors `CreateQuotation` / `StartQuotationFromTask`.
- Those four fields are removed from `AddAppraisalToDraftRequest` / `AddAppraisalToDraftCommand` / endpoint wiring — the FE only needs to send `AppraisalId`.

## Compatibility
Non-breaking for the current frontend: it may still send the removed fields, and ASP.NET ignores unknown JSON properties. No FE change is required to merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)