### PR TITLE
feat(regulatory): Excel writer + file-sink abstraction for AS400 regulatory export

### DIFF
--- a/Database/Scripts/Views/Collateral/vw_RegulatoryExport.sql
+++ b/Database/Scripts/Views/Collateral/vw_RegulatoryExport.sql
@@ -105,6 +105,7 @@ RepresentativeBuilding AS (
 SELECT
     m.Id                                                        AS CollateralMasterId,
     m.CollateralType,
+    m.HostCollateralId,
 
     -- Previous engagement (2nd-most-recent) → "Application Id" field
     prev.PreviousAppraisalNumber,

--- a/Modules/Collateral/Collateral.Contracts/FileInterface/IRegulatoryExportQuery.cs
+++ b/Modules/Collateral/Collateral.Contracts/FileInterface/IRegulatoryExportQuery.cs
@@ -11,13 +11,14 @@ public interface IRegulatoryExportQuery
 
 /// <summary>
 /// One row of the outbound CAS-AS400-Regulatory interface (per active IsMaster collateral master).
-/// Carries typed field values that <c>RegulatoryFileWriter</c> formats into a 308-char Detail record.
+/// Carries typed field values that <c>RegulatoryFileWriter</c> formats into a 300-char Detail record.
 /// Produced by <c>RegulatoryExportQuery</c> via <c>vw_RegulatoryExport</c>.
 /// </summary>
 public sealed record RegulatoryExportRow(
     string? PreviousAppraisalNumber,
     string? LatestAppraisalNumber,
     string CollateralType,
+    string? HostCollateralId,
     string? LatestAppraisalType,
     bool IsUnderConstruction,
     decimal? ConstructionProgressPercent,

--- a/Modules/Collateral/Collateral/CollateralMasters/RegulatoryExport/RegulatoryExportQuery.cs
+++ b/Modules/Collateral/Collateral/CollateralMasters/RegulatoryExport/RegulatoryExportQuery.cs
@@ -19,6 +19,7 @@ public class RegulatoryExportQuery(ISqlConnectionFactory connectionFactory) : IR
         PreviousAppraisalNumber: r.PreviousAppraisalNumber,
         LatestAppraisalNumber: r.LatestAppraisalNumber,
         CollateralType: r.CollateralType,
+        HostCollateralId: r.HostCollateralId,
         LatestAppraisalType: r.LatestAppraisalType,
         IsUnderConstruction: r.IsUnderConstruction,
         ConstructionProgressPercent: r.ConstructionProgressPercent,
@@ -41,6 +42,7 @@ public class RegulatoryExportQuery(ISqlConnectionFactory connectionFactory) : IR
     {
         public Guid CollateralMasterId { get; init; }
         public string CollateralType { get; init; } = null!;
+        public string? HostCollateralId { get; init; }
         public string? PreviousAppraisalNumber { get; init; }
         public string? LatestAppraisalNumber { get; init; }
         public string? LatestAppraisalType { get; init; }

--- a/Modules/Integration/Integration.Contracts/FileSink/IOutboundFileSink.cs
+++ b/Modules/Integration/Integration.Contracts/FileSink/IOutboundFileSink.cs
@@ -15,4 +15,11 @@ public interface IOutboundFileSink
     /// <paramref name="directory"/>, overwriting any existing file with the same name.
     /// </summary>
     Task WriteAsync(string directory, string fileName, string content, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Writes binary <paramref name="content"/> (e.g. an xlsx workbook) to a file named
+    /// <paramref name="fileName"/> in <paramref name="directory"/>, overwriting any existing file
+    /// with the same name.
+    /// </summary>
+    Task WriteAsync(string directory, string fileName, byte[] content, CancellationToken cancellationToken = default);
 }

--- a/Modules/Integration/Integration/FileInterface/Format/RegulatoryExport/RegulatoryExcelWriter.cs
+++ b/Modules/Integration/Integration/FileInterface/Format/RegulatoryExport/RegulatoryExcelWriter.cs
@@ -1,0 +1,195 @@
+using Collateral.Contracts;
+using Collateral.Contracts.FileInterface;
+using ClosedXML.Excel;
+
+namespace Integration.FileInterface.Format.RegulatoryExport;
+
+/// <summary>
+/// Writes a human-readable Excel companion to the CAS-AS400-Regulatory interface file. Same fields and
+/// order as <see cref="RegulatoryFileWriter"/>, but with friendly column headers and values non-IT users
+/// can read: real decimals (not implied-decimal ×100), dd/MM/yyyy dates, and code+description text.
+///
+/// Uses the same <see cref="RegulatoryExportRow"/> data as the fixed-width writer, so the two cannot drift.
+/// </summary>
+public sealed class RegulatoryExcelWriter
+{
+    private const string MoneyFormat = "#,##0.00";
+    private const string PercentFormat = "0.00";
+    private const string DateFormat = "dd/MM/yyyy";
+    private const string ProgressiveAppraisalType = "Progressive";
+
+    // Friendly column headers, in interface-file field order (Record Type is omitted; Collateral Type is
+    // added up front so a reader can tell what each row is).
+    private static readonly string[] Headers =
+    [
+        "Collateral Type",
+        "Previous Appraisal No.",
+        "Latest Appraisal No.",
+        "HOST Collateral ID",
+        "Under Construction",
+        "Construction Progress (%)",
+        "Appraisal Value as Completed",
+        "Appraisal Value at Origination",
+        "Number of Floors",
+        "Building Age (yrs)",
+        "Market Selling Price",
+        "Valuation Date",
+        "Valuation Price (Baht)",
+        "Mortgage Value",
+        "Appraiser Type",
+        "Registration Flag",
+        "Land Ownership Flag",
+        "DOPA Location",
+        "Land Area (Sq.Wa)",
+        "Area Utilization",
+        "Building Type ID",
+        "Building Name",
+        "Expected Completion Date",
+        "Construction Review Date",
+        "First Valuation Date",
+        "Latest Valuation Date",
+    ];
+
+    public byte[] Build(DateOnly effectiveDate, IReadOnlyList<RegulatoryExportRow> rows)
+    {
+        using var workbook = new XLWorkbook();
+        var ws = workbook.Worksheets.Add("Regulatory");
+
+        // Caption echoing the file Header/Trailer (effective date + record count).
+        ws.Cell(1, 1).Value =
+            $"CAS-AS400-Regulatory — Effective {effectiveDate:dd/MM/yyyy} — {rows.Count} record(s)";
+        ws.Range(1, 1, 1, Headers.Length).Merge();
+        ws.Cell(1, 1).Style.Font.Bold = true;
+
+        // Header row.
+        for (var i = 0; i < Headers.Length; i++)
+            ws.Cell(2, i + 1).Value = Headers[i];
+        var headerRow = ws.Row(2);
+        headerRow.Style.Font.Bold = true;
+        headerRow.Style.Fill.BackgroundColor = XLColor.LightGray;
+
+        var r = 3;
+        foreach (var row in rows)
+        {
+            WriteRow(ws, r, row);
+            r++;
+        }
+
+        ws.Columns().AdjustToContents();
+
+        using var ms = new MemoryStream();
+        workbook.SaveAs(ms);
+        return ms.ToArray();
+    }
+
+    private static void WriteRow(IXLWorksheet ws, int r, RegulatoryExportRow row)
+    {
+        var c = 1;
+
+        ws.Cell(r, c++).Value = row.CollateralType;
+        ws.Cell(r, c++).Value = row.PreviousAppraisalNumber ?? "";
+        ws.Cell(r, c++).Value = row.LatestAppraisalNumber ?? "";
+        ws.Cell(r, c++).Value = row.HostCollateralId ?? "";
+        ws.Cell(r, c++).Value = UnderConstructionText(row);
+        Percent(ws.Cell(r, c++), ConstructionProgress(row));
+        Money(ws.Cell(r, c++), row.LatestAppraisalValue);
+        Money(ws.Cell(r, c++), OriginationValue(row));
+        Number(ws.Cell(r, c++), row.NumberOfFloors);
+        Number(ws.Cell(r, c++), row.BuildingAge);
+        c++; // Market Selling Price — not yet sourced
+        Date(ws.Cell(r, c++), row.LatestAppraisalDate);
+        Money(ws.Cell(r, c++), row.LatestAppraisalValue);
+        c++; // Mortgage Value — not yet sourced
+        ws.Cell(r, c++).Value = row.LatestAppraisalCompanyId.HasValue ? "External (1)" : "Internal (2)";
+        c++; // Registration Flag — not yet sourced
+        c++; // Land Ownership Flag — not yet sourced
+        ws.Cell(r, c++).Value = row.DopaCode ?? "";
+        // Collateral-type gating mirrors RegulatoryFileWriter so the .xlsx companion cannot drift
+        // from the fixed-width .txt: Land Area only for land types; Area Utilization for building
+        // types + condo; Building Type ID/Name only for building types.
+        var isLandType = IsLandType(row);
+        var isBuildingType = IsBuildingType(row);
+        var isCondo = IsCondo(row);
+        Money(ws.Cell(r, c++), isLandType ? row.LandAreaSqWa : null);
+        Money(ws.Cell(r, c++), (isBuildingType || isCondo) ? row.BuildingArea : null);
+        ws.Cell(r, c++).Value = isBuildingType ? (row.BuildingTypeCode ?? "") : "";
+        ws.Cell(r, c++).Value = isBuildingType ? (row.BuildingTypeDescription ?? "") : "";
+        c++; // Expected Completion Date — not yet sourced
+        Date(ws.Cell(r, c++), row.LatestProgressiveAppraisalDate);
+        Date(ws.Cell(r, c++), row.EarliestAppraisalDate);
+        Date(ws.Cell(r, c++), row.LatestAppraisalDate);
+    }
+
+    // Collateral-type predicates — bodies match RegulatoryFileWriter exactly so the two writers
+    // gate the same fields identically and cannot drift.
+    private static bool IsLandType(RegulatoryExportRow row) =>
+        row.CollateralType is CollateralTypes.Land
+                           or CollateralTypes.LandWithBuilding
+                           or CollateralTypes.Leasehold
+                           or CollateralTypes.LeaseholdBuilding
+                           or CollateralTypes.LeaseholdWithBuilding;
+
+    private static bool IsBuildingType(RegulatoryExportRow row) =>
+        row.CollateralType is CollateralTypes.LandWithBuilding
+                           or CollateralTypes.LeaseholdBuilding
+                           or CollateralTypes.LeaseholdWithBuilding;
+
+    private static bool IsCondo(RegulatoryExportRow row) =>
+        row.CollateralType == CollateralTypes.Condo;
+
+    private static bool IsBareLand(RegulatoryExportRow row) =>
+        row.CollateralType is CollateralTypes.Land or CollateralTypes.Leasehold;
+
+    // Mirrors RegulatoryFileWriter's Under Construction rule (Y/N/L/blank), rendered as readable text.
+    private static string UnderConstructionText(RegulatoryExportRow row)
+    {
+        if (IsBareLand(row))
+            return "Vacant land (L)";
+        if (IsBuildingType(row) || IsCondo(row))
+            return row.IsUnderConstruction ? "Under construction (Y)" : "Completed (N)";
+        return "";
+    }
+
+    // Mirrors RegulatoryFileWriter's Construction Progress rule.
+    private static decimal? ConstructionProgress(RegulatoryExportRow row)
+    {
+        if (IsBareLand(row))
+            return 100m;
+        if (IsBuildingType(row) || IsCondo(row))
+            return row.ConstructionProgressPercent ?? 0m;
+        return 0m;
+    }
+
+    // Mirrors RegulatoryFileWriter's origination-value rule.
+    private static decimal? OriginationValue(RegulatoryExportRow row) =>
+        string.Equals(row.LatestAppraisalType, ProgressiveAppraisalType, StringComparison.Ordinal)
+            ? row.EarliestAppraisalValue
+            : row.LatestAppraisalValue;
+
+    private static void Money(IXLCell cell, decimal? value)
+    {
+        if (value is null) return;
+        cell.Value = value.Value;
+        cell.Style.NumberFormat.Format = MoneyFormat;
+    }
+
+    private static void Percent(IXLCell cell, decimal? value)
+    {
+        if (value is null) return;
+        cell.Value = value.Value;
+        cell.Style.NumberFormat.Format = PercentFormat;
+    }
+
+    private static void Number(IXLCell cell, int? value)
+    {
+        if (value is null) return;
+        cell.Value = value.Value;
+    }
+
+    private static void Date(IXLCell cell, DateTime? value)
+    {
+        if (value is null) return;
+        cell.Value = value.Value;
+        cell.Style.NumberFormat.Format = DateFormat;
+    }
+}

--- a/Modules/Integration/Integration/FileInterface/Format/RegulatoryExport/RegulatoryFileWriter.cs
+++ b/Modules/Integration/Integration/FileInterface/Format/RegulatoryExport/RegulatoryFileWriter.cs
@@ -126,7 +126,7 @@ public sealed class RegulatoryFileWriter
             ["RecordType"]                 = "D",
             ["ApplicationId"]              = row.PreviousAppraisalNumber,
             ["NewestApplicationId"]        = row.LatestAppraisalNumber,
-            ["CollateralIdHost"]           = null,
+            ["CollateralIdHost"]           = row.HostCollateralId,
             ["UnderConstruction"]          = underConstruction,
             ["ConstructionProgress"]       = constructionProgress,
             ["AppraisalValueCompleted"]    = Money(row.LatestAppraisalValue),

--- a/Modules/Integration/Integration/FileInterface/Jobs/RegulatoryExport/RegulatoryExportJob.cs
+++ b/Modules/Integration/Integration/FileInterface/Jobs/RegulatoryExport/RegulatoryExportJob.cs
@@ -16,6 +16,7 @@ namespace Integration.FileInterface.Jobs.RegulatoryExport;
 public class RegulatoryExportJob(
     IRegulatoryExportQuery query,
     RegulatoryFileWriter writer,
+    RegulatoryExcelWriter excelWriter,
     IOutboundFileSink fileSink,
     IFileInterfaceConfigProvider configProvider,
     IDateTimeProvider dateTimeProvider,
@@ -54,8 +55,14 @@ public class RegulatoryExportJob(
 
         await fileSink.WriteAsync(directory, fileName, content, ct);
 
+        // Human-readable Excel companion (same fields, friendly headers) written next to the .txt so
+        // non-IT users can inspect what was sent that month.
+        var excelFileName = $"{prefix}{now.ToString(dateFormat)}.xlsx";
+        var excelBytes = excelWriter.Build(effectiveDate, rows);
+        await fileSink.WriteAsync(directory, excelFileName, excelBytes, ct);
+
         logger.LogInformation(
-            "{Tag} Exported {Count} record(s) to {File} in {Dir}",
-            JobTag, rows.Count, fileName, directory);
+            "{Tag} Exported {Count} record(s) to {File} (+ {ExcelFile}) in {Dir}",
+            JobTag, rows.Count, fileName, excelFileName, directory);
     }
 }

--- a/Modules/Integration/Integration/Infrastructure/FileSink/LocalFileSink.cs
+++ b/Modules/Integration/Integration/Infrastructure/FileSink/LocalFileSink.cs
@@ -29,4 +29,17 @@ public class LocalFileSink(IHostEnvironment environment, ILogger<LocalFileSink> 
         logger.LogInformation("[OutboundFileSink:Local] Wrote {File} ({Chars} chars) to {Dir}",
             fileName, content.Length, dir);
     }
+
+    public async Task WriteAsync(string directory, string fileName, byte[] content, CancellationToken cancellationToken = default)
+    {
+        var rooted = Path.IsPathRooted(directory) ? directory : Path.Combine(environment.ContentRootPath, directory);
+        var dir = Path.GetFullPath(rooted);
+        Directory.CreateDirectory(dir);
+
+        var fullPath = Path.Combine(dir, Path.GetFileName(fileName));
+        await File.WriteAllBytesAsync(fullPath, content, cancellationToken);
+
+        logger.LogInformation("[OutboundFileSink:Local] Wrote {File} ({Bytes} bytes) to {Dir}",
+            fileName, content.Length, dir);
+    }
 }

--- a/Modules/Integration/Integration/Infrastructure/FileSink/SftpFileSink.cs
+++ b/Modules/Integration/Integration/Infrastructure/FileSink/SftpFileSink.cs
@@ -19,7 +19,13 @@ public class SftpFileSink(
     private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
     private readonly SftpSinkOptions _opts = options.Value.Sftp;
 
-    public async Task WriteAsync(string directory, string fileName, string content, CancellationToken cancellationToken = default)
+    public Task WriteAsync(string directory, string fileName, string content, CancellationToken cancellationToken = default) =>
+        UploadAsync(directory, fileName, Utf8NoBom.GetBytes(content), content.Length + " chars", cancellationToken);
+
+    public Task WriteAsync(string directory, string fileName, byte[] content, CancellationToken cancellationToken = default) =>
+        UploadAsync(directory, fileName, content, content.Length + " bytes", cancellationToken);
+
+    private async Task UploadAsync(string directory, string fileName, byte[] bytes, string sizeDescription, CancellationToken cancellationToken)
     {
         await Task.Run(() =>
         {
@@ -27,7 +33,6 @@ public class SftpFileSink(
             client.Connect();
             try
             {
-                var bytes = Utf8NoBom.GetBytes(content);
                 using var ms = new MemoryStream(bytes);
 
                 EnsureRemoteDirectory(client, directory);
@@ -35,8 +40,8 @@ public class SftpFileSink(
                 var remotePath = $"{directory.TrimEnd('/')}/{Path.GetFileName(fileName)}";
                 client.UploadFile(ms, remotePath, canOverride: true);
 
-                logger.LogInformation("[OutboundFileSink:Sftp] Uploaded {File} ({Chars} chars) → {Path}",
-                    fileName, content.Length, remotePath);
+                logger.LogInformation("[OutboundFileSink:Sftp] Uploaded {File} ({Size}) → {Path}",
+                    fileName, sizeDescription, remotePath);
             }
             finally
             {

--- a/Modules/Integration/Integration/Integration.csproj
+++ b/Modules/Integration/Integration/Integration.csproj
@@ -16,6 +16,8 @@
         <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
         <!-- Explicit: SftpFileSink uses Renci.SshNet directly (don't rely on the transitive ref via Shared). -->
         <PackageReference Include="SSH.NET" />
+        <!-- Explicit: RegulatoryExcelWriter builds the xlsx companion with ClosedXML. -->
+        <PackageReference Include="ClosedXML" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Modules/Integration/Integration/IntegrationModule.cs
+++ b/Modules/Integration/Integration/IntegrationModule.cs
@@ -76,6 +76,7 @@ public static class IntegrationModule
         services.AddScoped<CollatrevTestFileBuilder>();
         services.AddSingleton<CollateralResultFileWriter>();
         services.AddSingleton<RegulatoryFileWriter>();
+        services.AddSingleton<RegulatoryExcelWriter>();
 
         // File interface jobs (moved from Collateral — thin orchestration only).
         services.AddScoped<As400ReappraisalJob>();

--- a/Tests/Unit/Collateral.Tests/RegulatoryExport/RegulatoryExcelWriterTests.cs
+++ b/Tests/Unit/Collateral.Tests/RegulatoryExport/RegulatoryExcelWriterTests.cs
@@ -1,0 +1,113 @@
+using ClosedXML.Excel;
+using Collateral.Contracts;
+using Collateral.Contracts.FileInterface;
+using Integration.FileInterface.Format.RegulatoryExport;
+
+namespace Collateral.Tests.RegulatoryExport;
+
+/// <summary>
+/// Verifies the human-readable Excel companion (<see cref="RegulatoryExcelWriter"/>): a header row, one
+/// data row per master, and friendly decoded values (money as a real decimal, dates as real dates,
+/// coded fields as text) — the opposite of the fixed-width file's implied-decimal encoding.
+/// </summary>
+public class RegulatoryExcelWriterTests
+{
+    private static RegulatoryExportRow SampleRow() => new(
+        PreviousAppraisalNumber: "6800100",
+        LatestAppraisalNumber: "6800123",
+        CollateralType: CollateralTypes.LandWithBuilding,
+        HostCollateralId: "6702522",
+        LatestAppraisalType: "ReAppraisal",
+        IsUnderConstruction: false,
+        ConstructionProgressPercent: null,
+        LatestAppraisalValue: 2_000_000.00m,
+        EarliestAppraisalValue: 1_000_000.00m,
+        NumberOfFloors: 5,
+        BuildingAge: 12,
+        LatestAppraisalDate: new DateTime(2025, 1, 21),
+        LatestProgressiveAppraisalDate: null,
+        EarliestAppraisalDate: new DateTime(2020, 1, 21),
+        LatestAppraisalCompanyId: Guid.NewGuid(),
+        DopaCode: "103004",
+        LandAreaSqWa: 80.00m,
+        BuildingArea: 150.00m,
+        BuildingTypeCode: "01",
+        BuildingTypeDescription: "House");
+
+    private static IXLWorksheet BuildAndOpen(params RegulatoryExportRow[] rows)
+    {
+        var bytes = new RegulatoryExcelWriter().Build(new DateOnly(2025, 1, 31), rows);
+
+        // Valid xlsx = a ZIP archive (starts with the "PK" signature).
+        Assert.Equal((byte)'P', bytes[0]);
+        Assert.Equal((byte)'K', bytes[1]);
+
+        using var ms = new MemoryStream(bytes);
+        var wb = new XLWorkbook(ms);
+        return wb.Worksheet("Regulatory");
+    }
+
+    [Fact]
+    public void HasCaption_AndHeaderRow()
+    {
+        var ws = BuildAndOpen(SampleRow());
+
+        Assert.Contains("Effective 31/01/2025", ws.Cell(1, 1).GetString());
+        Assert.Contains("1 record", ws.Cell(1, 1).GetString());
+
+        // Header row is row 2 (row 1 is the caption).
+        Assert.Equal("Collateral Type", ws.Cell(2, 1).GetString());
+        Assert.Equal("Latest Valuation Date", ws.Cell(2, 26).GetString());
+    }
+
+    [Fact]
+    public void OneDataRowPerMaster()
+    {
+        var ws = BuildAndOpen(SampleRow(), SampleRow());
+
+        // Data starts at row 3 → two rows means the last used row is 4.
+        Assert.Equal(4, ws.LastRowUsed()!.RowNumber());
+    }
+
+    [Fact]
+    public void FriendlyValues_AreDecoded()
+    {
+        var ws = BuildAndOpen(SampleRow());
+
+        // Money is a real decimal, NOT the implied-decimal ×100 the fixed-width file writes.
+        Assert.Equal(2_000_000.00m, ws.Cell(3, 7).GetValue<decimal>());   // Appraisal Value as Completed
+        // Date is a real date cell.
+        Assert.Equal(new DateTime(2025, 1, 21), ws.Cell(3, 12).GetDateTime()); // Valuation Date
+        // Coded fields are readable text.
+        Assert.Equal("External (1)", ws.Cell(3, 15).GetString());          // Appraiser Type
+        Assert.Equal("Completed (N)", ws.Cell(3, 5).GetString());          // Under Construction
+        Assert.Equal("6702522", ws.Cell(3, 4).GetString());               // HOST Collateral ID
+        Assert.Equal("House", ws.Cell(3, 22).GetString());                // Building Name
+    }
+
+    [Fact]
+    public void Condo_GatesFields_LikeFixedWidthWriter()
+    {
+        // Condo mirrors RegulatoryFileWriter: no Land Area, no Building Type ID/Name,
+        // but Area Utilization (BuildingArea) IS populated.
+        var ws = BuildAndOpen(SampleRow() with { CollateralType = CollateralTypes.Condo });
+
+        Assert.True(ws.Cell(3, 19).IsEmpty());                             // Land Area (Sq.Wa) — blank
+        Assert.Equal(150.00m, ws.Cell(3, 20).GetValue<decimal>());        // Area Utilization — populated
+        Assert.Equal("", ws.Cell(3, 21).GetString());                     // Building Type ID — blank
+        Assert.Equal("", ws.Cell(3, 22).GetString());                     // Building Name — blank
+    }
+
+    [Fact]
+    public void BareLand_GatesFields_LikeFixedWidthWriter()
+    {
+        // Bare land mirrors RegulatoryFileWriter: Land Area populated, but no Area Utilization
+        // and no Building Type ID/Name.
+        var ws = BuildAndOpen(SampleRow() with { CollateralType = CollateralTypes.Land });
+
+        Assert.Equal(80.00m, ws.Cell(3, 19).GetValue<decimal>());         // Land Area (Sq.Wa) — populated
+        Assert.True(ws.Cell(3, 20).IsEmpty());                            // Area Utilization — blank
+        Assert.Equal("", ws.Cell(3, 21).GetString());                     // Building Type ID — blank
+        Assert.Equal("", ws.Cell(3, 22).GetString());                     // Building Name — blank
+    }
+}

--- a/Tests/Unit/Collateral.Tests/RegulatoryExport/RegulatoryFileWriterTests.cs
+++ b/Tests/Unit/Collateral.Tests/RegulatoryExport/RegulatoryFileWriterTests.cs
@@ -24,6 +24,7 @@ public class RegulatoryFileWriterTests
         PreviousAppraisalNumber: "6800100",
         LatestAppraisalNumber: "6800123",
         CollateralType: CollateralTypes.LandWithBuilding, // "LB" → building fields populate
+        HostCollateralId: "6702522",
         LatestAppraisalType: "ReAppraisal",
         IsUnderConstruction: false,
         ConstructionProgressPercent: null,
@@ -115,6 +116,25 @@ public class RegulatoryFileWriterTests
 
         // pos 80-82 (index 79..82): age 12 → "012".
         Assert.Equal("012", line[79..82]);
+    }
+
+    [Fact]
+    public void Field4_HostCollateralId_IsZeroFilled_WhenPresent()
+    {
+        var line = new RegulatoryFileWriter().BuildDetail(SampleRow());
+
+        // pos 22-40 (index 21..40), 19-char HOST collateral id, right-aligned zero-filled.
+        Assert.Equal("6702522".PadLeft(19, '0'), line[21..40]);
+    }
+
+    [Fact]
+    public void Field4_HostCollateralId_IsZeros_WhenNull()
+    {
+        // Column is NULL until the inbound host-mapping feed populates it → all zeros.
+        var row = SampleRow() with { HostCollateralId = null };
+        var line = new RegulatoryFileWriter().BuildDetail(row);
+
+        Assert.Equal(new string('0', 19), line[21..40]);
     }
 
     [Fact]

--- a/docs/regulatory/regulatory-field-reference.md
+++ b/docs/regulatory/regulatory-field-reference.md
@@ -1,0 +1,113 @@
+# CAS → AS400 Regulatory Interface — Field Reference
+
+This is the field-by-field reference for the monthly **CAS → AS400 Regulatory** (Basel/RDT) interface
+file. It describes every field of the record: its position, length, type, **where the value comes
+from**, and the **condition** that decides the value. It is written to be readable by non-IT users who
+need to check the data that was sent.
+
+> A human-readable **Excel companion** (`REGULATORY_yyyyMMdd.xlsx`) is produced alongside the interface
+> file each month with these same fields under friendly column headers — open that to inspect the data.
+
+---
+
+## File at a glance
+
+| Property | Value |
+|---|---|
+| Direction | Outbound — CAS → AS400 |
+| Frequency | Monthly (1st of the month, 02:00), full snapshot — **not** incremental |
+| Scope | One **Detail** record per active master collateral (`IsDeleted = 0` and `IsMaster = 1`) |
+| Encoding | UTF-8 (no BOM), CRLF line endings |
+| Record length | **300 characters**, fixed width |
+| File name | `REGULATORY_yyyyMMdd.txt` (date = run date) |
+
+**Record layout:** the file has three record types.
+
+| Type | Marker | Content |
+|---|---|---|
+| Header | `H` | `H` + effective date `ddMMyyyy` (the run date), padded with spaces to 300 |
+| Detail | `D` | One per master collateral — the 26 fields below |
+| Trailer | `T` | `T` + total detail count (9 digits, zero-padded), padded with spaces to 300 |
+
+**Number formatting (important):** money/decimal fields are written as **implied-decimal, no decimal
+point** — the value is multiplied by 100 and left-padded with zeros. Example: `5,000,000.50` is written
+as `500000050`. A blank/absent numeric field is written as all zeros. Dates are `ddMMyyyy`; a blank date
+is spaces. (The Excel companion, by contrast, shows real decimals and `dd/MM/yyyy` dates for readability.)
+
+---
+
+## Detail record — all 26 fields
+
+Positions are 1-based. "Type" is the logical type; on the wire, `decimal(x,2)` fields drop the decimal
+point (×100, zero-filled). "Building types" = Land&Building (LB), Leasehold Building (LSB), Leasehold
+w/ Building (LS). "Land types" = Land (L), LB, Leasehold Land (LSL), LSB, LS.
+
+| # | Pos | Len | Field | Type | Where the value comes from / condition |
+|---|-----|-----|-------|------|----------------------------------------|
+| 1 | 1 | 1 | Record Type | string(1) | Constant `D` (Header `H`, Trailer `T`). |
+| 2 | 2–11 | 10 | Application Id (previous appraisal no.) | string(10) | The **previous** (2nd-most-recent) engagement's appraisal number for the master. Blank if the master has only one appraisal. |
+| 3 | 12–21 | 10 | Newest Application Id (latest appraisal no.) | string(10) | The **latest** engagement's appraisal number. |
+| 4 | 22–40 | 19 | HOST Collateral ID | decimal(19,0) | `CollateralMaster.HostCollateralId`. Populated by the inbound host-mapping feed; **zeros until that feed provides it**. |
+| 5 | 41 | 1 | Collateral Under Construction | string(1) | `Y` / `N` / `L` / blank. **Rule:** not a land/building/condo type → blank; bare Land or Leasehold land → `L`; building types → `Y` if under construction else `N`; Condo → `Y`/`N`. "Under construction" comes from the land detail's *is-under-construction-at-last-appraisal* flag. |
+| 6 | 42–46 | 5 | Construction Progress % | decimal(5,2) | Not land/building/condo → `0.00`; bare Land/Leasehold → `100.00`; otherwise the land detail's overall construction-progress percent (bounded 0–100). |
+| 7 | 47–61 | 15 | Appraisal Value as Completed | decimal(15,2) | The **latest** engagement's appraisal value. |
+| 8 | 62–76 | 15 | Appraisal Value at Origination | decimal(15,2) | If the latest appraisal is a **Progressive** (construction) inspection → the **earliest** engagement's value (the first appraisal already estimated the as-completed value); otherwise the latest value. |
+| 9 | 77–79 | 3 | Number of Floors | decimal(3,0) | Building types → the representative building's floor count (bounded 0–999); otherwise `0`. |
+| 10 | 80–82 | 3 | Building Age (years) | decimal(3,0) | Building types → representative building's age; Condo → condo detail's building age; otherwise `0` (bounded 0–999). |
+| 11 | 83–97 | 15 | Market Selling Price | decimal(15,2) | **Not yet sourced — sent as zeros.** (Pending source confirmation.) |
+| 12 | 98–105 | 8 | Valuation Date | DDMMYYYY | The **latest** engagement's appraisal date. |
+| 13 | 106–120 | 15 | Valuation Price in Baht | decimal(15,2) | The latest engagement's appraisal value (same figure as field 7). |
+| 14 | 121–135 | 15 | Mortgage Value | decimal(15,2) | **Not yet sourced — sent as zeros.** |
+| 15 | 136 | 1 | Appraiser Type | string(1) | `1` = external appraisal, `2` = internal. Determined by whether the latest engagement has an external appraisal-company id. |
+| 16 | 137 | 1 | Collateral Registration Flag | string(1) | **Not yet sourced — sent blank.** |
+| 17 | 138 | 1 | Land Ownership Flag | string(1) | **Not yet sourced — sent blank.** |
+| 18 | 139–144 | 6 | DOPA Location | string(6) | 6-digit DOPA sub-district code, matched by sub-district name against the official DOPA sub-district table. Land/building/condo types. |
+| 19 | 145–151 | 7 | Land Area (Sq.Wa) | decimal(7,2) | Land types → the land detail's land area (must be ≤ 99,999.99); otherwise zeros. |
+| 20 | 152–158 | 7 | Area Utilization (building area) | decimal(7,2) | Building types → representative building's area; Condo → condo detail's usable area (≤ 99,999.99); otherwise zeros. |
+| 21 | 159–168 | 10 | Building Type ID | string(10) | Building types → representative building's building-type code; otherwise blank. |
+| 22 | 169–268 | 100 | Building Name | string(100) | Building types → the English description of the building-type code (from the BuildingType parameter table); otherwise blank. |
+| 23 | 269–276 | 8 | Expected Building Completion Date | DDMMYYYY | **Not yet sourced — sent blank.** |
+| 24 | 277–284 | 8 | Construction Review Date | DDMMYYYY | The latest **Progressive** (construction-inspection) engagement date. Blank if the master has none. |
+| 25 | 285–292 | 8 | First Valuation Date | DDMMYYYY | The **earliest** engagement's appraisal date. |
+| 26 | 293–300 | 8 | Latest Valuation Date | DDMMYYYY | The **latest** engagement's appraisal date. |
+
+**Widths sum to exactly 300.**
+
+---
+
+## How records are selected
+
+- **One record per active master collateral** (`IsDeleted = 0`, `IsMaster = 1`).
+- Most value/date fields are driven by the master's **engagements** (its appraisal history):
+  - **Earliest** = engagement with the earliest appraisal date → first valuation date + origination value.
+  - **Latest** = engagement with the latest appraisal date → completed value, valuation date/price, latest date.
+  - **Previous** = the 2nd-most-recent engagement → the "Application Id" (previous appraisal number).
+  - **Latest Progressive** = the latest engagement whose appraisal type is *Progressive* → construction review date.
+- **Representative building** (fields 9, 10, 20, 21, 22) = the first (`Sequence = 1`) building recorded on
+  the **latest** engagement.
+
+---
+
+## Fields not yet sourced
+
+The following fields are currently sent blank (strings/dates) or zeros (numeric), because the source data
+is not yet captured in the system. Each needs a source decision before it can be populated:
+
+| # | Field | Status |
+|---|---|---|
+| 4 | HOST Collateral ID | Column exists; awaits the inbound host-mapping feed to populate it. |
+| 11 | Market Selling Price | No source column yet — needs a source decision. |
+| 14 | Mortgage Value | No source column yet — needs a source decision. |
+| 16 | Collateral Registration Flag | No source column yet — needs a source decision. |
+| 17 | Land Ownership Flag | No source column yet — needs a source decision. |
+| 23 | Expected Building Completion Date | No source column yet — needs a source decision. |
+
+---
+
+## Note on the older spec documents
+
+The original spec (`.claude/docs/CAS-AS400-Regulatory.xlsx`) and the flow diagram
+(`docs/regulatory/cas-as400-flow.html`) describe a **308-character** record with **inclusive decimal
+symbols** (decimal points in numbers). The **live interface is 300 characters with implied-decimal
+numbers (no decimal point)** — the shorter, no-point format is authoritative. Treat this document as the
+current source of truth for the field layout.


### PR DESCRIPTION
## Summary
- Adds `RegulatoryExcelWriter` and an `IOutboundFileSink` abstraction (local + SFTP implementations) for the AS400 regulatory export interface.
- Wires the export job and Integration module registration; updates `RegulatoryExportQuery` and `vw_RegulatoryExport`.
- Adds `docs/regulatory/regulatory-field-reference.md` and unit tests for the Excel/file writers.

## Test plan
- `dotnet build` — 0 errors.
- `dotnet test Tests/Unit/Collateral.Tests` (RegulatoryExport writer tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)