### PR TITLE
fix(reporting): source ProfitRent FinalValueRounded from PricingFinalValues

### DIFF
--- a/Modules/Reporting/Reporting/Application/Providers/Sections/ProfitRentSectionLoader.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/Sections/ProfitRentSectionLoader.cs
@@ -89,6 +89,8 @@ internal static class ProfitRentSectionLoader
         // W2 fix: EstimatePriceRounded confirmed on ProfitRentAnalysis.cs line 24.
         // Effective value = EstimatePriceRounded ?? FinalValueRounded
         //   (mirrors SaveProfitRentAnalysisCommandHandler.cs:110)
+        // FinalValueRounded is sourced from PricingFinalValues (Phase C: never lived on
+        // ProfitRentAnalyses — mirrors LeaseholdSectionLoader / IncomeSectionLoader).
         const string headerSql = """
             SELECT
                 pra.Id               AS ProfitRentAnalysisId,
@@ -98,9 +100,11 @@ internal static class ProfitRentSectionLoader
                 pra.GrowthIntervalYears,
                 pra.DiscountRate,
                 pra.TotalPresentValue,
-                pra.FinalValueRounded,
+                COALESCE(pfv.FinalValueRounded, 0) AS FinalValueRounded,
                 pra.EstimatePriceRounded
             FROM appraisal.ProfitRentAnalyses pra
+            LEFT JOIN appraisal.PricingFinalValues pfv
+                ON pfv.PricingMethodId = pra.PricingMethodId
             WHERE pra.PricingMethodId = @MethodId
             """;
 


### PR DESCRIPTION
## Summary
Phase C of the PricingFinalValue consolidation for the ProfitRent reporting section.

`FinalValueRounded` no longer lives on `appraisal.ProfitRentAnalyses`. This updates `ProfitRentSectionLoader` to read it from `appraisal.PricingFinalValues` via a `LEFT JOIN` on `PricingMethodId`, using `COALESCE(..., 0)` for the missing case — mirroring `LeaseholdSectionLoader` and `IncomeSectionLoader`.

## Changes
- `ProfitRentSectionLoader.cs`: header SQL now joins `PricingFinalValues` and selects `COALESCE(pfv.FinalValueRounded, 0)` instead of `pra.FinalValueRounded`.

## Testing
- `dotnet build` of the Reporting module: 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)