### PR TITLE
fix(integration): resolve PrevAppraisalId from AppraisalNumber for external appeal requests

### DIFF
--- a/Modules/Integration/Integration/Application/Features/AppraisalRequests/CreateRequest/CreateRequestCommandHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalRequests/CreateRequest/CreateRequestCommandHandler.cs
@@ -1,8 +1,10 @@
+using Integration.Application.Services;
 using Mapster;
 using Request.Application.Services;
 using Request.Contracts.RequestDocuments.Dto;
 using Request.Contracts.Requests.Dtos;
 using Shared.CQRS;
+using Shared.Exceptions;
 using Shared.Time;
 
 namespace Integration.Application.Features.AppraisalRequests.CreateRequest;
@@ -10,13 +12,41 @@ namespace Integration.Application.Features.AppraisalRequests.CreateRequest;
 public class CreateRequestCommandHandler(
     ICreateRequestService createRequestService,
     IRequestDocumentValidator validator,
+    IAppraisalLookupService appraisalLookup,
     IDateTimeProvider dateTimeProvider
 ) : ICommandHandler<CreateRequestCommand, Guid>
 {
+    // Purposes that continue a prior appraisal (Progressive/CI "06"/"11", Appeal "12"). Mirrors
+    // Request.PriorAppraisalSubmissionGuard's set (internal there); only these purposes need — and
+    // strictly require — the prior appraisal, so number resolution is scoped to them to avoid
+    // 400-ing other purposes that may carry a PrevAppraisalNumber for reference only.
+    private static readonly HashSet<string> PriorAppraisalRequiredPurposes =
+        new(StringComparer.Ordinal) { "06", "11", "12" };
+
+    // Cross-module string contract for AppraisalStatus.Completed (mirrors PriorAppraisalSubmissionGuard).
+    private const string CompletedStatus = "Completed";
+
     public async Task<Guid> Handle(
         CreateRequestCommand command,
         CancellationToken cancellationToken)
     {
+        // External callers reference the prior appraisal by its number (SurveyNo), not our internal
+        // GUID. Resolve it to PrevAppraisalId so the downstream PriorAppraisalSubmissionGuard (which
+        // requires the GUID for these purposes) is satisfied, and reject early — naming the number —
+        // when it is missing or not yet Completed. An explicitly supplied GUID wins.
+        if (PriorAppraisalRequiredPurposes.Contains(command.Purpose) &&
+            command.Detail is { PrevAppraisalId: null, PrevAppraisalNumber: { Length: > 0 } prevNumber })
+        {
+            var prior = await appraisalLookup.ResolvePriorAppraisalByNumberAsync(prevNumber, cancellationToken);
+            if (prior is null)
+                throw new BadRequestException($"No appraisal found for AppraisalNumber '{prevNumber}'.");
+            if (!string.Equals(prior.Status, CompletedStatus, StringComparison.Ordinal))
+                throw new BadRequestException(
+                    $"The prior appraisal '{prevNumber}' must be completed before this request can be submitted.");
+
+            command = command with { Detail = command.Detail with { PrevAppraisalId = prior.Id } };
+        }
+
         var input = new DocumentValidationInput(
             command.Purpose,
             (command.Documents ?? new List<RequestDocumentDto>())

--- a/Modules/Integration/Integration/Application/Services/AppraisalLookupService.cs
+++ b/Modules/Integration/Integration/Application/Services/AppraisalLookupService.cs
@@ -48,6 +48,35 @@ public class AppraisalLookupService(
         return new AppraisalKeys(row.AppraisalNumber, row.ExternalCaseKey, row.ExternalSystem);
     }
 
+    private const string SqlPriorAppraisalByNumber = """
+        SELECT TOP 1 a.Id, a.Status
+        FROM appraisal.Appraisals a
+        WHERE a.AppraisalNumber = @AppraisalNumber AND a.IsDeleted = 0
+        """;
+
+    public async Task<PriorAppraisalRef?> ResolvePriorAppraisalByNumberAsync(
+        string appraisalNumber, CancellationToken ct = default)
+    {
+        var connection = connectionFactory.GetOpenConnection();
+
+        var parameters = new DynamicParameters();
+        parameters.Add("AppraisalNumber", appraisalNumber);
+
+        var command = new CommandDefinition(SqlPriorAppraisalByNumber, parameters, cancellationToken: ct);
+        var row = await connection.QueryFirstOrDefaultAsync<PriorAppraisalRefRow>(command);
+
+        if (row is null)
+        {
+            logger.LogWarning(
+                "AppraisalLookupService: no appraisal found for AppraisalNumber {AppraisalNumber}", appraisalNumber);
+            return null;
+        }
+
+        return new PriorAppraisalRef(row.Id, row.Status);
+    }
+
+    private sealed record PriorAppraisalRefRow(Guid Id, string? Status);
+
     public async Task<AppraisalKeys?> GetKeysByRequestIdAsync(Guid requestId, CancellationToken ct = default)
     {
         var connection = connectionFactory.GetOpenConnection();

--- a/Modules/Integration/Integration/Application/Services/IAppraisalLookupService.cs
+++ b/Modules/Integration/Integration/Application/Services/IAppraisalLookupService.cs
@@ -2,8 +2,24 @@ namespace Integration.Application.Services;
 
 public record AppraisalKeys(string? AppraisalNumber, string? ExternalCaseKey, string? ExternalSystem);
 
+/// <summary>
+/// A prior appraisal resolved from its external number: the in-system Id plus its current status
+/// string (e.g. "Completed"), so the Integration boundary can both reference it and gate on status.
+/// </summary>
+public record PriorAppraisalRef(Guid Id, string? Status);
+
 public interface IAppraisalLookupService
 {
     Task<AppraisalKeys?> GetKeysAsync(Guid appraisalId, CancellationToken ct = default);
     Task<AppraisalKeys?> GetKeysByRequestIdAsync(Guid requestId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolves an external-supplied appraisal number (a.k.a. SurveyNo) to the in-system appraisal
+    /// Id and its current status. Used at the Integration boundary so external callers can reference
+    /// a prior appraisal by its number instead of our internal GUID, and so the create-request
+    /// handler can reject early when that prior appraisal is not yet Completed. Returns null when no
+    /// non-deleted appraisal carries that number. AppraisalNumber has a filtered unique index, so at
+    /// most one row matches.
+    /// </summary>
+    Task<PriorAppraisalRef?> ResolvePriorAppraisalByNumberAsync(string appraisalNumber, CancellationToken ct = default);
 }


### PR DESCRIPTION
## What

External callers (AS400/LOS/PMA) create an **appeal** via `POST /api/v1/requests` with `Purpose = "12"` (and Progressive/CI use `06`/`11`). These flows require the prior appraisal, but the downstream `PriorAppraisalSubmissionGuard` needs the internal `PrevAppraisalId` (a `Guid`) — which external systems don't know. They only know the prior appraisal's **number** (`AppraisalNumber` / `SurveyNo`).

This adds number→id resolution at the Integration boundary so external callers can reference the prior appraisal by number.

## How

- **`IAppraisalLookupService` / `AppraisalLookupService`** — new `ResolvePriorAppraisalByNumberAsync(number)` returning `PriorAppraisalRef(Id, Status)` via a single Dapper read (`SELECT TOP 1 a.Id, a.Status FROM appraisal.Appraisals WHERE AppraisalNumber = @n AND IsDeleted = 0`). `AppraisalNumber` has a filtered unique index, so at most one row matches.
- **`CreateRequestCommandHandler`** — for prior-appraisal purposes (`06`/`11`/`12`) only, when `PrevAppraisalNumber` is supplied but `PrevAppraisalId` is null, resolves the GUID and sets it. An explicitly supplied `PrevAppraisalId` still wins.

## Behavior

- Number resolves + prior appraisal **Completed** → `PrevAppraisalId` populated, request proceeds.
- Number matches nothing → **400** *"No appraisal found for AppraisalNumber 'X'."*
- Number matches but not Completed → **400** *"The prior appraisal 'X' must be completed before this request can be submitted."*
- Non prior-appraisal purposes carrying a `PrevAppraisalNumber` → unchanged lenient pass-through (no regression).

The downstream `PriorAppraisalSubmissionGuard` remains as the backstop (and still covers the direct-GUID path).

## Verification

- `dotnet build Modules/Integration/Integration/Integration.csproj` — 0 errors.
- POST an appeal with `Detail.PrevAppraisalNumber` of a Completed appraisal, no `PrevAppraisalId` → `201`, `PrevAppraisalId` populated.
- Bogus number → `400`; non-Completed prior → `400` (both name the number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
