### PR TITLE
feat(quotation): listing search, multi-select status, sorting, customer column

### DIFF
--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetMyInvitations/GetMyInvitationsEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetMyInvitations/GetMyInvitationsEndpoint.cs
@@ -8,15 +8,19 @@ public class GetMyInvitationsEndpoint : ICarterModule
                 "/quotations/my-invitations",
                 async (
                     [AsParameters] PaginationRequest request,
-                    string? status,
-                    string? search,
+                    string[]? statuses,
+                    string? quotationNo,
+                    string? appraisalNo,
+                    string? customerName,
                     DateOnly? cutOffTimeFrom,
                     DateOnly? cutOffTimeTo,
+                    string? sortBy,
+                    string? sortDir,
                     ISender sender,
                     CancellationToken cancellationToken
                 ) =>
                 {
-                    var query = new GetMyInvitationsQuery(request, status, search, cutOffTimeFrom, cutOffTimeTo);
+                    var query = new GetMyInvitationsQuery(request, statuses, quotationNo, appraisalNo, customerName, cutOffTimeFrom, cutOffTimeTo, sortBy, sortDir);
 
                     var result = await sender.Send(query, cancellationToken);
 

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetMyInvitations/GetMyInvitationsQuery.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetMyInvitations/GetMyInvitationsQuery.cs
@@ -2,7 +2,11 @@ namespace Appraisal.Application.Features.Quotations.GetMyInvitations;
 
 public record GetMyInvitationsQuery(
     PaginationRequest PaginationRequest,
-    string? Status = null,
-    string? Search = null,
+    string[]? Statuses = null,
+    string? QuotationNo = null,
+    string? AppraisalNo = null,
+    string? CustomerName = null,
     DateOnly? CutOffTimeFrom = null,
-    DateOnly? CutOffTimeTo = null) : IQuery<GetMyInvitationsResult>;
+    DateOnly? CutOffTimeTo = null,
+    string? SortBy = null,
+    string? SortDir = null) : IQuery<GetMyInvitationsResult>;

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetMyInvitations/GetMyInvitationsQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetMyInvitations/GetMyInvitationsQueryHandler.cs
@@ -16,12 +16,28 @@ public class GetMyInvitationsQueryHandler(
     ICurrentUserService currentUser
 ) : IQueryHandler<GetMyInvitationsQuery, GetMyInvitationsResult>
 {
-    // Explicit column list matches MyInvitationDto positional record constructor exactly.
-    // CompanyId is used for scoping only — it is still selected so Dapper maps the DTO.
+    // Explicit column list matches MyInvitationDto. CompanyId is used for scoping only.
+    // Customer columns come from the CustomerApply join below.
     private const string SelectColumns = """
         SELECT v.Id, v.QuotationNumber, v.RequestDate, v.CutOffTime, v.RequestedBy,
                v.TotalAppraisals, v.CompanyId, v.ReceivedAt, v.TotalFeeAmount,
-               v.QuotedAt, v.QuotedBy, v.CompanyStatus, v.HasSubmitted
+               v.QuotedAt, v.QuotedBy, v.CompanyStatus, v.HasSubmitted,
+               cust.CustomerName, cust.CustomerCount, cust.CustomerNames
+        """;
+
+    // Distinct customer names for the RFQ, via QuotationRequestAppraisals → Appraisals →
+    // RequestCustomers (correlated on v.Id — the same chain the customer search filter uses).
+    // Representative name = MIN; count + ordered full list drive the "+N" indicator and tooltip.
+    private const string CustomerApply = """
+        OUTER APPLY (
+            SELECT CustomerName = MIN(x.Name), CustomerCount = COUNT(*),
+                   CustomerNames = STRING_AGG(x.Name, ', ') WITHIN GROUP (ORDER BY x.Name)
+            FROM (SELECT DISTINCT rc.Name
+                  FROM appraisal.QuotationRequestAppraisals qra
+                  JOIN appraisal.Appraisals a ON a.Id = qra.AppraisalId
+                  JOIN request.RequestCustomers rc ON rc.RequestId = a.RequestId
+                  WHERE qra.QuotationRequestId = v.Id) x
+        ) cust
         """;
 
     public async Task<GetMyInvitationsResult> Handle(
@@ -35,20 +51,51 @@ public class GetMyInvitationsQueryHandler(
         var dynamicParams = new DynamicParameters();
         dynamicParams.Add("CompanyId", companyId.Value);
 
-        var sql = $"{SelectColumns} FROM appraisal.vw_MyCompanyInvitationList v WHERE v.CompanyId = @CompanyId";
+        var sql = $"{SelectColumns} FROM appraisal.vw_MyCompanyInvitationList v {CustomerApply} WHERE v.CompanyId = @CompanyId";
 
-        // Optional filter: CompanyStatus
-        if (!string.IsNullOrWhiteSpace(query.Status))
+        // Optional filter: CompanyStatus (multi-select → IN list; Dapper expands the array)
+        if (query.Statuses is { Length: > 0 })
         {
-            sql += " AND v.CompanyStatus = @Status";
-            dynamicParams.Add("Status", query.Status.Trim());
+            sql += " AND v.CompanyStatus IN @Statuses";
+            dynamicParams.Add("Statuses", query.Statuses);
         }
 
-        // Optional filter: free-text search across QuotationNumber and RequestedBy
-        if (!string.IsNullOrWhiteSpace(query.Search))
+        // Optional per-field search. Each field is an INDEPENDENT predicate AND-ed onto the
+        // query, so combining them NARROWS the result set. Each is a contains match ("%term%").
+        // Mirrors GetQuotationsQueryHandler so both quotation listings expose the same fields.
+        // v.Id is the QuotationRequest id, so appraisal/customer are reached via the same joins
+        // the internal listing uses (QuotationRequestAppraisals → Appraisals → RequestCustomers).
+        if (!string.IsNullOrWhiteSpace(query.QuotationNo))
         {
-            sql += " AND (v.QuotationNumber LIKE @SearchPattern OR v.RequestedBy LIKE @SearchPattern)";
-            dynamicParams.Add("SearchPattern", "%" + query.Search.Trim() + "%");
+            sql += " AND v.QuotationNumber LIKE @QuotationNoPattern";
+            dynamicParams.Add("QuotationNoPattern", BuildLikePattern(query.QuotationNo));
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.AppraisalNo))
+        {
+            sql += """
+                 AND EXISTS (
+                     SELECT 1 FROM appraisal.QuotationRequestAppraisals qra
+                     JOIN appraisal.Appraisals a ON a.Id = qra.AppraisalId
+                     WHERE qra.QuotationRequestId = v.Id
+                       AND a.AppraisalNumber LIKE @AppraisalNoPattern
+                 )
+                """;
+            dynamicParams.Add("AppraisalNoPattern", BuildLikePattern(query.AppraisalNo));
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.CustomerName))
+        {
+            sql += """
+                 AND EXISTS (
+                     SELECT 1 FROM appraisal.QuotationRequestAppraisals qra
+                     JOIN appraisal.Appraisals a ON a.Id = qra.AppraisalId
+                     JOIN request.RequestCustomers rc ON rc.RequestId = a.RequestId
+                     WHERE qra.QuotationRequestId = v.Id
+                       AND rc.Name LIKE @CustomerNamePattern
+                 )
+                """;
+            dynamicParams.Add("CustomerNamePattern", BuildLikePattern(query.CustomerName));
         }
 
         // Optional filter: CutOffTime range — convert DateOnly → DateTime (Dapper rejects DateOnly)
@@ -66,13 +113,41 @@ public class GetMyInvitationsQueryHandler(
 
         var result = await connectionFactory.QueryPaginatedAsync<MyInvitationDto>(
             sql,
-            "RequestDate DESC",
+            BuildOrderBy(query.SortBy, query.SortDir),
             query.PaginationRequest,
             dynamicParams);
 
         return new GetMyInvitationsResult(result);
     }
 
+    // Whitelist of user-sortable columns → real view columns. Only these literal strings ever
+    // reach the ORDER BY, so user input can never inject. Keys are what the frontend sends.
+    private static readonly Dictionary<string, string> AllowedSortColumns = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["QuotationNumber"] = "QuotationNumber",
+        ["CompanyStatus"] = "CompanyStatus",
+        ["TotalAppraisals"] = "TotalAppraisals",
+        ["TotalFeeAmount"] = "TotalFeeAmount",
+        ["ReceivedAt"] = "ReceivedAt",
+        ["CutOffTime"] = "CutOffTime",
+        ["QuotedAt"] = "QuotedAt",
+        ["CustomerName"] = "cust.CustomerName",
+    };
+
+    // Default RequestDate DESC; Id is a stable tiebreaker (never a sort key → no duplicate-column trap).
+    private static string BuildOrderBy(string? sortBy, string? sortDir)
+    {
+        var column = AllowedSortColumns.TryGetValue(sortBy ?? "", out var col) ? col : "RequestDate";
+        var direction = string.Equals(sortDir, "asc", StringComparison.OrdinalIgnoreCase) ? "ASC" : "DESC";
+        return $"{column} {direction}, Id DESC";
+    }
+
     private static GetMyInvitationsResult EmptyResult(PaginationRequest request) =>
         new(new PaginatedResult<MyInvitationDto>([], 0, request.PageNumber, request.PageSize));
