### PR TITLE
refactor: rename LOS PMA payload TitleDetails to PmaDetails

### DIFF
--- a/Modules/Integration/Integration/Application/Services/LosPmaPayloadMapper.cs
+++ b/Modules/Integration/Integration/Application/Services/LosPmaPayloadMapper.cs
@@ -28,7 +28,7 @@ public static class LosPmaPayloadMapper
                     CasReportNo: data.AppraisalNumber!,
                     LoanApplicationNo: data.LoanApplicationNo,
                     Action: DefaultAction,
-                    TitleDetails: new LosPmaTitleDetails(
+                    PmaDetails: new LosPmaDetails(
                         prices,
                         new LosLandCollateral(
                             Rawang: title.Rawang,
@@ -56,7 +56,7 @@ public static class LosPmaPayloadMapper
                     CasReportNo: data.AppraisalNumber!,
                     LoanApplicationNo: data.LoanApplicationNo,
                     Action: DefaultAction,
-                    TitleDetails: new LosPmaTitleDetails(
+                    PmaDetails: new LosPmaDetails(
                         prices,
                         new LosCondoCollateral(
                             TitleDeedNo: condo.BuiltOnTitleNumber, // sent like the land collateral's titleDeedNo

--- a/Modules/Integration/Integration/Application/Services/LosPmaUpdatePayload.cs
+++ b/Modules/Integration/Integration/Application/Services/LosPmaUpdatePayload.cs
@@ -12,7 +12,7 @@ public sealed record LosPmaUpdatePayload(
     string CasReportNo,
     string? LoanApplicationNo,
     string Action,
-    LosPmaTitleDetails TitleDetails);
+    LosPmaDetails PmaDetails);
 
 /// <summary>
 /// <see cref="Collateral"/> is set by <see cref="LosPmaPayloadMapper"/> to a
@@ -20,7 +20,7 @@ public sealed record LosPmaUpdatePayload(
 /// (one payload for the whole property) — never both, so each JSON payload only ever carries the
 /// fields for its own property type (no cross-type null leakage).
 /// </summary>
-public sealed record LosPmaTitleDetails(
+public sealed record LosPmaDetails(
     LosPmaPrices Pma,
     object Collateral);
 

--- a/Modules/Integration/Integration/Application/Services/WebhookService.cs
+++ b/Modules/Integration/Integration/Application/Services/WebhookService.cs
@@ -31,7 +31,7 @@ public class WebhookService(
     // top level with no CAS envelope. No WhenWritingNull here (unlike the envelope options): a
     // legitimately-cleared field (e.g. BuildingInsurance reset to null) must be sent as explicit
     // JSON null so LOS can distinguish "cleared" from "field absent", not omitted. Land/condo
-    // no longer share one collateral record (see LosPmaTitleDetails), so there is no cross-type
+    // no longer share one collateral record (see LosPmaDetails), so there is no cross-type
     // null leakage to guard against either.
     private static readonly JsonSerializerOptions _rawPayloadJsonOptions = new()
     {


### PR DESCRIPTION
## Summary
Renames the LOS PMA update payload field `TitleDetails` → `PmaDetails` and the record type `LosPmaTitleDetails` → `LosPmaDetails`, so the node name reflects that it carries PMA details (prices + collateral) rather than title data.

## Changes
- `LosPmaUpdatePayload.cs` — rename field + record type.
- `LosPmaPayloadMapper.cs` — construct `LosPmaDetails` for land and condo paths.
- `WebhookService.cs` — update stale doc-comment reference.

## Notes
- Pure rename; behavior and serialized structure of the collateral node are unchanged apart from the renamed key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)