### PR TITLE
fix(workflow): make appraisal-value tiering deliverable (bind consumer queue + null-safe switch)

### DIFF
--- a/Modules/Workflow/Workflow/Workflow/Activities/SwitchActivity.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/SwitchActivity.cs
@@ -190,10 +190,14 @@ public class SwitchActivity : WorkflowActivityBase
                 // Build a comparison expression: expressionResult [operator] [value]
                 var comparisonExpression = $"expressionValue {caseCondition}";
                 
-                // Create temporary variables for evaluation
+                // Create temporary variables for evaluation.
+                // Missing/null variable → compare as numeric 0 (not the string "null"): for a
+                // numeric threshold switch a missing value then fails safe to the lowest tier
+                // (e.g. missing appraisalValue matches "<= 30000000" → no meeting) instead of
+                // sorting after every number and hitting the first ">" case.
                 var tempVariables = new Dictionary<string, object>(variables)
                 {
-                    ["expressionValue"] = expressionResult ?? "null"
+                    ["expressionValue"] = expressionResult ?? 0m
                 };
 
                 return _expressionEvaluator.EvaluateExpression(comparisonExpression, tempVariables);


### PR DESCRIPTION
Two fixes that make the appraisal-value approval tiering (merged to `main` via the accumulated backend bundle) actually work at runtime.

## 1. Bind the RabbitMQ queue for `AppraisalValueChangedIntegrationEventConsumer` (the real bug)

**Symptom:** `appraisalValue` is completely absent from `WorkflowInstance.Variables` — even for appraisals that already have a computed `ValuationAnalyses.AppraisedValue`.

**Root cause:** the consumer that writes `appraisalValue` into the workflow variables is marked `[ExcludeFromConfigureEndpoints]` (mirroring the appointment consumer) but was never given a matching manual `ReceiveEndpoint` in `Program.cs`. `ConfigureEndpoints(context)` skips excluded consumers, so **no queue was ever bound**. The outbox relay published `AppraisalValueChangedIntegrationEvent` to an exchange with no bound queue → the message was **silently dropped** (the outbox row is still marked `Processed`), so the variable was never written.

Every other stage of the path was verified sound: the domain event fires (`PricingAnalysis : Aggregate<Guid>`), the outbox publish from the pre-save handler commits atomically, the event type resolves for publishing, and the correlation-id lookup matches.

**Fix:** add a partitioned receive endpoint mirroring `workflow-appointment-changed`, partitioned by `AppraisalId` so concurrent pricing recomputes for the same appraisal serialize (an out-of-order older event can't overwrite a newer `appraisalValue`).

## 2. Null-safe `SwitchActivity` comparison (defensive)

If the tier switch evaluates a missing/null variable, it previously coerced it to the string `"null"`, which sorts after every number and always matched the first `>` case — so a missing `appraisalValue` would wrongly route to `> 30000000` (committee meeting). Coerce a missing/null value to numeric `0` instead, so it fails safe to the lowest tier (`<= 30000000` → no meeting). Only the comparison-condition branch is touched; `approval-tier-switch` is the only comparison-style switch in the workflow definitions.

## Notes for reviewers / rollout
- After #1, `appraisalValue` populates on the **next** pricing recompute. An appraisal already past pricing needs a re-save of its Final Appraised Value (or a one-off backfill that republishes the event) to get the variable.
- Separately, the edited `appraisal-workflow.json` still must be published as a new workflow-definition version for the switch to actually read `appraisalValue` (the engine runs the DB-stored schema, not the file).

## Tests
- `SwitchActivity` tests: 30/30 pass. Meeting domain tests: 61/61 pass. `Bootstrapper/Api` builds 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFf4SdmqB2aP3c1uRbbhWV