### PR TITLE
CA-220 Add document management, remark, and approach selection to pricing analysis

### DIFF
--- a/Modules/Appraisal/Appraisal/Application/EventHandlers/DocumentLinkedEventHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/EventHandlers/DocumentLinkedEventHandler.cs
@@ -1,0 +1,21 @@
+using Shared.Data.Outbox;
+using Shared.Messaging.Events;
+
+namespace Appraisal.Application.EventHandlers;
+
+public class DocumentLinkedEventHandler(IIntegrationEventOutbox outbox, ILogger<DocumentLinkedEventHandler> logger)
+    : INotificationHandler<DocumentLinkedEvent>
+{
+    public Task Handle(DocumentLinkedEvent notification, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Document with ID {DocumentId} linked to PricingAnalysis with ID {PricingAnalysisId}",
+            notification.DocumentId, notification.PricingId);
+
+        outbox.Publish(
+            new DocumentLinkedIntegrationEventV2(
+                notification.PricingId, notification.DocumentId),
+            correlationId: notification.PricingId.ToString());
+
+        return Task.CompletedTask;
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/EventHandlers/DocumentUnlinkedEventHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/EventHandlers/DocumentUnlinkedEventHandler.cs
@@ -1,0 +1,20 @@
+using Shared.Data.Outbox;
+using Shared.Messaging.Events;
+
+namespace Appraisal.Application.EventHandlers;
+
+public class DocumentUnlinkedEventHandler(IIntegrationEventOutbox outbox, ILogger<DocumentUnlinkedEventHandler> logger)
+    : INotificationHandler<DocumentUnlinkedEvent>
+{
+    public Task Handle(DocumentUnlinkedEvent notification, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Document with ID {DocumentId} unlinked from PricingAnalysis with ID {PricingAnalysisId}",
+            notification.DocumentId, notification.PricingId);
+
+        outbox.Publish(
+            new DocumentUnlinkedIntegrationEvent(notification.PricingId, notification.DocumentId),
+            correlationId: notification.PricingId.ToString());
+
+        return Task.CompletedTask;
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/EventHandlers/DocumentUpdatedEventHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/EventHandlers/DocumentUpdatedEventHandler.cs
@@ -1,0 +1,22 @@
+using Shared.Data.Outbox;
+using Shared.Messaging.Events;
+
+namespace Appraisal.Application.EventHandlers;
+
+public class DocumentUpdatedEventHandler(IIntegrationEventOutbox outbox, ILogger<DocumentUpdatedEventHandler> logger)
+    : INotificationHandler<DocumentUpdatedEvent>
+{
+    public Task Handle(DocumentUpdatedEvent notification, CancellationToken cancellationToken)
+    {
+        logger.LogInformation(
+            "Document with ID {DocumentId} replaced previous document {PreviousDocumentId} on PricingAnalysis with ID {PricingAnalysisId}",
+            notification.DocumentId, notification.PreviousDocumentId, notification.PricingId);
+
+        outbox.Publish(
+            new DocumentUpdatedIntegrationEvent(
+                notification.PricingId, notification.PreviousDocumentId, notification.DocumentId),
+            correlationId: notification.PricingId.ToString());
+
+        return Task.CompletedTask;
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/AttachPricingAnalysisDocument/AttachPricingAnalysisDocumentCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/AttachPricingAnalysisDocument/AttachPricingAnalysisDocumentCommand.cs
@@ -1,0 +1,12 @@
+using Appraisal.Application.Configurations;
+
+namespace Appraisal.Application.Features.PricingAnalysis.AttachPricingAnalysisDocument;
+
+/// <summary>
+/// Command to link an already-uploaded document (from the Document module) to a PricingAnalysis.
+/// </summary>
+public record AttachPricingAnalysisDocumentCommand(
+    Guid PricingAnalysisId,
+    Guid DocumentId,
+    string? FileName
+) : ICommand<AttachPricingAnalysisDocumentResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/AttachPricingAnalysisDocument/AttachPricingAnalysisDocumentCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/AttachPricingAnalysisDocument/AttachPricingAnalysisDocumentCommandHandler.cs
@@ -1,0 +1,42 @@
+using Shared.Time;
+
+namespace Appraisal.Application.Features.PricingAnalysis.AttachPricingAnalysisDocument;
+
+/// <summary>
+/// Handler for linking an already-uploaded document to a PricingAnalysis.
+/// Mirrors Request module's AttachRequestDocumentCommandHandler.
+/// </summary>
+public class AttachPricingAnalysisDocumentCommandHandler(
+    IPricingAnalysisRepository pricingAnalysisRepository,
+    IDateTimeProvider dateTimeProvider,
+    ICurrentUserService currentUser
+) : ICommandHandler<AttachPricingAnalysisDocumentCommand, AttachPricingAnalysisDocumentResult>
+{
+    public async Task<AttachPricingAnalysisDocumentResult> Handle(
+        AttachPricingAnalysisDocumentCommand command,
+        CancellationToken cancellationToken)
+    {
+        var pricingAnalysis = await pricingAnalysisRepository.GetByIdWithAllDataAsync(
+            command.PricingAnalysisId,
+            cancellationToken);
+
+        if (pricingAnalysis is null)
+            throw new NotFoundException("PricingAnalysis", command.PricingAnalysisId);
+
+        var data = new PricingAnalysisDocumentData(
+            command.DocumentId,
+            command.FileName,
+            null,
+            currentUser.Username,
+            currentUser.Username,
+            dateTimeProvider.Now);
+
+        var document = pricingAnalysis.AddDocument(data);
+
+        return new AttachPricingAnalysisDocumentResult(
+            document.Id,
+            command.PricingAnalysisId,
+            document.DocumentId,
+            document.FileName);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/AttachPricingAnalysisDocument/AttachPricingAnalysisDocumentEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/AttachPricingAnalysisDocument/AttachPricingAnalysisDocumentEndpoint.cs
@@ -1,0 +1,34 @@
+namespace Appraisal.Application.Features.PricingAnalysis.AttachPricingAnalysisDocument;
+
+public class AttachPricingAnalysisDocumentEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPost(
+                "/pricing-analysis/{id:guid}/documents",
+                async (
+                    Guid id,
+                    AttachPricingAnalysisDocumentRequest request,
+                    ISender sender,
+                    CancellationToken cancellationToken) =>
+                {
+                    var command = new AttachPricingAnalysisDocumentCommand(
+                        id,
+                        request.DocumentId,
+                        request.FileName);
+
+                    var result = await sender.Send(command, cancellationToken);
+
+                    var response = result.Adapt<AttachPricingAnalysisDocumentResponse>();
+
+                    return Results.Ok(response);
+                })
+            .WithName("AttachPricingAnalysisDocument")
+            .Produces<AttachPricingAnalysisDocumentResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Attach a document to a pricing analysis")
+            .WithDescription("Links an already-uploaded document (via POST /documents) to a pricing analysis.")
+            .WithTags("PricingAnalysis");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/AttachPricingAnalysisDocument/AttachPricingAnalysisDocumentRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/AttachPricingAnalysisDocument/AttachPricingAnalysisDocumentRequest.cs
@@ -1,0 +1,9 @@
+namespace Appraisal.Application.Features.PricingAnalysis.AttachPricingAnalysisDocument;
+
+/// <summary>
+/// Request body for attaching an already-uploaded document (via the Document module's
+/// POST /documents endpoint) to a PricingAnalysis.
+/// </summary>
+public record AttachPricingAnalysisDocumentRequest(
+    Guid DocumentId,
+    string? FileName);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/AttachPricingAnalysisDocument/AttachPricingAnalysisDocumentResponse.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/AttachPricingAnalysisDocument/AttachPricingAnalysisDocumentResponse.cs
@@ -1,0 +1,7 @@
+namespace Appraisal.Application.Features.PricingAnalysis.AttachPricingAnalysisDocument;
+
+public record AttachPricingAnalysisDocumentResponse(
+    Guid Id,
+    Guid PricingAnalysisId,
+    Guid? DocumentId,
+    string? FileName);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/AttachPricingAnalysisDocument/AttachPricingAnalysisDocumentResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/AttachPricingAnalysisDocument/AttachPricingAnalysisDocumentResult.cs
@@ -1,0 +1,7 @@
+namespace Appraisal.Application.Features.PricingAnalysis.AttachPricingAnalysisDocument;
+
+public record AttachPricingAnalysisDocumentResult(
+    Guid Id,
+    Guid PricingAnalysisId,
+    Guid? DocumentId,
+    string? FileName);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysis/GetPricingAnalysisQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysis/GetPricingAnalysisQueryHandler.cs
@@ -1,3 +1,5 @@
+using Appraisal.Application.Features.PricingAnalysis.GetPricingAnalysisDocuments;
+
 namespace Appraisal.Application.Features.PricingAnalysis.GetPricingAnalysis;
 
 /// <summary>
@@ -29,6 +31,15 @@ public class GetPricingAnalysisQueryHandler(
             )).ToList()
         )).ToList();
 
+        var documents = pricingAnalysis.Documents.Select(d => new PricingAnalysisDocumentDto(
+            d.Id,
+            d.DocumentId,
+            d.FileName,
+            d.FilePath,
+            d.UploadedBy,
+            d.UploadedByName,
+            d.UploadedAt)).ToList();
+
         return new GetPricingAnalysisResult(
             pricingAnalysis.Id,
             pricingAnalysis.SubjectType,
@@ -38,7 +49,9 @@ public class GetPricingAnalysisQueryHandler(
             pricingAnalysis.Status,
             pricingAnalysis.FinalAppraisedValue,
             pricingAnalysis.UseSystemCalc,
-            approaches
+            approaches,
+            documents,
+            pricingAnalysis.Remark
         );
     }
 }

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysis/GetPricingAnalysisResponse.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysis/GetPricingAnalysisResponse.cs
@@ -1,3 +1,5 @@
+using Appraisal.Application.Features.PricingAnalysis.GetPricingAnalysisDocuments;
+
 namespace Appraisal.Application.Features.PricingAnalysis.GetPricingAnalysis;
 
 public record GetPricingAnalysisResponse(
@@ -12,5 +14,7 @@ public record GetPricingAnalysisResponse(
     decimal? FinalForcedSaleValue,
     DateTime? ValuationDate,
     bool UseSystemCalc,
-    List<ApproachDto> Approaches
+    List<ApproachDto> Approaches,
+    List<PricingAnalysisDocumentDto> Documents,
+    string? Remark
 );

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysis/GetPricingAnalysisResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysis/GetPricingAnalysisResult.cs
@@ -1,3 +1,5 @@
+using Appraisal.Application.Features.PricingAnalysis.GetPricingAnalysisDocuments;
+
 namespace Appraisal.Application.Features.PricingAnalysis.GetPricingAnalysis;
 
 /// <summary>
@@ -12,5 +14,7 @@ public record GetPricingAnalysisResult(
     string Status,
     decimal? FinalAppraisedValue,
     bool UseSystemCalc,
-    List<ApproachDto> Approaches
+    List<ApproachDto> Approaches,
+    List<PricingAnalysisDocumentDto> Documents,
+    string? Remark
 );

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysisDocuments/GetPricingAnalysisDocumentsEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysisDocuments/GetPricingAnalysisDocumentsEndpoint.cs
@@ -1,0 +1,28 @@
+namespace Appraisal.Application.Features.PricingAnalysis.GetPricingAnalysisDocuments;
+
+public class GetPricingAnalysisDocumentsEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet(
+                "/pricing-analysis/{id:guid}/documents",
+                async (
+                    Guid id,
+                    ISender sender,
+                    CancellationToken cancellationToken) =>
+                {
+                    var query = new GetPricingAnalysisDocumentsQuery(id);
+
+                    var result = await sender.Send(query, cancellationToken);
+
+                    var response = result.Adapt<GetPricingAnalysisDocumentsResponse>();
+
+                    return Results.Ok(response);
+                })
+            .WithName("GetPricingAnalysisDocuments")
+            .Produces<GetPricingAnalysisDocumentsResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("List documents attached to a pricing analysis")
+            .WithTags("PricingAnalysis");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysisDocuments/GetPricingAnalysisDocumentsQuery.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysisDocuments/GetPricingAnalysisDocumentsQuery.cs
@@ -1,0 +1,8 @@
+namespace Appraisal.Application.Features.PricingAnalysis.GetPricingAnalysisDocuments;
+
+/// <summary>
+/// Query to list all document entries attached to a pricing analysis.
+/// </summary>
+public record GetPricingAnalysisDocumentsQuery(
+    Guid PricingAnalysisId
+) : IQuery<GetPricingAnalysisDocumentsResult>;

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysisDocuments/GetPricingAnalysisDocumentsQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysisDocuments/GetPricingAnalysisDocumentsQueryHandler.cs
@@ -1,0 +1,40 @@
+namespace Appraisal.Application.Features.PricingAnalysis.GetPricingAnalysisDocuments;
+
+public class GetPricingAnalysisDocumentsQueryHandler(
+    IPricingAnalysisRepository pricingAnalysisRepository
+) : IQueryHandler<GetPricingAnalysisDocumentsQuery, GetPricingAnalysisDocumentsResult>
+{
+    public async Task<GetPricingAnalysisDocumentsResult> Handle(
+        GetPricingAnalysisDocumentsQuery query,
+        CancellationToken cancellationToken)
+    {
+        var pricingAnalysis = await pricingAnalysisRepository.GetByIdWithAllDataAsync(
+            query.PricingAnalysisId,
+            cancellationToken);
+
+        if (pricingAnalysis is null)
+            throw new NotFoundException("PricingAnalysis", query.PricingAnalysisId);
+
+        var documents = pricingAnalysis.Documents
+            .Select(d => new PricingAnalysisDocumentDto(
+                d.Id,
+                d.DocumentId,
+                d.FileName,
+                d.FilePath,
+                d.UploadedBy,
+                d.UploadedByName,
+                d.UploadedAt))
+            .ToList();
+
+        return new GetPricingAnalysisDocumentsResult(documents);
+    }
+}
+
+public record PricingAnalysisDocumentDto(
+    Guid Id,
+    Guid? DocumentId,
+    string? FileName,
+    string? FilePath,
+    string? UploadedBy,
+    string? UploadedByName,
+    DateTime? UploadedAt);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysisDocuments/GetPricingAnalysisDocumentsResponse.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysisDocuments/GetPricingAnalysisDocumentsResponse.cs
@@ -1,0 +1,4 @@
+namespace Appraisal.Application.Features.PricingAnalysis.GetPricingAnalysisDocuments;
+
+public record GetPricingAnalysisDocumentsResponse(
+    List<PricingAnalysisDocumentDto> Documents);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysisDocuments/GetPricingAnalysisDocumentsResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/GetPricingAnalysisDocuments/GetPricingAnalysisDocumentsResult.cs
@@ -1,0 +1,4 @@
+namespace Appraisal.Application.Features.PricingAnalysis.GetPricingAnalysisDocuments;
+
+public record GetPricingAnalysisDocumentsResult(
+    List<PricingAnalysisDocumentDto> Documents);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/RemovePricingAnalysisDocument/RemovePricingAnalysisDocumentCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/RemovePricingAnalysisDocument/RemovePricingAnalysisDocumentCommand.cs
@@ -1,0 +1,12 @@
+using Appraisal.Application.Configurations;
+
+namespace Appraisal.Application.Features.PricingAnalysis.RemovePricingAnalysisDocument;
+
+/// <summary>
+/// Command to remove a PricingAnalysisDocument entry entirely (not just unlink the file).
+/// Fires DocumentUnlinkedEvent if a document was linked.
+/// </summary>
+public record RemovePricingAnalysisDocumentCommand(
+    Guid PricingAnalysisId,
+    Guid DocumentEntryId
+) : ICommand<RemovePricingAnalysisDocumentResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/RemovePricingAnalysisDocument/RemovePricingAnalysisDocumentCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/RemovePricingAnalysisDocument/RemovePricingAnalysisDocumentCommandHandler.cs
@@ -1,0 +1,22 @@
+namespace Appraisal.Application.Features.PricingAnalysis.RemovePricingAnalysisDocument;
+
+public class RemovePricingAnalysisDocumentCommandHandler(
+    IPricingAnalysisRepository pricingAnalysisRepository
+) : ICommandHandler<RemovePricingAnalysisDocumentCommand, RemovePricingAnalysisDocumentResult>
+{
+    public async Task<RemovePricingAnalysisDocumentResult> Handle(
+        RemovePricingAnalysisDocumentCommand command,
+        CancellationToken cancellationToken)
+    {
+        var pricingAnalysis = await pricingAnalysisRepository.GetByIdWithAllDataAsync(
+            command.PricingAnalysisId,
+            cancellationToken);
+
+        if (pricingAnalysis is null)
+            throw new NotFoundException("PricingAnalysis", command.PricingAnalysisId);
+
+        pricingAnalysis.RemoveDocument(command.DocumentEntryId);
+
+        return new RemovePricingAnalysisDocumentResult(command.DocumentEntryId, true);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/RemovePricingAnalysisDocument/RemovePricingAnalysisDocumentEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/RemovePricingAnalysisDocument/RemovePricingAnalysisDocumentEndpoint.cs
@@ -1,0 +1,27 @@
+namespace Appraisal.Application.Features.PricingAnalysis.RemovePricingAnalysisDocument;
+
+public class RemovePricingAnalysisDocumentEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapDelete(
+                "/pricing-analysis/{id:guid}/documents/{documentEntryId:guid}",
+                async (
+                    Guid id,
+                    Guid documentEntryId,
+                    ISender sender,
+                    CancellationToken cancellationToken) =>
+                {
+                    var command = new RemovePricingAnalysisDocumentCommand(id, documentEntryId);
+                    var result = await sender.Send(command, cancellationToken);
+                    return Results.Ok(result);
+                })
+            .WithName("RemovePricingAnalysisDocument")
+            .Produces<RemovePricingAnalysisDocumentResult>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Remove a document entry from a pricing analysis")
+            .WithDescription("Deletes the PricingAnalysisDocument entry entirely (not just the file link).")
+            .WithTags("PricingAnalysis");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/RemovePricingAnalysisDocument/RemovePricingAnalysisDocumentResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/RemovePricingAnalysisDocument/RemovePricingAnalysisDocumentResult.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.PricingAnalysis.RemovePricingAnalysisDocument;
+
+public record RemovePricingAnalysisDocumentResult(Guid DocumentEntryId, bool IsSuccess);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveComparativeAnalysis/SaveComparativeAnalysisCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveComparativeAnalysis/SaveComparativeAnalysisCommand.cs
@@ -21,5 +21,6 @@ public record SaveComparativeAnalysisCommand(
     decimal? AppraisalPrice = null,
     bool? IncludeLandArea = null,
     decimal? LandArea = null,
-    decimal? LandValue = null
+    decimal? LandValue = null,
+    string? Remark = null
 ) : ICommand<SaveComparativeAnalysisResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveComparativeAnalysis/SaveComparativeAnalysisCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveComparativeAnalysis/SaveComparativeAnalysisCommandHandler.cs
@@ -38,7 +38,8 @@ public class SaveComparativeAnalysisCommandHandler(
         method.SetComparativeAnalysisTemplate(command.ComparativeAnalysisTemplateId);
 
         // Persist remark (parity with Hypothesis/ProfitRent/MachineCost/Leasehold saves)
-        method.SetRemark(command.Remark);
+        if (command.Remark is not null)
+            method.SetRemark(command.Remark);
 
         // STEP 1: Upsert comparative factors
         UpsertComparativeFactors(method, command.ComparativeFactors);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveComparativeAnalysis/SaveComparativeAnalysisCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveComparativeAnalysis/SaveComparativeAnalysisCommandHandler.cs
@@ -37,6 +37,9 @@ public class SaveComparativeAnalysisCommandHandler(
         // Persist template selection
         method.SetComparativeAnalysisTemplate(command.ComparativeAnalysisTemplateId);
 
+        // Persist remark (parity with Hypothesis/ProfitRent/MachineCost/Leasehold saves)
+        method.SetRemark(command.Remark);
+
         // STEP 1: Upsert comparative factors
         UpsertComparativeFactors(method, command.ComparativeFactors);
 

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveComparativeAnalysis/SaveComparativeAnalysisEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveComparativeAnalysis/SaveComparativeAnalysisEndpoint.cs
@@ -28,7 +28,8 @@ public class SaveComparativeAnalysisEndpoint : ICarterModule
                         request.AppraisalPrice,
                         request.IncludeLandArea,
                         request.LandArea,
-                        request.LandValue
+                        request.LandValue,
+                        request.Remark
                     );
 
                     var result = await sender.Send(command);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveComparativeAnalysis/SaveComparativeAnalysisRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SaveComparativeAnalysis/SaveComparativeAnalysisRequest.cs
@@ -15,7 +15,8 @@ public record SaveComparativeAnalysisRequest(
     decimal? AppraisalPrice = null,
     bool? IncludeLandArea = null,
     decimal? LandArea = null,
-    decimal? LandValue = null
+    decimal? LandValue = null,
+    string? Remark = null
 );
 
 /// <summary>

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SelectApproach/SelectApproachCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SelectApproach/SelectApproachCommand.cs
@@ -1,0 +1,13 @@
+using Appraisal.Application.Configurations;
+
+namespace Appraisal.Application.Features.PricingAnalysis.SelectApproach;
+
+/// <summary>
+/// Command to select an approach as the final approach for this pricing analysis,
+/// setting all other approaches as unselected. Propagates the approach's already-computed
+/// ApproachValue up to FinalAppraisedValue.
+/// </summary>
+public record SelectApproachCommand(
+    Guid PricingAnalysisId,
+    Guid ApproachId
+) : ICommand<SelectApproachResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SelectApproach/SelectApproachCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SelectApproach/SelectApproachCommandHandler.cs
@@ -1,0 +1,34 @@
+namespace Appraisal.Application.Features.PricingAnalysis.SelectApproach;
+
+/// <summary>
+/// Handler for selecting an approach as the final approach for the analysis.
+/// Split out of SelectMethod so an approach can be chosen independently of picking
+/// a method within it — see SelectMethodCommandHandler for the method-only half.
+/// </summary>
+public class SelectApproachCommandHandler(
+    IPricingAnalysisRepository pricingAnalysisRepository
+) : ICommandHandler<SelectApproachCommand, SelectApproachResult>
+{
+    public async Task<SelectApproachResult> Handle(
+        SelectApproachCommand command,
+        CancellationToken cancellationToken)
+    {
+        var pricingAnalysis = await pricingAnalysisRepository.GetByIdWithAllDataAsync(
+            command.PricingAnalysisId,
+            cancellationToken);
+
+        if (pricingAnalysis is null)
+            throw new NotFoundException("PricingAnalysis", command.PricingAnalysisId);
+
+        // Invariants (exactly one selected approach, must have a selected method) and the
+        // FinalAppraisedValue propagation are now enforced inside the aggregate.
+        pricingAnalysis.SelectApproach(command.ApproachId);
+
+        var targetApproach = pricingAnalysis.Approaches.First(a => a.Id == command.ApproachId);
+
+        return new SelectApproachResult(
+            targetApproach.Id,
+            targetApproach.ApproachType,
+            pricingAnalysis.FinalAppraisedValue);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SelectApproach/SelectApproachEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SelectApproach/SelectApproachEndpoint.cs
@@ -1,0 +1,33 @@
+namespace Appraisal.Application.Features.PricingAnalysis.SelectApproach;
+
+public class SelectApproachEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPost(
+                "/pricing-analysis/{id:guid}/approaches/{approachId:guid}/select",
+                async (
+                    Guid id,
+                    Guid approachId,
+                    ISender sender,
+                    CancellationToken cancellationToken
+                ) =>
+                {
+                    var command = new SelectApproachCommand(id, approachId);
+
+                    var result = await sender.Send(command, cancellationToken);
+
+                    var response = result.Adapt<SelectApproachResponse>();
+
+                    return Results.Ok(response);
+                }
+            )
+            .WithName("SelectApproach")
+            .Produces<SelectApproachResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Select approach")
+            .WithDescription("Selects an approach as the final approach for the analysis, unselecting all others, and propagates its value to FinalAppraisedValue. The approach must already have a selected method (see SelectMethod).")
+            .WithTags("PricingAnalysis");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SelectApproach/SelectApproachResponse.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SelectApproach/SelectApproachResponse.cs
@@ -1,0 +1,7 @@
+namespace Appraisal.Application.Features.PricingAnalysis.SelectApproach;
+
+public record SelectApproachResponse(
+    Guid Id,
+    string ApproachType,
+    decimal? FinalAppraisedValue
+);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SelectApproach/SelectApproachResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SelectApproach/SelectApproachResult.cs
@@ -1,0 +1,7 @@
+namespace Appraisal.Application.Features.PricingAnalysis.SelectApproach;
+
+public record SelectApproachResult(
+    Guid Id,
+    string ApproachType,
+    decimal? FinalAppraisedValue
+);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SelectMethod/SelectMethodCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SelectMethod/SelectMethodCommandHandler.cs
@@ -15,53 +15,17 @@ public class SelectMethodCommandHandler(
             command.PricingAnalysisId,
             cancellationToken);
 
-        if (pricingAnalysis == null)
-            throw new InvalidOperationException($"Pricing analysis with ID '{command.PricingAnalysisId}' not found");
+        if (pricingAnalysis is null)
+            throw new NotFoundException("PricingAnalysis", command.PricingAnalysisId);
 
-        PricingAnalysisMethod? targetMethod = null;
-        PricingAnalysisApproach? parentApproach = null;
+        // Selection invariants (exactly one selected method per approach) and the
+        // FinalAppraisedValue propagation (when this approach is already the analysis's
+        // selected/final approach) are now enforced inside the aggregate.
+        pricingAnalysis.SelectMethod(command.MethodId);
 
-        // Find the target method and its parent approach
-        foreach (var approach in pricingAnalysis.Approaches)
-        {
-            targetMethod = approach.Methods.FirstOrDefault(m => m.Id == command.MethodId);
-            if (targetMethod != null)
-            {
-                parentApproach = approach;
-                break;
-            }
-        }
-
-        if (targetMethod == null)
-            throw new InvalidOperationException($"Method with ID '{command.MethodId}' not found");
-
-        // Set a target method as Selected
-        targetMethod.SetAsSelected();
-
-        // Set all other methods in the same approach as Alternative
-        foreach (var method in parentApproach!.Methods)
-        {
-            if (method.Id != command.MethodId)
-            {
-                method.SetAsUnselected();
-            }
-        }
-
-        // Mark parent approach as selected, unselect all others
-        foreach (var approach in pricingAnalysis.Approaches)
-        {
-            if (approach.Id == parentApproach.Id)
-                approach.Select();
-            else
-                approach.Unselect();
-        }
-
-        // Propagate selected method's MethodValue → ApproachValue → FinalAppraisedValue
-        if (targetMethod.MethodValue.HasValue)
-        {
-            parentApproach.SetValue(targetMethod.MethodValue.Value);
-            pricingAnalysis.SetFinalValues(targetMethod.MethodValue.Value);
-        }
+        var targetMethod = pricingAnalysis.Approaches
+            .SelectMany(a => a.Methods)
+            .First(m => m.Id == command.MethodId);
 
         return new SelectMethodResult(
             targetMethod.Id,

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SelectMethod/SelectMethodEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/SelectMethod/SelectMethodEndpoint.cs
@@ -31,7 +31,7 @@ public class SelectMethodEndpoint : ICarterModule
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .WithSummary("Select method")
-            .WithDescription("Selects a method as the primary method, setting all other methods in the same approach as Alternative.")
+            .WithDescription("Selects a method as the primary method within its approach, setting all other methods in the same approach as Alternative. Does not affect approach selection — use SelectApproach for that.")
             .WithTags("PricingAnalysis");
     }
 }

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdatePricingAnalysisDocument/UpdatePricingAnalysisDocumentCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdatePricingAnalysisDocument/UpdatePricingAnalysisDocumentCommand.cs
@@ -1,0 +1,15 @@
+using Appraisal.Application.Configurations;
+
+namespace Appraisal.Application.Features.PricingAnalysis.UpdatePricingAnalysisDocument;
+
+/// <summary>
+/// Command to replace the linked document on an existing PricingAnalysisDocument entry.
+/// Fires DocumentLinkedEvent / DocumentUpdatedEvent / DocumentUnlinkedEvent depending on the
+/// previous/new DocumentId combination (see PricingAnalysis.UpdateDocument).
+/// </summary>
+public record UpdatePricingAnalysisDocumentCommand(
+    Guid PricingAnalysisId,
+    Guid DocumentEntryId,
+    Guid? DocumentId,
+    string? FileName
+) : ICommand<UpdatePricingAnalysisDocumentResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdatePricingAnalysisDocument/UpdatePricingAnalysisDocumentCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdatePricingAnalysisDocument/UpdatePricingAnalysisDocumentCommandHandler.cs
@@ -1,0 +1,40 @@
+using Shared.Time;
+
+namespace Appraisal.Application.Features.PricingAnalysis.UpdatePricingAnalysisDocument;
+
+public class UpdatePricingAnalysisDocumentCommandHandler(
+    IPricingAnalysisRepository pricingAnalysisRepository,
+    IDateTimeProvider dateTimeProvider,
+    ICurrentUserService currentUser
+) : ICommandHandler<UpdatePricingAnalysisDocumentCommand, UpdatePricingAnalysisDocumentResult>
+{
+    public async Task<UpdatePricingAnalysisDocumentResult> Handle(
+        UpdatePricingAnalysisDocumentCommand command,
+        CancellationToken cancellationToken)
+    {
+        var pricingAnalysis = await pricingAnalysisRepository.GetByIdWithAllDataAsync(
+            command.PricingAnalysisId,
+            cancellationToken);
+
+        if (pricingAnalysis is null)
+            throw new NotFoundException("PricingAnalysis", command.PricingAnalysisId);
+
+        var data = new PricingAnalysisDocumentData(
+            command.DocumentId,
+            command.FileName,
+            null,
+            currentUser.Username,
+            currentUser.Username,
+            dateTimeProvider.Now);
+
+        pricingAnalysis.UpdateDocument(command.DocumentEntryId, data);
+
+        var document = pricingAnalysis.GetDocument(command.DocumentEntryId)!;
+
+        return new UpdatePricingAnalysisDocumentResult(
+            document.Id,
+            command.PricingAnalysisId,
+            document.DocumentId,
+            document.FileName);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdatePricingAnalysisDocument/UpdatePricingAnalysisDocumentEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdatePricingAnalysisDocument/UpdatePricingAnalysisDocumentEndpoint.cs
@@ -1,0 +1,36 @@
+namespace Appraisal.Application.Features.PricingAnalysis.UpdatePricingAnalysisDocument;
+
+public class UpdatePricingAnalysisDocumentEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPut(
+                "/pricing-analysis/{id:guid}/documents/{documentEntryId:guid}",
+                async (
+                    Guid id,
+                    Guid documentEntryId,
+                    UpdatePricingAnalysisDocumentRequest request,
+                    ISender sender,
+                    CancellationToken cancellationToken) =>
+                {
+                    var command = new UpdatePricingAnalysisDocumentCommand(
+                        id,
+                        documentEntryId,
+                        request.DocumentId,
+                        request.FileName);
+
+                    var result = await sender.Send(command, cancellationToken);
+
+                    var response = result.Adapt<UpdatePricingAnalysisDocumentResponse>();
+
+                    return Results.Ok(response);
+                })
+            .WithName("UpdatePricingAnalysisDocument")
+            .Produces<UpdatePricingAnalysisDocumentResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Replace the document linked to a pricing analysis document entry")
+            .WithDescription("Pass a new DocumentId to replace the linked file, or null to unlink without deleting the entry.")
+            .WithTags("PricingAnalysis");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdatePricingAnalysisDocument/UpdatePricingAnalysisDocumentRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdatePricingAnalysisDocument/UpdatePricingAnalysisDocumentRequest.cs
@@ -1,0 +1,9 @@
+namespace Appraisal.Application.Features.PricingAnalysis.UpdatePricingAnalysisDocument;
+
+/// <summary>
+/// Request body for replacing the linked document on an existing PricingAnalysisDocument entry.
+/// Pass DocumentId = null to unlink without deleting the entry.
+/// </summary>
+public record UpdatePricingAnalysisDocumentRequest(
+    Guid? DocumentId,
+    string? FileName);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdatePricingAnalysisDocument/UpdatePricingAnalysisDocumentResponse.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdatePricingAnalysisDocument/UpdatePricingAnalysisDocumentResponse.cs
@@ -1,0 +1,7 @@
+namespace Appraisal.Application.Features.PricingAnalysis.UpdatePricingAnalysisDocument;
+
+public record UpdatePricingAnalysisDocumentResponse(
+    Guid Id,
+    Guid PricingAnalysisId,
+    Guid? DocumentId,
+    string? FileName);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdatePricingAnalysisDocument/UpdatePricingAnalysisDocumentResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdatePricingAnalysisDocument/UpdatePricingAnalysisDocumentResult.cs
@@ -1,0 +1,7 @@
+namespace Appraisal.Application.Features.PricingAnalysis.UpdatePricingAnalysisDocument;
+
+public record UpdatePricingAnalysisDocumentResult(
+    Guid Id,
+    Guid PricingAnalysisId,
+    Guid? DocumentId,
+    string? FileName);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkCommand.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.PricingAnalysis.UpdateRemark;
+
+public record UpdateRemarkCommand(Guid PricingAnalysisId, string Remark) : ICommand<UpdateRemarkResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkCommand.cs
@@ -1,3 +1,3 @@
 namespace Appraisal.Application.Features.PricingAnalysis.UpdateRemark;
 
-public record UpdateRemarkCommand(Guid PricingAnalysisId, string Remark) : ICommand<UpdateRemarkResult>, ITransactionalCommand<IAppraisalUnitOfWork>;
+public record UpdateRemarkCommand(Guid PricingAnalysisId, string? Remark) : ICommand<UpdateRemarkResult>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkCommandHandler.cs
@@ -1,0 +1,20 @@
+namespace Appraisal.Application.Features.PricingAnalysis.UpdateRemark;
+
+public class UpdateRemarkCommandHandler(
+    IPricingAnalysisRepository pricingAnalysisRepository
+) : ICommandHandler<UpdateRemarkCommand, UpdateRemarkResult>
+{
+    public async Task<UpdateRemarkResult> Handle(UpdateRemarkCommand command, CancellationToken cancellationToken)
+    {
+        var pricingAnalysis = await pricingAnalysisRepository.GetByIdWithAllDataAsync(
+            command.PricingAnalysisId,
+            cancellationToken);
+
+        if (pricingAnalysis is null)
+            throw new NotFoundException("PricingAnalysis", command.PricingAnalysisId);
+
+        pricingAnalysis.SetRemark(command.Remark);
+
+        return new UpdateRemarkResult(pricingAnalysis.Id, pricingAnalysis.Remark);
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkEndpoint.cs
@@ -1,0 +1,36 @@
+namespace Appraisal.Application.Features.PricingAnalysis.UpdateRemark;
+
+public class UpdateRemarkEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPut(
+                "/pricing-analysis/{id:guid}/remark",
+                async (
+                    Guid id,
+                    UpdateRemarkRequest request,
+                    ISender sender,
+                    CancellationToken cancellationToken
+                ) =>
+                {
+                    var command = new UpdateRemarkCommand(
+                        id,
+                        request.Remark
+                    );
+
+                    var result = await sender.Send(command, cancellationToken);
+
+                    var response = result.Adapt<UpdateRemarkResponse>();
+
+                    return Results.Ok(response);
+                }
+            )
+            .WithName("UpdateRemark")
+            .Produces<UpdateRemarkResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Update remark for pricing analysis")
+            .WithDescription("Creates or updates the remark.")
+            .WithTags("PricingAnalysis");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkRequest.cs
@@ -4,4 +4,4 @@ namespace Appraisal.Application.Features.PricingAnalysis.UpdateRemark;
 /// Request to update the remark for a pricing analysis.
 /// </summary>
 /// <param name="Remark"></param>
-public record UpdateRemarkRequest(string Remark);
+public record UpdateRemarkRequest(string? Remark);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkRequest.cs
@@ -1,0 +1,7 @@
+namespace Appraisal.Application.Features.PricingAnalysis.UpdateRemark;
+
+/// <summary>
+/// Request to update the remark for a pricing analysis.
+/// </summary>
+/// <param name="Remark"></param>
+public record UpdateRemarkRequest(string Remark);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkResponse.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkResponse.cs
@@ -1,3 +1,3 @@
 namespace Appraisal.Application.Features.PricingAnalysis.UpdateRemark;
 
-public record UpdateRemarkResponse(Guid Id, string Remark);
+public record UpdateRemarkResponse(Guid Id, string? Remark);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkResponse.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkResponse.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.PricingAnalysis.UpdateRemark;
+
+public record UpdateRemarkResponse(Guid Id, string Remark);

--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/UpdateRemark/UpdateRemarkResult.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Application.Features.PricingAnalysis.UpdateRemark;
+
+public record UpdateRemarkResult(Guid Id, string Remark);

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/Events/DocumentLinkedEvent.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/Events/DocumentLinkedEvent.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Domain.Appraisals.Events;
+
+public record DocumentLinkedEvent(Guid PricingId, Guid DocumentId) : IDomainEvent;

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/Events/DocumentUnlinkedEvent.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/Events/DocumentUnlinkedEvent.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Domain.Appraisals.Events;
+
+public record DocumentUnlinkedEvent(Guid PricingId, Guid DocumentId) : IDomainEvent;

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/Events/DocumentUpdatedEvent.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/Events/DocumentUpdatedEvent.cs
@@ -1,0 +1,3 @@
+namespace Appraisal.Domain.Appraisals.Events;
+
+public record DocumentUpdatedEvent(Guid PricingId, Guid PreviousDocumentId, Guid DocumentId) : IDomainEvent;

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysis.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysis.cs
@@ -342,6 +342,12 @@ public class PricingAnalysis : Aggregate<Guid>
     // Documents management
     public PricingAnalysisDocument AddDocument(PricingAnalysisDocumentData data)
     {
+        RuleCheck.Valid()
+             .AddErrorIf(
+                 data.DocumentId.HasValue && _documents.Any(d => d.DocumentId == data.DocumentId),
+                 $"Document '{data.DocumentId}' is already linked to this pricing analysis.")
+             .ThrowIfInvalid();
+
         var document = PricingAnalysisDocument.Create(Id, data);
 
         _documents.Add(document);
@@ -358,6 +364,9 @@ public class PricingAnalysis : Aggregate<Guid>
 
         RuleCheck.Valid()
             .AddErrorIf(document is null, $"Document with id '{documentId}' not found in this pricing analysis.")
+            .AddErrorIf(
+                 data.DocumentId.HasValue && _documents.Any(d => d.DocumentId == data.DocumentId),
+                 $"Document '{data.DocumentId}' is already linked to this pricing analysis.")
             .ThrowIfInvalid();
 
         var (previousDocId, newDocId) = document!.Update(data);

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysis.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysis.cs
@@ -404,7 +404,7 @@ public class PricingAnalysis : Aggregate<Guid>
         return _documents.Any(d => d.Id == documentId);
     }
 
-    public void SetRemark(string remark)
+    public void SetRemark(string? remark)
     {
         Remark = remark;
     }

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysis.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysis.cs
@@ -1,3 +1,5 @@
+using Appraisal.Domain.Appraisals.Events;
+
 namespace Appraisal.Domain.Appraisals;
 
 /// <summary>
@@ -58,6 +60,10 @@ public class PricingAnalysis : Aggregate<Guid>
 
     // Use system pricing calculation
     public bool UseSystemCalc { get; private set; } = true;
+
+    private readonly List<PricingAnalysisDocument> _documents = [];
+    public IReadOnlyList<PricingAnalysisDocument> Documents => _documents.AsReadOnly();
+    public string? Remark { get; private set; } = null!;
 
     private PricingAnalysis()
     {
@@ -223,6 +229,55 @@ public class PricingAnalysis : Aggregate<Guid>
         SetFinalAppraisedValueInternal(null);
     }
 
+    /// <summary>
+    /// Selects <paramref name="approachId"/> as the analysis's final approach, unselecting all
+    /// others, and propagates its <c>ApproachValue</c> up to <see cref="FinalAppraisedValue"/> —
+    /// even when that value is null — so the rollup never keeps a stale value from a previously
+    /// selected approach.
+    /// </summary>
+    public void SelectApproach(Guid approachId)
+    {
+        var targetApproach = _approaches.FirstOrDefault(a => a.Id == approachId);
+
+        if (targetApproach is null)
+            throw new NotFoundException("PricingAnalysisApproach", approachId);
+
+        RuleCheck.Valid()
+            .AddErrorIf(
+                targetApproach.Methods.All(m => !m.IsSelected),
+                "Cannot select an approach that has no selected method.")
+            .ThrowIfInvalid();
+
+        foreach (var approach in _approaches)
+        {
+            if (approach.Id == targetApproach.Id)
+                approach.Select();
+            else
+                approach.Unselect();
+        }
+
+        SetFinalAppraisedValueInternal(targetApproach.ApproachValue);
+    }
+
+    /// <summary>
+    /// Selects <paramref name="methodId"/> as the primary method within its parent approach
+    /// (setting all other methods in that approach as Alternative). If the parent approach is
+    /// already the analysis's selected/final approach, also propagates the method's value up to
+    /// <see cref="FinalAppraisedValue"/> — even when that value is null.
+    /// </summary>
+    public void SelectMethod(Guid methodId)
+    {
+        var parentApproach = _approaches.FirstOrDefault(a => a.Methods.Any(m => m.Id == methodId));
+
+        if (parentApproach is null)
+            throw new NotFoundException("PricingAnalysisMethod", methodId);
+
+        parentApproach.SelectMethod(methodId);
+
+        if (parentApproach.IsSelected)
+            SetFinalAppraisedValueInternal(parentApproach.ApproachValue);
+    }
+
     private void SetFinalAppraisedValueInternal(decimal? value)
     {
         FinalAppraisedValue = value;
@@ -282,5 +337,66 @@ public class PricingAnalysis : Aggregate<Guid>
             clone.AddDomainEvent(new AppraisalFinalValuesChangedEvent(newPropertyGroupId));
 
         return clone;
+    }
+
+    // Documents management
+    public PricingAnalysisDocument AddDocument(PricingAnalysisDocumentData data)
+    {
+        var document = PricingAnalysisDocument.Create(Id, data);
+
+        _documents.Add(document);
+
+        if (data.DocumentId.HasValue)
+            AddDomainEvent(new DocumentLinkedEvent(Id, data.DocumentId.Value));
+
+        return document;
+    }
+
+    public void UpdateDocument(Guid documentId, PricingAnalysisDocumentData data)
+    {
+        var document = _documents.FirstOrDefault(d => d.Id == documentId);
+
+        RuleCheck.Valid()
+            .AddErrorIf(document is null, $"Document with id '{documentId}' not found in this pricing analysis.")
+            .ThrowIfInvalid();
+
+        var (previousDocId, newDocId) = document!.Update(data);
+
+        // Fire appropriate domain events based on document changes
+        if (previousDocId.HasValue && newDocId.HasValue)
+            AddDomainEvent(new DocumentUpdatedEvent(Id, previousDocId.Value, newDocId.Value));
+        else if (!previousDocId.HasValue && newDocId.HasValue)
+            AddDomainEvent(new DocumentLinkedEvent(Id, newDocId.Value));
+        else if (previousDocId.HasValue && !newDocId.HasValue)
+            AddDomainEvent(new DocumentUnlinkedEvent(Id, previousDocId.Value));
+    }
+
+    public void RemoveDocument(Guid documentId)
+    {
+        var document = _documents.FirstOrDefault(d => d.Id == documentId);
+
+        RuleCheck.Valid()
+            .AddErrorIf(document is null, $"Document with id '{documentId}' not found in this pricing analysis.")
+            .ThrowIfInvalid();
+
+        _documents.Remove(document!);
+
+        if (document!.DocumentId.HasValue)
+            AddDomainEvent(new DocumentUnlinkedEvent(Id, document.DocumentId.Value));
+    }
+
+    public PricingAnalysisDocument? GetDocument(Guid documentId)
+    {
+        return _documents.FirstOrDefault(d => d.Id == documentId);
+    }
+
+    public bool HasDocument(Guid documentId)
+    {
+        return _documents.Any(d => d.Id == documentId);
+    }
+
+    public void SetRemark(string remark)
+    {
+        Remark = remark;
     }
 }

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysisApproach.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysisApproach.cs
@@ -83,6 +83,33 @@ public class PricingAnalysisApproach : Entity<Guid>
         ApproachValue = null;
     }
 
+    /// <summary>
+    /// Selects <paramref name="methodId"/> as the primary method within this approach, setting
+    /// all other methods here as Alternative, and syncs <see cref="ApproachValue"/> to the
+    /// newly-selected method's value — even when that value is null — so the approach never
+    /// keeps a stale value left over from a previously selected method.
+    /// </summary>
+    public void SelectMethod(Guid methodId)
+    {
+        var targetMethod = _methods.FirstOrDefault(m => m.Id == methodId);
+
+        if (targetMethod is null)
+            throw new NotFoundException("PricingAnalysisMethod", methodId);
+
+        targetMethod.SetAsSelected();
+
+        foreach (var method in _methods)
+        {
+            if (method.Id != methodId)
+                method.SetAsUnselected();
+        }
+
+        if (targetMethod.MethodValue.HasValue)
+            SetValue(targetMethod.MethodValue.Value);
+        else
+            ClearValue();
+    }
+
     public void Select()
     {
         IsSelected = true;

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysisDocument.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysisDocument.cs
@@ -1,0 +1,67 @@
+namespace Appraisal.Domain.Appraisals;
+
+
+public class PricingAnalysisDocument : Entity<Guid>
+{
+    public Guid PricingAnalysisId { get; private set; }
+    public Guid? DocumentId { get; private set; }
+    public string? FileName { get; private set; }
+    public string? FilePath { get; private set; }
+    public string? UploadedBy { get; private set; }
+    public string? UploadedByName { get; private set; }
+    public DateTime? UploadedAt { get; private set; }
+
+    private PricingAnalysisDocument()
+    {
+        // EF Core
+    }
+
+    private PricingAnalysisDocument(Guid pricingAnalysisId)
+    {
+        PricingAnalysisId = pricingAnalysisId;
+    }
+
+    internal static PricingAnalysisDocument Create(Guid pricingAnalysisId, PricingAnalysisDocumentData data)
+    {
+        return new PricingAnalysisDocument(pricingAnalysisId)
+        {
+            DocumentId = data.DocumentId,
+            FileName = data.FileName,
+            FilePath = data.FilePath,
+            UploadedBy = data.UploadedBy,
+            UploadedByName = data.UploadedByName,
+            UploadedAt = data.UploadedAt
+        };
+    }
+
+    internal (Guid? PreviousDocumentId, Guid? NewDocumentId) Update(PricingAnalysisDocumentData data)
+    {
+        Guid? previousDocumentId = null;
+        Guid? newDocumentId = null;
+
+        if (DocumentId != data.DocumentId)
+        {
+            previousDocumentId = DocumentId;
+            newDocumentId = data.DocumentId;
+
+            DocumentId = data.DocumentId;
+            FileName = data.FileName;
+            FilePath = data.FilePath;
+
+            UploadedBy = data.DocumentId.HasValue ? data.UploadedBy : null;
+            UploadedByName = data.DocumentId.HasValue ? data.UploadedByName : null;
+            UploadedAt = data.DocumentId.HasValue ? data.UploadedAt : null;
+        }
+
+        return (previousDocumentId, newDocumentId);
+    }
+}
+
+public record PricingAnalysisDocumentData(
+    Guid? DocumentId,
+    string? FileName,
+    string? FilePath,
+    string? UploadedBy,
+    string? UploadedByName,
+    DateTime? UploadedAt
+);

--- a/Modules/Appraisal/Appraisal/Infrastructure/AppraisalDbContext.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/AppraisalDbContext.cs
@@ -121,6 +121,7 @@ public class AppraisalDbContext : DbContext
     // Pricing Entities (part of Appraisal aggregate)
     // =====================================================
     public DbSet<PricingAnalysis> PricingAnalyses => Set<PricingAnalysis>();
+    public DbSet<PricingAnalysisDocument> PricingAnalysisDocuments => Set<PricingAnalysisDocument>();
     public DbSet<PricingAnalysisApproach> PricingAnalysisApproaches => Set<PricingAnalysisApproach>();
     public DbSet<PricingAnalysisMethod> PricingAnalysisMethods => Set<PricingAnalysisMethod>();
     public DbSet<PricingComparableLink> PricingComparableLinks => Set<PricingComparableLink>();

--- a/Modules/Appraisal/Appraisal/Infrastructure/Configurations/PricingConfiguration.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Configurations/PricingConfiguration.cs
@@ -47,6 +47,9 @@ public class PricingAnalysisConfiguration : IEntityTypeConfiguration<PricingAnal
             .WithOne()
             .HasForeignKey(a => a.PricingAnalysisId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        builder.OwnsMany(r => r.Documents, doc => new PricingDocumentConfiguration().Configure(doc));
+        builder.Property(p => p.Remark).HasMaxLength(4000);
     }
 }
 

--- a/Modules/Appraisal/Appraisal/Infrastructure/Configurations/PricingDocumentConfiguration.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Configurations/PricingDocumentConfiguration.cs
@@ -1,0 +1,22 @@
+namespace Appraisal.Infrastructure.Configurations;
+
+public class PricingDocumentConfiguration
+    : IOwnedEntityConfiguration<Domain.Appraisals.PricingAnalysis, PricingAnalysisDocument>
+{
+    public void Configure(OwnedNavigationBuilder<PricingAnalysis, PricingAnalysisDocument> builder)
+    {
+        builder.ToTable("PricingAnalysisDocuments");
+        builder.WithOwner().HasForeignKey(d => d.PricingAnalysisId);
+        builder.HasKey(d => d.Id);
+
+        builder.Property(d => d.FileName).HasMaxLength(255);
+        builder.Property(d => d.FilePath).HasMaxLength(500);
+        builder.Property(d => d.UploadedBy).HasMaxLength(10);
+        builder.Property(d => d.UploadedByName).HasMaxLength(100);
+
+        builder.HasIndex(d => new { d.PricingAnalysisId, d.DocumentId })
+            .IsUnique()
+            .HasFilter("[DocumentId] IS NOT NULL")
+            .HasDatabaseName("IX_PricingAnalysisDocument_PricingAnalysis_Document");
+    }
+}

--- a/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260703070750_AddPricingAnalysisDocument.Designer.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260703070750_AddPricingAnalysisDocument.Designer.cs
@@ -4,6 +4,7 @@ using Appraisal.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Appraisal.Infrastructure.Migrations
 {
     [DbContext(typeof(AppraisalDbContext))]
-    partial class AppraisalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260703070750_AddPricingAnalysisDocument")]
+    partial class AddPricingAnalysisDocument
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1239,10 +1242,6 @@ namespace Appraisal.Infrastructure.Migrations
                     b.Property<Guid>("AppraisalId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<decimal?>("BuildingInsurancePrice")
-                        .HasPrecision(18, 2)
-                        .HasColumnType("decimal(18,2)");
-
                     b.Property<DateTime?>("CreatedAt")
                         .HasColumnType("datetime2");
 
@@ -1256,14 +1255,6 @@ namespace Appraisal.Infrastructure.Migrations
                     b.Property<string>("Description")
                         .HasMaxLength(500)
                         .HasColumnType("nvarchar(500)");
-
-                    b.Property<decimal?>("ForcedSalePrice")
-                        .HasPrecision(18, 2)
-                        .HasColumnType("decimal(18,2)");
-
-                    b.Property<decimal?>("SellingPrice")
-                        .HasPrecision(18, 2)
-                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("SequenceNumber")
                         .HasColumnType("int");
@@ -3005,10 +2996,6 @@ namespace Appraisal.Infrastructure.Migrations
 
                     b.Property<Guid?>("HostMethodId")
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("Remark")
-                        .HasMaxLength(4000)
-                        .HasColumnType("nvarchar(4000)");
 
                     b.Property<string>("Status")
                         .IsRequired()

--- a/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260703070750_AddPricingAnalysisDocument.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260703070750_AddPricingAnalysisDocument.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Appraisal.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPricingAnalysisDocument : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PricingAnalysisDocuments",
+                schema: "appraisal",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PricingAnalysisId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DocumentId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    FileName = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
+                    FilePath = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    UploadedBy = table.Column<string>(type: "nvarchar(10)", maxLength: 10, nullable: true),
+                    UploadedByName = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    UploadedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    CreatedBy = table.Column<string>(type: "nvarchar(10)", maxLength: 10, nullable: true),
+                    CreatedWorkstation = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "nvarchar(10)", maxLength: 10, nullable: true),
+                    UpdatedWorkstation = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PricingAnalysisDocuments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PricingAnalysisDocuments_PricingAnalysis_PricingAnalysisId",
+                        column: x => x.PricingAnalysisId,
+                        principalSchema: "appraisal",
+                        principalTable: "PricingAnalysis",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PricingAnalysisDocument_PricingAnalysis_Document",
+                schema: "appraisal",
+                table: "PricingAnalysisDocuments",
+                columns: new[] { "PricingAnalysisId", "DocumentId" },
+                unique: true,
+                filter: "[DocumentId] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PricingAnalysisDocuments",
+                schema: "appraisal");
+        }
+    }
+}

--- a/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260709030819_AddPricingAnalysisRemark.Designer.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260709030819_AddPricingAnalysisRemark.Designer.cs
@@ -4,6 +4,7 @@ using Appraisal.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Appraisal.Infrastructure.Migrations
 {
     [DbContext(typeof(AppraisalDbContext))]
-    partial class AppraisalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709030819_AddPricingAnalysisRemark")]
+    partial class AddPricingAnalysisRemark
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1239,10 +1242,6 @@ namespace Appraisal.Infrastructure.Migrations
                     b.Property<Guid>("AppraisalId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<decimal?>("BuildingInsurancePrice")
-                        .HasPrecision(18, 2)
-                        .HasColumnType("decimal(18,2)");
-
                     b.Property<DateTime?>("CreatedAt")
                         .HasColumnType("datetime2");
 
@@ -1256,14 +1255,6 @@ namespace Appraisal.Infrastructure.Migrations
                     b.Property<string>("Description")
                         .HasMaxLength(500)
                         .HasColumnType("nvarchar(500)");
-
-                    b.Property<decimal?>("ForcedSalePrice")
-                        .HasPrecision(18, 2)
-                        .HasColumnType("decimal(18,2)");
-
-                    b.Property<decimal?>("SellingPrice")
-                        .HasPrecision(18, 2)
-                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("SequenceNumber")
                         .HasColumnType("int");

--- a/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260709030819_AddPricingAnalysisRemark.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260709030819_AddPricingAnalysisRemark.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Appraisal.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPricingAnalysisRemark : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Remark",
+                schema: "appraisal",
+                table: "PricingAnalysis",
+                type: "nvarchar(4000)",
+                maxLength: 4000,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Remark",
+                schema: "appraisal",
+                table: "PricingAnalysis");
+        }
+    }
+}

--- a/Modules/Appraisal/Appraisal/Infrastructure/Repositories/PricingAnalysisRepository.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Repositories/PricingAnalysisRepository.cs
@@ -88,6 +88,7 @@ public class PricingAnalysisRepository(AppraisalDbContext dbContext)
         CancellationToken cancellationToken = default)
     {
         return await _dbContext.PricingAnalyses
+            .Include(pa => pa.Documents)
             .Include(pa => pa.Approaches)
                 .ThenInclude(a => a.Methods)
                     .ThenInclude(m => m.Calculations)

--- a/Tests/Unit/Appraisal.Tests/Domain/PricingAnalysisDocumentTests.cs
+++ b/Tests/Unit/Appraisal.Tests/Domain/PricingAnalysisDocumentTests.cs
@@ -1,4 +1,5 @@
 using Appraisal.Domain.Appraisals;
+using Shared.Exceptions;
 using Appraisal.Domain.Appraisals.Events;
 
 namespace Appraisal.Tests.Domain;

--- a/Tests/Unit/Appraisal.Tests/Domain/PricingAnalysisDocumentTests.cs
+++ b/Tests/Unit/Appraisal.Tests/Domain/PricingAnalysisDocumentTests.cs
@@ -1,0 +1,125 @@
+using Appraisal.Domain.Appraisals;
+using Appraisal.Domain.Appraisals.Events;
+
+namespace Appraisal.Tests.Domain;
+
+/// <summary>
+/// Domain-level tests for PricingAnalysis document attach/update/remove — no EF, no HTTP,
+/// just the aggregate. Locks in which domain event fires for each Link/Update/Unlink transition,
+/// since that's what the outbox → RabbitMQ → Document-module chain depends on downstream.
+/// </summary>
+public class PricingAnalysisDocumentTests
+{
+    private static PricingAnalysis CreateAnalysis() =>
+        PricingAnalysis.CreateForPropertyGroup(Guid.NewGuid());
+
+    [Fact]
+    public void AddDocument_WithDocumentId_RaisesDocumentLinkedEvent()
+    {
+        var analysis = CreateAnalysis();
+
+        var document = analysis.AddDocument(new PricingAnalysisDocumentData(
+            DocumentId: Guid.NewGuid(),
+            FileName: "survey.pdf",
+            FilePath: null,
+            UploadedBy: "211",
+            UploadedByName: "John",
+            UploadedAt: DateTime.UtcNow));
+
+        Assert.Single(analysis.Documents);
+        Assert.Same(document, analysis.Documents[0]);
+
+        var domainEvent = Assert.Single(analysis.DomainEvents);
+        var linked = Assert.IsType<DocumentLinkedEvent>(domainEvent);
+        Assert.Equal(analysis.Id, linked.PricingId);
+        Assert.Equal(document.DocumentId, linked.DocumentId);
+    }
+
+    [Fact]
+    public void AddDocument_WithoutDocumentId_RaisesNoEvent()
+    {
+        // Placeholder entry (e.g. a required-document slot not yet uploaded) — nothing to link yet.
+        var analysis = CreateAnalysis();
+
+        analysis.AddDocument(new PricingAnalysisDocumentData(
+            DocumentId: null,
+            FileName: null,
+            FilePath: null,
+            UploadedBy: null,
+            UploadedByName: null,
+            UploadedAt: null));
+
+        Assert.Empty(analysis.DomainEvents);
+    }
+
+    [Fact]
+    public void UpdateDocument_ReplacingDocumentId_RaisesDocumentUpdatedEvent()
+    {
+        var analysis = CreateAnalysis();
+        var firstDocumentId = Guid.NewGuid();
+        var document = analysis.AddDocument(new PricingAnalysisDocumentData(
+            firstDocumentId, "v1.pdf", null, "211", "John", DateTime.UtcNow));
+        analysis.ClearDomainEvents();
+
+        var secondDocumentId = Guid.NewGuid();
+        analysis.UpdateDocument(document.Id, new PricingAnalysisDocumentData(
+            secondDocumentId, "v2.pdf", null, "212", "Jane", DateTime.UtcNow));
+
+        var domainEvent = Assert.Single(analysis.DomainEvents);
+        var updated = Assert.IsType<DocumentUpdatedEvent>(domainEvent);
+        Assert.Equal(firstDocumentId, updated.PreviousDocumentId);
+        Assert.Equal(secondDocumentId, updated.DocumentId);
+    }
+
+    [Fact]
+    public void UpdateDocument_ClearingDocumentId_RaisesDocumentUnlinkedEvent()
+    {
+        var analysis = CreateAnalysis();
+        var documentId = Guid.NewGuid();
+        var document = analysis.AddDocument(new PricingAnalysisDocumentData(
+            documentId, "v1.pdf", null, "211", "John", DateTime.UtcNow));
+        analysis.ClearDomainEvents();
+
+        analysis.UpdateDocument(document.Id, new PricingAnalysisDocumentData(
+            null, null, null, null, null, null));
+
+        var domainEvent = Assert.Single(analysis.DomainEvents);
+        var unlinked = Assert.IsType<DocumentUnlinkedEvent>(domainEvent);
+        Assert.Equal(documentId, unlinked.DocumentId);
+    }
+
+    [Fact]
+    public void UpdateDocument_UnknownEntryId_ThrowsDomainException()
+    {
+        var analysis = CreateAnalysis();
+
+        Assert.Throws<DomainException>(() =>
+            analysis.UpdateDocument(Guid.NewGuid(), new PricingAnalysisDocumentData(
+                Guid.NewGuid(), "x.pdf", null, "211", "John", DateTime.UtcNow)));
+    }
+
+    [Fact]
+    public void RemoveDocument_WithLinkedDocument_RaisesDocumentUnlinkedEvent()
+    {
+        var analysis = CreateAnalysis();
+        var documentId = Guid.NewGuid();
+        var document = analysis.AddDocument(new PricingAnalysisDocumentData(
+            documentId, "v1.pdf", null, "211", "John", DateTime.UtcNow));
+        analysis.ClearDomainEvents();
+
+        analysis.RemoveDocument(document.Id);
+
+        Assert.Empty(analysis.Documents);
+        var domainEvent = Assert.Single(analysis.DomainEvents);
+        var unlinked = Assert.IsType<DocumentUnlinkedEvent>(domainEvent);
+        Assert.Equal(documentId, unlinked.DocumentId);
+    }
+
+    [Fact]
+    public void RemoveDocument_UnknownEntryId_ThrowsDomainException()
+    {
+        var analysis = CreateAnalysis();
+
+        Assert.Throws<DomainException>(() => analysis.RemoveDocument(Guid.NewGuid()));
+    }
+}

--- a/httpRequests/Appraisal/PricingAnalysis.http
+++ b/httpRequests/Appraisal/PricingAnalysis.http
@@ -802,6 +802,91 @@ GET {{baseUrl}}/pricing-analysis/{pricingAnalysisId}
 Content-Type: application/json
 
 ### =====================================================
+### 11A. DOCUMENTS
+### =====================================================
+### Two-step flow: upload the raw file to the Document module first (steps 11A.1-11A.2),
+### then attach the returned documentId to the pricing analysis (11A.3).
+
+### 11A.1 Create an upload session (Document module)
+POST {{baseUrl}}/documents/session
+Content-Type: application/json
+
+### Copy the returned "id" into @uploadSessionId below.
+@uploadSessionId = 00000000-0000-0000-0000-000000000000
+
+### 11A.2 Upload the file (Document module) — multipart/form-data
+POST {{baseUrl}}/documents
+X-Dev-Auth: dev-bypass
+Content-Type: multipart/form-data; boundary=----PricingDocBoundary
+
+------PricingDocBoundary
+Content-Disposition: form-data; name="uploadSessionId"
+
+{{uploadSessionId}}
+------PricingDocBoundary
+Content-Disposition: form-data; name="documentType"
+
+SURVEY
+------PricingDocBoundary
+Content-Disposition: form-data; name="documentCategory"
+
+PricingAnalysis
+------PricingDocBoundary
+Content-Disposition: form-data; name="description"
+
+Content-Disposition: form-data; name="file"; filename="upload.pdf"
+Content-Type: application/pdf
+
+< ./upload.pdf
+------PricingDocBoundary--
+
+### Copy the returned "documentId" into @documentId below.
+@documentId = 00000000-0000-0000-0000-000000000000
+
+### 11A.3 Attach the uploaded document to the pricing analysis
+POST {{baseUrl}}/pricing-analysis/{{pricingAnalysisId}}/documents
+Content-Type: application/json
+
+{
+  "documentId": "{{documentId}}",
+  "fileName": "survey.pdf"
+}
+
+### Copy the returned "id" into @documentEntryId below (the PricingAnalysisDocument entry id,
+### NOT the documentId).
+@documentEntryId = 00000000-0000-0000-0000-000000000000
+
+### 11A.4 List documents attached to the pricing analysis
+GET {{baseUrl}}/pricing-analysis/{{pricingAnalysisId}}/documents
+Content-Type: application/json
+
+### 11A.5 Replace the file linked to an existing document entry
+PUT {{baseUrl}}/pricing-analysis/{{pricingAnalysisId}}/documents/{{documentEntryId}}
+Content-Type: application/json
+
+{
+  "documentId": "{{documentId}}",
+  "fileName": "survey-v2.pdf"
+}
+
+### 11A.6 Unlink without deleting the entry (DocumentId = null)
+PUT {{baseUrl}}/pricing-analysis/{{pricingAnalysisId}}/documents/{{documentEntryId}}
+Content-Type: application/json
+
+{
+  "documentId": null,
+  "fileName": null
+}
+
+### 11A.7 Delete the document entry entirely
+DELETE {{baseUrl}}/pricing-analysis/{{pricingAnalysisId}}/documents/{{documentEntryId}}
+Content-Type: application/json
+
+### 11A.8 Sanity check: GetPricingAnalysis now includes a "documents" array
+GET {{baseUrl}}/pricing-analysis/{{pricingAnalysisId}}
+Content-Type: application/json
+
+### =====================================================
 ### 12. METHOD TYPES REFERENCE
 ### =====================================================
 # MethodType values:


### PR DESCRIPTION
Problem
Manual mode's Save Summary flow (frontend) needed backend support for three things it didn't have: attaching/removing supporting documents on a pricing analysis, persisting an analysis-level remark, and selecting a final approach independently of selecting a method within it.

Solution
- Document management: new PricingAnalysisDocument owned entity, with Attach/Get/Remove/Update endpoints under /pricing-analysis/{id}/documents. Attach links an already-uploaded document (from the Document module) to the analysis, mirroring Request module's AttachRequestDocumentCommandHandler pattern. Remove deletes the entry entirely. Update replaces the linked document on an existing entry. Each fires the correct domain event (DocumentLinked/DocumentUpdated/DocumentUnlinked) depending on the previous/new DocumentId combination, published to the outbox for the Document-module integration chain.
- SelectApproach: new POST /pricing-analysis/{id}/approaches/{approachId}/select endpoint, split out of SelectMethod. Selects the final approach independently of picking a method within it, and propagates ApproachValue up to FinalAppraisedValue — even when null — so the rollup never keeps a stale value from a previously selected approach.
- SelectMethod: simplified — selection invariants and FinalAppraisedValue propagation moved into the aggregate (PricingAnalysis.SelectMethod / PricingAnalysisApproach.SelectMethod).
- UpdateRemark: new PUT /pricing-analysis/{id}/remark endpoint, analysis-level remark only (PricingAnalysis.Remark). Wired into GetPricingAnalysis so it round-trips on load.
- Repository: GetByIdWithAllDataAsync now includes Documents, since every new handler above depends on the full document set being loaded.

Fix included in this batch
PricingAnalysisApproach.SelectMethod originally only set ApproachValue when the newly-selected method had a value, leaving a stale value from the previously selected method if the new one doesn't have one yet. Now clears ApproachValue via ClearValue() in that case, matching the same no-stale-value discipline SelectApproach already applies at the analysis level.

Explicitly not included
UpdateMethod does not carry a Remark parameter — method-level remark isn't collected anywhere in this feature; remark is analysis-level only, via UpdateRemark. SaveComparativeAnalysisCommandHandler's existing method.SetRemark(command.Remark) call (and the same pre-existing pattern in Hypothesis/ProfitRent/MachineCost/Leasehold saves) was intentionally left untouched — out of scope for this change.

Files: Domain/Appraisals/PricingAnalysis.cs, PricingAnalysisApproach.cs, PricingAnalysisDocument.cs (new), Domain/Appraisals/Events/DocumentLinkedEvent.cs, DocumentUnlinkedEvent.cs, DocumentUpdatedEvent.cs (new), Application/EventHandlers/DocumentLinkedEventHandler.cs, DocumentUnlinkedEventHandler.cs, DocumentUpdatedEventHandler.cs (new), Application/Features/PricingAnalysis/AttachPricingAnalysisDocument/*, GetPricingAnalysisDocuments/*, RemovePricingAnalysisDocument/*, UpdatePricingAnalysisDocument/* (new), SelectApproach/* (new), SelectMethod/SelectMethodCommandHandler.cs, SelectMethodEndpoint.cs, UpdateRemark/* (new), UpdateMethod/UpdateMethodCommand.cs, UpdateMethodCommandHandler.cs, UpdateMethodRequest.cs, UpdateMethodEndpoint.cs, GetPricingAnalysis/GetPricingAnalysisQueryHandler.cs, GetPricingAnalysisResponse.cs, GetPricingAnalysisResult.cs, Infrastructure/Configurations/PricingConfiguration.cs, PricingDocumentConfiguration.cs (new), Infrastructure/Repositories/PricingAnalysisRepository.cs, migrations AddPricingAnalysisDocument + AddPricingAnalysisRemark, Tests/Domain/PricingAnalysisDocumentTests.cs (new).