+
+    // Contains match ("%term%") — matches anywhere in the field. On these listings this is
+    // cheap: quotation number is a tiny table, and appraisal/customer ride a correlated EXISTS
+    // driven from the small quotation set, so it never scans the large Appraisals /
+    // RequestCustomers tables directly.
+    private static string BuildLikePattern(string term) => $"%{term.Trim()}%";
 }

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetMyInvitations/GetMyInvitationsResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetMyInvitations/GetMyInvitationsResult.cs
@@ -15,4 +15,7 @@ public record MyInvitationDto(
     DateTime? QuotedAt,
     string? QuotedBy,
     string CompanyStatus,
-    bool HasSubmitted);
+    bool HasSubmitted,
+    string? CustomerName,
+    int CustomerCount,
+    string? CustomerNames);

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotations/GetQuotationsEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotations/GetQuotationsEndpoint.cs
@@ -9,16 +9,20 @@ public class GetQuotationsEndpoint : ICarterModule
                 async (
                     [AsParameters] PaginationRequest request,
                     Guid? appraisalId,
-                    string? status,
-                    string? search,
+                    string[]? statuses,
+                    string? quotationNo,
+                    string? appraisalNo,
+                    string? customerName,
                     DateOnly? cutOffTimeFrom,
                     DateOnly? cutOffTimeTo,
                     Guid? companyId,
+                    string? sortBy,
+                    string? sortDir,
                     ISender sender,
                     CancellationToken cancellationToken
                 ) =>
                 {
-                    var query = new GetQuotationsQuery(request, appraisalId, status, search, cutOffTimeFrom, cutOffTimeTo, companyId);
+                    var query = new GetQuotationsQuery(request, appraisalId, statuses, quotationNo, appraisalNo, customerName, cutOffTimeFrom, cutOffTimeTo, companyId, sortBy, sortDir);
 
                     var result = await sender.Send(query, cancellationToken);
 

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotations/GetQuotationsQuery.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotations/GetQuotationsQuery.cs
@@ -3,8 +3,12 @@ namespace Appraisal.Application.Features.Quotations.GetQuotations;
 public record GetQuotationsQuery(
     PaginationRequest PaginationRequest,
     Guid? AppraisalId = null,
-    string? Status = null,
-    string? Search = null,
+    string[]? Statuses = null,
+    string? QuotationNo = null,
+    string? AppraisalNo = null,
+    string? CustomerName = null,
     DateOnly? CutOffTimeFrom = null,
     DateOnly? CutOffTimeTo = null,
-    Guid? CompanyId = null) : IQuery<GetQuotationsResult>;
+    Guid? CompanyId = null,
+    string? SortBy = null,
+    string? SortDir = null) : IQuery<GetQuotationsResult>;

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotations/GetQuotationsQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotations/GetQuotationsQueryHandler.cs
@@ -20,11 +20,27 @@ public class GetQuotationsQueryHandler(
     IPoolTaskClauseService poolTaskClauseService
 ) : IQueryHandler<GetQuotationsQuery, GetQuotationsResult>
 {
-    // Explicit column list matches the QuotationDto positional record constructor exactly.
-    // RmUserId and AppraisalId are used for filtering only — not selected into the DTO.
+    // Explicit column list matches the QuotationDto record. RmUserId/AppraisalId are used for
+    // filtering only. Customer columns come from the CustomerApply join below.
     private const string SelectColumns = """
         SELECT q.Id, q.QuotationNumber, q.RequestDate, q.CutOffTime, q.Status, q.RequestedBy,
-               q.TotalAppraisals, q.TotalCompaniesInvited, q.TotalQuotationsReceived
+               q.TotalAppraisals, q.TotalCompaniesInvited, q.TotalQuotationsReceived,
+               cust.CustomerName, cust.CustomerCount, cust.CustomerNames
+        """;
+
+    // Distinct customer names for the quotation, via QuotationRequestAppraisals → Appraisals →
+    // RequestCustomers (correlated on q.Id — the same chain the customer search filter uses).
+    // Representative name = MIN; count + ordered full list drive the "+N" indicator and tooltip.
+    private const string CustomerApply = """
+        OUTER APPLY (
+            SELECT CustomerName = MIN(x.Name), CustomerCount = COUNT(*),
+                   CustomerNames = STRING_AGG(x.Name, ', ') WITHIN GROUP (ORDER BY x.Name)
+            FROM (SELECT DISTINCT rc.Name
+                  FROM appraisal.QuotationRequestAppraisals qra
+                  JOIN appraisal.Appraisals a ON a.Id = qra.AppraisalId
+                  JOIN request.RequestCustomers rc ON rc.RequestId = a.RequestId
+                  WHERE qra.QuotationRequestId = q.Id) x
+        ) cust
         """;
 
     // PoolTaskAccess.BuildSqlClause references AssigneeUserId / AssigneeCompanyId column names.
@@ -45,7 +61,7 @@ public class GetQuotationsQueryHandler(
 
         if (currentUser.IsInRole("Admin") || currentUser.IsInRole("IntAdmin"))
         {
-            sql = $"{SelectColumns} FROM appraisal.vw_QuotationList q WHERE 1 = 1";
+            sql = $"{SelectColumns} FROM appraisal.vw_QuotationList q {CustomerApply} WHERE 1 = 1";
         }
         else
         {
@@ -61,6 +77,7 @@ public class GetQuotationsQueryHandler(
             // rm-pick-winner rows (type '1') and claimed-task rows (type '1') for RM callers.
             sql = $$"""
                 {{SelectColumns}} FROM appraisal.vw_QuotationList q
+                {{CustomerApply}}
                 WHERE EXISTS (
                     SELECT 1 FROM {{PendingTasksSubquery}} pt
                     WHERE pt.CorrelationId = q.Id
@@ -88,45 +105,48 @@ public class GetQuotationsQueryHandler(
             dynamicParams.Add("AppraisalId", query.AppraisalId.Value);
         }
 
-        // Optional filter: Status
-        if (!string.IsNullOrWhiteSpace(query.Status))
+        // Optional filter: Status (multi-select → IN list; Dapper expands the array)
+        if (query.Statuses is { Length: > 0 })
         {
-            sql += " AND q.Status = @Status";
-            dynamicParams.Add("Status", query.Status.Trim());
+            sql += " AND q.Status IN @Statuses";
+            dynamicParams.Add("Statuses", query.Statuses);
         }
 
-        // Optional free-text search: matches quotation number, linked appraisal number,
-        // or customer name (via the appraisal → request chain). Appraisal/customer are
-        // OR-ed in as EXISTS subqueries so the outer statement stays wrappable for COUNT.
-        //
-        // Performance: all three columns (QuotationNumber, Appraisals.AppraisalNumber,
-        // RequestCustomers.Name) have indexes tuned for a PREFIX seek. So the default is a
-        // prefix match ("term%") which seeks the index. A leading-wildcard contains-search
-        // scans every row, so it is opt-in: the user types '*' wherever they want a wildcard
-        // (e.g. "*abc" → "%abc", "ab*cd" → "ab%cd", "*abc*" → "%abc%").
-        if (!string.IsNullOrWhiteSpace(query.Search))
+        // Optional per-field search. Each field is an INDEPENDENT predicate AND-ed onto the
+        // query, so combining fields NARROWS the result set (e.g. quotation-no AND customer).
+        // Splitting them (vs one OR-ed omnibox) keeps each predicate on a single column.
+        // Each is a contains match ("%term%") — see BuildLikePattern for why that is cheap here.
+        if (!string.IsNullOrWhiteSpace(query.QuotationNo))
+        {
+            sql += " AND q.QuotationNumber LIKE @QuotationNoPattern";
+            dynamicParams.Add("QuotationNoPattern", BuildLikePattern(query.QuotationNo));
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.AppraisalNo))
         {
             sql += """
-                 AND (
-                     q.QuotationNumber LIKE @SearchPattern
-                     OR EXISTS (
-                         SELECT 1 FROM appraisal.QuotationRequestAppraisals qra
-                         JOIN appraisal.Appraisals a ON a.Id = qra.AppraisalId
-                         WHERE qra.QuotationRequestId = q.Id
-                           AND a.AppraisalNumber LIKE @SearchPattern
-                     )
-                     OR EXISTS (
-                         SELECT 1 FROM appraisal.QuotationRequestAppraisals qra
-                         JOIN appraisal.Appraisals a ON a.Id = qra.AppraisalId
-                         JOIN request.RequestCustomers rc ON rc.RequestId = a.RequestId
-                         WHERE qra.QuotationRequestId = q.Id
-                           AND rc.Name LIKE @SearchPattern
-                     )
+                 AND EXISTS (
+                     SELECT 1 FROM appraisal.QuotationRequestAppraisals qra
+                     JOIN appraisal.Appraisals a ON a.Id = qra.AppraisalId
+                     WHERE qra.QuotationRequestId = q.Id
+                       AND a.AppraisalNumber LIKE @AppraisalNoPattern
                  )
                 """;
-            var term = query.Search.Trim();
-            var pattern = term.Contains('*') ? term.Replace('*', '%') : term + "%";
-            dynamicParams.Add("SearchPattern", pattern);
+            dynamicParams.Add("AppraisalNoPattern", BuildLikePattern(query.AppraisalNo));
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.CustomerName))
+        {
+            sql += """
+                 AND EXISTS (
+                     SELECT 1 FROM appraisal.QuotationRequestAppraisals qra
+                     JOIN appraisal.Appraisals a ON a.Id = qra.AppraisalId
+                     JOIN request.RequestCustomers rc ON rc.RequestId = a.RequestId
+                     WHERE qra.QuotationRequestId = q.Id
+                       AND rc.Name LIKE @CustomerNamePattern
+                 )
+                """;
+            dynamicParams.Add("CustomerNamePattern", BuildLikePattern(query.CustomerName));
         }
 
         // Optional filter: CutOffTime range — convert DateOnly → DateTime (Dapper rejects DateOnly)
@@ -157,13 +177,39 @@ public class GetQuotationsQueryHandler(
 
         var result = await connectionFactory.QueryPaginatedAsync<QuotationDto>(
             sql,
-            "RequestDate DESC",
+            BuildOrderBy(query.SortBy, query.SortDir),
             query.PaginationRequest,
             dynamicParams);
 
         return new GetQuotationsResult(result);
     }
 
+    // Whitelist of user-sortable columns → real view columns. Only these literal strings ever
+    // reach the ORDER BY, so user input can never inject. Keys are what the frontend sends.
+    private static readonly Dictionary<string, string> AllowedSortColumns = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["QuotationNumber"] = "QuotationNumber",
+        ["Status"] = "Status",
+        ["CutOffTime"] = "CutOffTime",
+        ["TotalAppraisals"] = "TotalAppraisals",
+        ["RequestDate"] = "RequestDate",
+        ["CustomerName"] = "cust.CustomerName",
+    };
+
+    // Default RequestDate DESC; Id is a stable tiebreaker (never a sort key → no duplicate-column trap).
+    private static string BuildOrderBy(string? sortBy, string? sortDir)
+    {
+        var column = AllowedSortColumns.TryGetValue(sortBy ?? "", out var col) ? col : "RequestDate";
+        var direction = string.Equals(sortDir, "asc", StringComparison.OrdinalIgnoreCase) ? "ASC" : "DESC";
+        return $"{column} {direction}, Id DESC";
+    }
+
     private static GetQuotationsResult EmptyResult(PaginationRequest request) =>
         new(new PaginatedResult<QuotationDto>([], 0, request.PageNumber, request.PageSize));
+
+    // Contains match ("%term%") — matches anywhere in the field. On these listings this is
+    // cheap: quotation number is a tiny table, and appraisal/customer ride a correlated EXISTS
+    // driven from the small quotation set, so it never scans the large Appraisals /
+    // RequestCustomers tables directly.
+    private static string BuildLikePattern(string term) => $"%{term.Trim()}%";
 }

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotations/GetQuotationsResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotations/GetQuotationsResult.cs
@@ -11,4 +11,7 @@ public record QuotationDto(
     string RequestedBy,
     int TotalAppraisals,
     int TotalCompaniesInvited,
-    int TotalQuotationsReceived);
+    int TotalQuotationsReceived,
+    string? CustomerName,
+    int CustomerCount,
+    string? CustomerNames);


### PR DESCRIPTION
Enhances **both** quotation listings — internal `/quotations` and external vendor `/quotations/my-invitations`.

## Changes
1. **Search redesign** — per-field search params (`QuotationNo` / `AppraisalNo` / `CustomerName`), each a contains match (`%term%`). The single omnibox is replaced by a "search by" field selector on the frontend; only the selected field is sent.
2. **Status filter → multi-select** — `status` (single) becomes `Statuses` (`string[]`) with a Dapper `IN` expansion; repeated query params (`?Statuses=A&Statuses=B`).
3. **Sortable columns** — `SortBy`/`SortDir` mapped through a per-handler **whitelist** (injection-safe) with an `Id` tiebreaker for stable pagination.
4. **Customer Name column** — inline `OUTER APPLY` deriving a representative name (`MIN`), a distinct count, and a `STRING_AGG` full list, via the existing `QuotationRequestAppraisals → Appraisals → RequestCustomers` chain. **No SQL view change or DB migration.**

## Scope
- 8 files, all under `Modules/Appraisal/.../Features/Quotations/` (GetQuotations + GetMyInvitations).

## Verification
- `dotnet build` green.
- The derived customer `OUTER APPLY`, `IN` status filter, and `ORDER BY` variants (incl. computed external columns + `Id` tiebreaker) were run directly against the live DB — all execute cleanly.

## Notes
- Pairs with the frontend PR (same branch name) in `collateral-appraisal-system-app`. **Merge/deploy backend first** — the frontend sends the new params and reads the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199jW8oipg3BF6o8f2thhM6