### PR TITLE
feat(pma): scope Property Information (PMA) tab to int-pma-input activity

### DIFF
--- a/Database/Scripts/Maintenance/RestrictPmaPropertyPermissionToIntAppraisalStaff.sql
+++ b/Database/Scripts/Maintenance/RestrictPmaPropertyPermissionToIntAppraisalStaff.sql
@@ -1,0 +1,35 @@
+-- =============================================================================
+-- Restrict the "Property Information (PMA)" tab permission to IntAppraisalStaff.
+--
+-- Why: APPRAISAL_PROPERTY_PMA_VIEW/EDIT used to be part of the shared appraisal
+-- section permission set granted to EVERY appraisal role, so the PMA property tab
+-- could surface on any activity. The PMA tab is now exclusive to the int-pma-input
+-- activity (performed by IntAppraisalStaff); the C# seeder was changed to grant the
+-- permission to IntAppraisalStaff only, and to hide it on that role's other
+-- activities via ActivityMenuOverrides.
+--
+-- The role-permission seeder is ADD-ONLY (it never revokes), so on databases that
+-- were already seeded the broad grant lingers. This one-off script removes it from
+-- every role EXCEPT IntAppraisalStaff and Admin (Admin intentionally keeps all
+-- permissions). Idempotent: re-running is a no-op once the rows are gone.
+--
+-- The complementary additive changes (new TASK_INT_PMA_INPUT permission, the
+-- int-pma-input task menu item, and the ActivityMenuOverride rows) are INSERT-ONLY
+-- in the seeder and apply automatically on the next application boot — no script
+-- needed for those.
+-- =============================================================================
+
+DELETE rp
+FROM auth.RolePermissions rp
+INNER JOIN auth.Permissions   p ON p.Id = rp.PermissionId
+INNER JOIN auth.AspNetRoles   r ON r.Id = rp.RoleId
+WHERE p.PermissionCode IN ('APPRAISAL_PROPERTY_PMA_VIEW', 'APPRAISAL_PROPERTY_PMA_EDIT')
+  AND r.Name NOT IN ('IntAppraisalStaff', 'Admin');
+
+-- Verify (optional): rows that remain should be IntAppraisalStaff + Admin only.
+-- SELECT r.Name, p.PermissionCode
+-- FROM auth.RolePermissions rp
+-- INNER JOIN auth.Permissions p ON p.Id = rp.PermissionId
+-- INNER JOIN auth.AspNetRoles r ON r.Id = rp.RoleId
+-- WHERE p.PermissionCode IN ('APPRAISAL_PROPERTY_PMA_VIEW', 'APPRAISAL_PROPERTY_PMA_EDIT')
+-- ORDER BY r.Name, p.PermissionCode;

--- a/Modules/Auth/Auth/Infrastructure/Seed/ActivityMenuOverrideSeedData.cs
+++ b/Modules/Auth/Auth/Infrastructure/Seed/ActivityMenuOverrideSeedData.cs
@@ -33,5 +33,18 @@ public static class ActivityMenuOverrideSeedData
         new("provide-additional-documents", "appraisal.property-pma",   IsVisible: false, CanEdit: false),
         new("provide-additional-documents", "appraisal.administration", IsVisible: false, CanEdit: false),
         new("provide-additional-documents", "appraisal.summary",        IsVisible: false, CanEdit: false),
+
+        // Activity: int-pma-input (role: IntAppraisalStaff)
+        // Internal staff key in PMA property values here. Only the PMA property tab applies —
+        // hide the normal Property Information + block variants so the PMA tab takes over.
+        new("int-pma-input", "appraisal.property",       IsVisible: false, CanEdit: false),
+        new("int-pma-input", "appraisal.block-condo",    IsVisible: false, CanEdit: false),
+        new("int-pma-input", "appraisal.block-village",  IsVisible: false, CanEdit: false),
+
+        // Property Information (PMA) is granted ONLY to IntAppraisalStaff (see AuthDataSeed), so it
+        // would otherwise also appear on that role's other activities. Hide it there so the PMA tab
+        // is exclusive to int-pma-input; every other role never had the permission to begin with.
+        new("int-appraisal-execution",     "appraisal.property-pma", IsVisible: false, CanEdit: false),
+        new("appraisal-book-verification", "appraisal.property-pma", IsVisible: false, CanEdit: false),
     };
 }

--- a/Modules/Auth/Auth/Infrastructure/Seed/AuthDataSeed.cs
+++ b/Modules/Auth/Auth/Infrastructure/Seed/AuthDataSeed.cs
@@ -40,12 +40,16 @@ public class AuthDataSeed(
         await SeedActivityMenuOverridesAsync();
         await SeedAdminRoleAsync();
 
+        // NOTE: APPRAISAL_PROPERTY_PMA_VIEW/EDIT are intentionally NOT in these shared arrays.
+        // The PMA property tab is exclusive to the int-pma-input activity, so its permission is
+        // granted only to IntAppraisalStaff below and hidden on that role's other activities via
+        // ActivityMenuOverrides. Keeping it out of the shared set stops it leaking to every role.
         string[] appraisalSectionViews =
         [
             "APPRAISAL_360_VIEW", "APPRAISAL_REQUEST_VIEW",
             "APPRAISAL_ADMINISTRATION_VIEW", "APPRAISAL_APPOINTMENT_VIEW",
             "APPRAISAL_PROPERTY_VIEW", "APPRAISAL_BLOCK_CONDO_VIEW",
-            "APPRAISAL_BLOCK_VILLAGE_VIEW", "APPRAISAL_PROPERTY_PMA_VIEW",
+            "APPRAISAL_BLOCK_VILLAGE_VIEW",
             "APPRAISAL_DOCUMENTS_VIEW", "APPRAISAL_SUMMARY_VIEW"
         ];
         string[] appraisalSectionEdits =
@@ -53,7 +57,7 @@ public class AuthDataSeed(
             "APPRAISAL_REQUEST_EDIT",
             "APPRAISAL_ADMINISTRATION_EDIT", "APPRAISAL_APPOINTMENT_EDIT",
             "APPRAISAL_PROPERTY_EDIT", "APPRAISAL_BLOCK_CONDO_EDIT",
-            "APPRAISAL_BLOCK_VILLAGE_EDIT", "APPRAISAL_PROPERTY_PMA_EDIT",
+            "APPRAISAL_BLOCK_VILLAGE_EDIT",
             "APPRAISAL_DOCUMENTS_EDIT", "APPRAISAL_SUMMARY_EDIT"
         ];
 
@@ -87,7 +91,8 @@ public class AuthDataSeed(
             [
                 "DASHBOARD_VIEW", "REQUEST_VIEW", "APPRAISAL_VIEW", "TASK_LIST_VIEW",
                 "TASK_EXT_APPR_ASSIGNMENT", "USER_MANAGE",
-                "TASK_MONITOR_VIEW", "TASK_MONITOR_REASSIGN",
+                // Company-scoped: external admins may only see/reassign tasks within their own company.
+                "TASK_MONITOR_VIEW:TEAM", "TASK_MONITOR_REASSIGN:TEAM",
                 "QUOTATION_EXT_VIEW", "TASK_QUOTATION_SUBMIT", "TASK_QUOTATION_NEGOTIATE",
                 "INVOICE_EXT_VIEW", "INVOICE_CREATE",
                 ..appraisalSectionViews
@@ -114,11 +119,15 @@ public class AuthDataSeed(
             "Bank",
             [
                 "DASHBOARD_VIEW", "APPRAISAL_VIEW", "APPRAISAL_EDIT", "TASK_LIST_VIEW",
-                "TASK_APPR_BOOK_VERIFICATION", "TASK_INT_APPR_EXECUTION", "STANDALONE_USE",
+                "TASK_APPR_BOOK_VERIFICATION", "TASK_INT_APPR_EXECUTION", "TASK_INT_PMA_INPUT",
+                "STANDALONE_USE",
                 "HISTORY_SEARCH_VIEW",
                 "SUPPORTING_DATA_MAINT_EDIT",
                 "SUPPORTING_DATA_MAINT_VIEW",
                 "SUPPORTING_DATA_MAINT_REMOVE",
+                // PMA property tab — granted here only (kept out of the shared arrays) so it appears
+                // exclusively on the int-pma-input activity, hidden on this role's other activities.
+                "APPRAISAL_PROPERTY_PMA_VIEW", "APPRAISAL_PROPERTY_PMA_EDIT",
                 ..appraisalSectionViews, ..appraisalSectionEdits
             ]);
         await SeedRoleWithPermissionsAsync(IntAppraisalCheckerRoleName,
@@ -553,6 +562,8 @@ public class AuthDataSeed(
             ("TASK_LIST_VIEW", "View Task List", "View and manage assigned tasks", "Workflow"),
             ("TASK_MONITOR_VIEW", "View Task Monitor", "View the supervisor task-monitor list of pending tasks held by monitored groups", "Workflow"),
             ("TASK_MONITOR_REASSIGN", "Reassign Pending Task", "Reassign a pending task to another eligible assignee without resetting the SLA clock", "Workflow"),
+            ("TASK_MONITOR_VIEW:TEAM", "View Task Monitor — own team/company only", "View the task-monitor list confined to the user's own team (internal) or company (external)", "Workflow"),
+            ("TASK_MONITOR_REASSIGN:TEAM", "Reassign Pending Task — own team/company only", "Reassign pending tasks only within the user's own team (internal) or company (external)", "Workflow"),
             ("APPRAISAL_VIEW", "View Appraisal", "View appraisal requests and details", "Appraisal"),
             ("APPRAISAL_CREATE", "Create Appraisal", "Create new appraisal requests", "Appraisal"),
             ("APPRAISAL_EDIT", "Edit Appraisal", "Edit existing appraisal requests", "Appraisal"),
@@ -634,6 +645,8 @@ public class AuthDataSeed(
                 "Workflow"),
             ("TASK_INT_APPR_VERIFICATION", "Task: Internal Appraisal Verification",
                 "Access internal appraisal verification tasks", "Workflow"),
+            ("TASK_INT_PMA_INPUT", "Task: Internal PMA Property Input",
+                "Access internal PMA property input tasks (int-pma-input)", "Workflow"),
             ("TASK_PENDING_APPROVAL", "Task: Pending Approval", "Access pending approval tasks", "Workflow"),
             ("TASK_PROVIDE_ADDITIONAL_DOCS", "Task: Provide Additional Documents",
                 "Access document followup tasks raised by checkers", "Workflow"),
@@ -825,6 +838,23 @@ public class AuthDataSeed(
                 viewPermissionCode: null,
                 editPermissionCode: monitoring.EditPermissionCode,
                 viewPermissionPrefix: "MONITORING:");
+        }
+
+        // One-off repair: `main.task.int-pma-input` was first seeded mid-list (grouped with the
+        // internal-appraisal tasks) and so rendered above "All Tasks". The INSERT-ONLY UpsertTree
+        // above won't move an already-persisted row, so pin its SortOrder to 15 — just after
+        // "All Tasks" (10) and before the rest. Idempotent: a no-op once normalised.
+        if (existingByKey.TryGetValue("main.task.int-pma-input", out var pmaInput)
+            && pmaInput.SortOrder != 15)
+        {
+            pmaInput.Update(
+                pmaInput.Path,
+                pmaInput.Icon,
+                pmaInput.IconColor,
+                sortOrder: 15,
+                pmaInput.ViewPermissionCode,
+                pmaInput.EditPermissionCode,
+                pmaInput.ViewPermissionPrefix);
         }
 
         await dbContext.SaveChangesAsync();

--- a/Modules/Auth/Auth/Infrastructure/Seed/MenuSeedData.cs
+++ b/Modules/Auth/Auth/Infrastructure/Seed/MenuSeedData.cs
@@ -36,6 +36,7 @@ public static class MenuSeedData
             new List<MenuSeedNode>
             {
                 new("main.task.all", "All Tasks", "list", IconStyle.Solid, "text-purple-500", "/tasks", "TASK_LIST_VIEW", null),
+                new("main.task.int-pma-input", "PMA Property Input", "keyboard", IconStyle.Solid, "text-purple-500", "/tasks?activityId=int-pma-input", "TASK_INT_PMA_INPUT", null),
                 new("main.task.appraisal-initiation-check", "Appraisal Initiation Check", "clipboard-check", IconStyle.Solid, "text-purple-500", "/tasks?activityId=appraisal-initiation-check", "TASK_APPR_INITIATION_CHECK", null),
                 new("main.task.appraisal-initiation", "Appraisal Initiation", "file-pen", IconStyle.Solid, "text-purple-500", "/tasks?activityId=appraisal-initiation", "TASK_APPR_INITIATION", null),
                 new("main.task.appraisal-assignment", "Appraisal Assignment", "building", IconStyle.Solid, "text-purple-500", "/tasks?activityId=appraisal-assignment", "TASK_APPR_ASSIGNMENT", null),
@@ -56,7 +57,10 @@ public static class MenuSeedData
                 new("main.task.admin-finalize", "Finalize Quotation", "circle-check", IconStyle.Solid, "text-purple-500", "/tasks?activityId=admin-finalize", "TASK_QUOTATION_FINALIZE", null),
                 new("main.task.fee-appointment-approval", "Fee & Appointment Approval", "check-to-slot", IconStyle.Solid, "text-purple-500", "/tasks?activityId=fee-appointment-approval", "TASK_FEE_APPOINTMENT_APPROVAL", null),
             }),
-        new("main.task-monitor", "Task Monitor", "user-gear", IconStyle.Solid, "text-orange-500", "/task-monitor", "TASK_MONITOR_VIEW", "TASK_MONITOR_REASSIGN"),
+        // View gate is prefix-based so the :TEAM scope variant (TASK_MONITOR_VIEW:TEAM) also
+        // reveals the menu; base and :TEAM both start with "TASK_MONITOR_VIEW".
+        new("main.task-monitor", "Task Monitor", "user-gear", IconStyle.Solid, "text-orange-500", "/task-monitor", null, "TASK_MONITOR_REASSIGN",
+            ViewPermissionPrefix: "TASK_MONITOR_VIEW"),
         // Single tabbed Monitoring page — all 6 sections in one screen.
         // Visible to any user holding any MONITORING:* permission. Tabs are hidden client-side
         // based on the user's section-level permissions.


### PR DESCRIPTION
## What
Scopes the **Property Information (PMA)** tab to the `int-pma-input` workflow activity (internal PMA property input), instead of the appraisal-wide `isPma` flag. On every other activity the **normal** Property Information tab shows.

## Changes
- **New `TASK_INT_PMA_INPUT` permission** + `main.task.int-pma-input` task menu item (adds *PMA Property Input* to the activity catalog / task menu, pinned just below "All Tasks").
- **Narrow `APPRAISAL_PROPERTY_PMA_VIEW/EDIT`** — removed from the shared `appraisalSectionViews/Edits`; granted only to `IntAppraisalStaff`.
- **ActivityMenuOverrides** — `int-pma-input` hides normal Property + block variants; `int-appraisal-execution` + `appraisal-book-verification` hide the PMA tab.
- **Maintenance SQL** (`RestrictPmaPropertyPermissionToIntAppraisalStaff.sql`) revokes the previously-broad PMA grant on existing DBs (role-perm seed is add-only).

## Notes
- No schema/migration change — seed data only.
- `AuthDataSeed.cs` / `MenuSeedData.cs` also include a few incidental `:TEAM`-scope seed lines from a concurrent feature (included whole-file by request) — heads-up for the `:TEAM` PR owner.
- Pairs with the frontend PR (`appraisal/pma-property-tab` on the app repo): PMA form redesign, PMA-mode page trims, and the read-only fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)