### PR TITLE
feat(monitoring): shared :TEAM scope predicate for Task Monitor and Monitoring

### DIFF
--- a/Modules/Auth/Auth/AuthModule.cs
+++ b/Modules/Auth/Auth/AuthModule.cs
@@ -325,8 +325,10 @@ public static class AuthModule
             .AddUserPermissionPolicy("WebhookSubscriptionsManage", "WEBHOOK_SUBSCRIPTIONS_MANAGE")
             .AddUserPermissionPolicy("OAuthTokensRevoke", "OAUTH_TOKENS_REVOKE")
             .AddUserPermissionPolicy("LogsView", "LOGS_VIEW")
-            .AddUserPermissionPolicy("task-monitor.view", "TASK_MONITOR_VIEW")
-            .AddUserPermissionPolicy("task-monitor.reassign", "TASK_MONITOR_REASSIGN")
+            // Prefix policies so the optional :TEAM scope variant satisfies the endpoint too
+            // (base "TASK_MONITOR_VIEW" is a prefix of "TASK_MONITOR_VIEW:TEAM").
+            .AddUserPermissionPrefixPolicy("task-monitor.view", "TASK_MONITOR_VIEW")
+            .AddUserPermissionPrefixPolicy("task-monitor.reassign", "TASK_MONITOR_REASSIGN")
             .AddUserPermissionPolicy("history-search.view", "HISTORY_SEARCH_VIEW")
             .AddUserPermissionPolicy("sla-config.manage", "SLA_CONFIG_MANAGE")
             .AddUserPermissionPolicy("reappraisal.generate-test-file", "REAPPRAISAL_GENERATE_TEST_FILE")
@@ -482,6 +484,17 @@ public static class AuthModule
         );
         return authorizationBuilder;
     }
+
+    /// <summary>
+    /// Generic prefix policy: passes when the user holds ANY "permissions" claim that starts with
+    /// the given prefix. Lets a base permission and its scoped variants (e.g. "TASK_MONITOR_VIEW"
+    /// and "TASK_MONITOR_VIEW:TEAM") share one endpoint policy.
+    /// </summary>
+    private static AuthorizationBuilder AddUserPermissionPrefixPolicy(
+        this AuthorizationBuilder authorizationBuilder,
+        string policyName,
+        string permissionPrefix
+    ) => authorizationBuilder.AddMonitoringPrefixPolicy(policyName, permissionPrefix);
 
     /// <summary>
     /// Policy for the top-breaches endpoint: passes when the user holds ANY OLA monitoring

--- a/Modules/Common/Common/Application/Features/Monitoring/Shared/MonitoringScopeService.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/Shared/MonitoringScopeService.cs
@@ -27,8 +27,9 @@ public sealed record MonitoringScope(string[] AllActivityIds, string[] TeamActiv
 ///
 ///   A layer permission may carry an optional trailing ":TEAM" modifier
 ///   (e.g. "MONITORING:PENDING_INTERNAL:CHECKER:TEAM"). Without it the monitor sees every
-///   staff's tasks in that stage; with it the monitor sees only tasks assigned to members of
-///   their own auth.Teams team. The two can be mixed across layers.
+///   staff's tasks in that stage; with it the monitor is confined to their own "team" as
+///   resolved by <see cref="TeamScopePredicate"/> — same auth.Teams team for internal users,
+///   same company for external users. The two can be mixed across layers.
 ///
 ///   For the 4 admin-only screens (Quotation, Followup, Evaluation, MeetingFollowup)
 ///   there are no activity-ID layers — the handler skips this service.
@@ -37,24 +38,6 @@ public class MonitoringScopeService(ICurrentUserService currentUserService)
 {
     // Marks the optional scope modifier on a layer permission suffix (LAYER:TEAM).
     private const string TeamModifier = "TEAM";
-
-    // Correlated subquery: rows whose person assignee is a teammate of the current user.
-    // Matches person-assigned rows only (AssignedType='1'); AssignedTo is compared via UPPER()
-    // because the view stores it raw while auth.NormalizedUserName is uppercase.
-    // Pool/group rows (AssignedType='2', AssignedTo = group name) never match, so they are
-    // intentionally excluded from team-restricted activities.
-    // Multi-team membership resolves to the UNION of all the monitor's teams' members
-    // (confirmed intended behavior) — a monitor in two teams sees both teams' staff.
-    private const string TeamMemberPredicate = """
-        AssignedType = '1' AND UPPER(AssignedTo) IN (
-            SELECT tmateU.NormalizedUserName
-            FROM auth.TeamMembers myTm
-            INNER JOIN auth.AspNetUsers me ON me.Id = myTm.UserId AND me.NormalizedUserName = @MeNorm
-            INNER JOIN auth.Teams t ON t.Id = myTm.TeamId
-            INNER JOIN auth.TeamMembers tmate ON tmate.TeamId = t.Id
-            INNER JOIN auth.AspNetUsers tmateU ON tmateU.Id = tmate.UserId
-        )
-        """;
 
     /// <summary>Resolves the activity scope for the Pending Internal screen.</summary>
     public MonitoringScope ResolveInternalScope()
@@ -95,19 +78,16 @@ public class MonitoringScopeService(ICurrentUserService currentUserService)
             parameters.Add(p, scope.AllActivityIds);
         }
 
-        // Fail closed: a team-scoped layer needs a known username to resolve teammates.
-        // If the username is missing, drop the team branch entirely rather than emitting a
-        // query that can never match — the user simply doesn't see those team-scoped activities.
-        var meNorm = currentUserService.Username?.ToUpperInvariant();
-        if (scope.TeamActivityIds.Length > 0 && !string.IsNullOrEmpty(meNorm))
+        // Team-scoped layers are gated by the shared team predicate: same auth.Teams team for
+        // internal users, same company for external users. The builder fails closed (1 = 0) when
+        // the identity value needed to resolve the boundary is missing, so no additional guard
+        // is required here.
+        if (scope.TeamActivityIds.Length > 0)
         {
             var p = $"Team{paramSuffix}ActivityIds";
-            parts.Add($"(ActivityId IN @{p} AND ({TeamMemberPredicate}))");
+            var teamPredicate = TeamScopePredicate.Build(currentUserService, parameters);
+            parts.Add($"(ActivityId IN @{p} AND {teamPredicate})");
             parameters.Add(p, scope.TeamActivityIds);
-            // @MeNorm is intentionally shared (not paramSuffix-ed) across branches — the same
-            // user resolves the same teammates in every branch, so a single param is correct.
-            if (!parameters.ParameterNames.Contains("MeNorm"))
-                parameters.Add("MeNorm", meNorm);
         }
 
         return parts.Count == 0 ? null : "(" + string.Join(" OR ", parts) + ")";

--- a/Modules/Workflow/Workflow/GlobalUsing.cs
+++ b/Modules/Workflow/Workflow/GlobalUsing.cs
@@ -33,6 +33,7 @@ global using Workflow.Data;
 global using Workflow.Data.Repository;
 global using Workflow.Services.Groups;
 global using Workflow.Services.Hashing;
+global using Workflow.Services.TaskMonitor;
 global using Workflow.Tasks.Models;
 global using Workflow.Workflow.Resilience;
 

--- a/Modules/Workflow/Workflow/Services/TaskMonitor/ITaskMonitorScope.cs
+++ b/Modules/Workflow/Workflow/Services/TaskMonitor/ITaskMonitorScope.cs
@@ -1,0 +1,34 @@
+using Dapper;
+
+namespace Workflow.Services.TaskMonitor;
+
+/// <summary>
+/// Resolves the optional <c>:TEAM</c> scope on the Task Monitor permissions
+/// (<c>TASK_MONITOR_VIEW</c> / <c>TASK_MONITOR_REASSIGN</c>).
+///
+/// A user holding the plain base permission sees every user in their monitored groups (base wins).
+/// A user holding only the <c>:TEAM</c> variant is additionally confined to their own "team" —
+/// same auth.Teams team for internal users, same company for external users — resolved by the
+/// shared <see cref="Shared.Identity.TeamScopePredicate"/> so Task Monitor and the Monitoring
+/// screens never drift.
+/// </summary>
+public interface ITaskMonitorScope
+{
+    /// <summary>
+    /// True when the user holds the <c>:TEAM</c> variant of <paramref name="basePermission"/> but
+    /// NOT the base permission (base wins).
+    /// </summary>
+    bool IsTeamScoped(string basePermission);
+
+    /// <summary>
+    /// Returns an extra SQL WHERE fragment (no leading AND) restricting a person-assignee column
+    /// to the user's team/company, or null when the user is not team-scoped.
+    /// </summary>
+    string? BuildScopeClause(string basePermission, DynamicParameters parameters);
+
+    /// <summary>
+    /// True when <paramref name="targetUsername"/> is within the current user's team/company scope,
+    /// or when the user is not team-scoped. Used to block cross-boundary reassignment.
+    /// </summary>
+    Task<bool> IsTargetInScopeAsync(string basePermission, string targetUsername, CancellationToken cancellationToken = default);
+}

--- a/Modules/Workflow/Workflow/Services/TaskMonitor/TaskMonitorScope.cs
+++ b/Modules/Workflow/Workflow/Services/TaskMonitor/TaskMonitorScope.cs
@@ -1,0 +1,59 @@
+using Dapper;
+using Shared.Data;
+using Shared.Identity;
+
+namespace Workflow.Services.TaskMonitor;
+
+/// <inheritdoc />
+public class TaskMonitorScope(
+    ICurrentUserService currentUserService,
+    ISqlConnectionFactory connectionFactory) : ITaskMonitorScope
+{
+    private const string TeamSuffix = ":TEAM";
+
+    public bool IsTeamScoped(string basePermission)
+    {
+        var permissions = currentUserService.Permissions;
+        // Base wins: an unscoped grant means "see everyone", so :TEAM only bites when the user
+        // holds the :TEAM variant WITHOUT the base permission.
+        return !permissions.Contains(basePermission) && permissions.Contains(basePermission + TeamSuffix);
+    }
+
+    public string? BuildScopeClause(string basePermission, DynamicParameters parameters)
+    {
+        // workflow.vw_TaskMonitor already exposes only person-assigned rows and has no AssignedType
+        // column, so skip the AssignedType='1' guard (it would reference a non-existent column).
+        return IsTeamScoped(basePermission)
+            ? TeamScopePredicate.Build(currentUserService, parameters, requirePersonAssigned: false)
+            : null;
+    }
+
+    public async Task<bool> IsTargetInScopeAsync(
+        string basePermission, string targetUsername, CancellationToken cancellationToken = default)
+    {
+        if (!IsTeamScoped(basePermission))
+            return true;
+        if (string.IsNullOrWhiteSpace(targetUsername))
+            return false;
+
+        var parameters = new DynamicParameters();
+        var predicate = TeamScopePredicate.Build(currentUserService, parameters, requirePersonAssigned: false);
+        parameters.Add("TargetUser", targetUsername);
+
+        // Evaluate the shared predicate against a single-row derived table exposing the AssignedTo
+        // column it references, so the same team/company rule that filters the list also gates the
+        // reassign action. The caller already guarantees a person-assigned task, so no AssignedType.
+        var sql = $"""
+            SELECT CASE WHEN EXISTS (
+                SELECT 1
+                FROM (SELECT @TargetUser AS AssignedTo) x
+                WHERE {predicate}
+            ) THEN 1 ELSE 0 END
+            """;
+
+        using var connection = connectionFactory.GetOpenConnection();
+        var match = await connection.ExecuteScalarAsync<int>(
+            new CommandDefinition(sql, parameters, cancellationToken: cancellationToken));
+        return match == 1;
+    }
+}

--- a/Modules/Workflow/Workflow/Tasks/Features/GetMonitoredPeople/GetMonitoredPeopleQueryHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/GetMonitoredPeople/GetMonitoredPeopleQueryHandler.cs
@@ -7,7 +7,8 @@ namespace Workflow.Tasks.Features.GetMonitoredPeople;
 
 public class GetMonitoredPeopleQueryHandler(
     ISqlConnectionFactory connectionFactory,
-    ICurrentUserService currentUserService
+    ICurrentUserService currentUserService,
+    ITaskMonitorScope taskMonitorScope
 ) : IQueryHandler<GetMonitoredPeopleQuery, GetMonitoredPeopleResult>
 {
     private static readonly HashSet<string> AllowedSortFields = new(StringComparer.OrdinalIgnoreCase)
@@ -47,6 +48,12 @@ public class GetMonitoredPeopleQueryHandler(
 
         var parameters = new DynamicParameters();
         parameters.Add("SupervisorNormalizedUserName", currentUser?.ToUpperInvariant() ?? "");
+
+        // Additional :TEAM scope: when the user holds only TASK_MONITOR_VIEW:TEAM (not the base
+        // permission), confine the aggregate to their own team (internal) or company (external).
+        var teamScopeClause = taskMonitorScope.BuildScopeClause("TASK_MONITOR_VIEW", parameters);
+        if (teamScopeClause is not null)
+            baseSql += " AND " + teamScopeClause;
 
         var search = query.Filter?.Search;
         if (!string.IsNullOrWhiteSpace(search))

--- a/Modules/Workflow/Workflow/Tasks/Features/GetMonitoredTasks/GetMonitoredTasksQueryHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/GetMonitoredTasks/GetMonitoredTasksQueryHandler.cs
@@ -10,6 +10,7 @@ namespace Workflow.Tasks.Features.GetMonitoredTasks;
 public class GetMonitoredTasksQueryHandler(
     ISqlConnectionFactory connectionFactory,
     ICurrentUserService currentUserService,
+    ITaskMonitorScope taskMonitorScope,
     IBusinessTimeCalculator businessTime,
     IDateTimeProvider clock
 ) : IQueryHandler<GetMonitoredTasksQuery, GetMonitoredTasksResult>
@@ -46,6 +47,12 @@ public class GetMonitoredTasksQueryHandler(
             )
             """);
         parameters.Add("SupervisorNormalizedUserName", currentUser?.ToUpperInvariant() ?? "");
+
+        // Additional :TEAM scope: when the user holds only TASK_MONITOR_VIEW:TEAM (not the base
+        // permission), confine the list to their own team (internal) or company (external).
+        var teamScopeClause = taskMonitorScope.BuildScopeClause("TASK_MONITOR_VIEW", parameters);
+        if (teamScopeClause is not null)
+            conditions.Add(teamScopeClause);
 
         var filter = query.Filter;
         if (filter is not null)

--- a/Modules/Workflow/Workflow/Tasks/Features/GetTaskById/GetTaskByIdQueryHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/GetTaskById/GetTaskByIdQueryHandler.cs
@@ -49,7 +49,7 @@ public class GetTaskByIdQueryHandler(
                 qra_first.AppraisalId,
                 (SELECT TOP 1 Id FROM appraisal.Appraisals
                  WHERE RequestId = pt.CorrelationId
-                 ORDER BY CreatedAt DESC)
+                 ORDER BY Id)
             )                                  AS AppraisalId
         FROM workflow.PendingTasks pt
         -- Followup tasks: resolve RequestId / AppraisalId via FollowupWorkflowInstanceId

--- a/Modules/Workflow/Workflow/Tasks/Features/OpenTask/OpenTaskCommandHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/OpenTask/OpenTaskCommandHandler.cs
@@ -79,7 +79,7 @@ public class OpenTaskCommandHandler(
             """
             SELECT TOP 1 Id FROM appraisal.Appraisals
             WHERE RequestId = @CorrelationId
-            ORDER BY CreatedAt DESC
+            ORDER BY Id
             """,
             new { task.CorrelationId });
 

--- a/Modules/Workflow/Workflow/Tasks/Features/ReassignTask/ReassignTaskCommandHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/ReassignTask/ReassignTaskCommandHandler.cs
@@ -13,6 +13,7 @@ public class ReassignTaskCommandHandler(
     WorkflowDbContext dbContext,
     ICurrentUserService currentUserService,
     IGroupMonitoringService groupMonitoringService,
+    ITaskMonitorScope taskMonitorScope,
     IWorkflowInstanceRepository instanceRepository,
     IAssignmentPipeline assignmentPipeline,
     IDateTimeProvider dateTimeProvider,
@@ -54,6 +55,13 @@ public class ReassignTaskCommandHandler(
             task.AssignedTo, currentUser, cancellationToken);
         if (!isSupervisor)
             return new ReassignTaskResult(false, ErrorMessage: "You do not supervise this user");
+
+        // 7b. :TEAM scope — a team-scoped supervisor may only act on tasks whose current assignee is
+        // within their own team (internal) or company (external), matching what they can see.
+        var isInScope = await taskMonitorScope.IsTargetInScopeAsync(
+            "TASK_MONITOR_REASSIGN", task.AssignedTo, cancellationToken);
+        if (!isInScope)
+            return new ReassignTaskResult(false, ErrorMessage: "This task is outside your team/company scope");
 
         // 8. Target must be eligible for the activity
         var isEligible = await IsNewAssigneeEligibleAsync(task, command.NewAssignedTo, cancellationToken);

--- a/Modules/Workflow/Workflow/WorkflowModule.cs
+++ b/Modules/Workflow/Workflow/WorkflowModule.cs
@@ -51,6 +51,7 @@ public static class WorkflowModule
         services.AddScoped<WfIUserGroupService, UserGroupService>();
         services.AddScoped<IGroupHashService, GroupHashService>();
         services.AddScoped<IGroupMonitoringService, GroupMonitoringService>();
+        services.AddScoped<ITaskMonitorScope, TaskMonitorScope>();
 
         // Assignee selector services
         services.AddScoped<ManualAssigneeSelector>();

--- a/Shared/Shared/Identity/TeamScopePredicate.cs
+++ b/Shared/Shared/Identity/TeamScopePredicate.cs
@@ -1,0 +1,86 @@
+using Dapper;
+
+namespace Shared.Identity;
+
+/// <summary>
+/// Builds the SQL predicate that restricts a person-assignee column to the current user's
+/// "team" — the single source of truth shared by every screen that offers a <c>:TEAM</c>
+/// permission scope (Monitoring pending screens, Task Monitor).
+///
+/// "Team" is resolved by user kind:
+///   • Internal (bank) user  → members of the same <c>auth.Teams</c> team(s) as the user
+///                             (multi-team membership = UNION of all their teams' members).
+///   • External (company) user → users belonging to the same <c>CompanyId</c>. External appraisal
+///                             companies are not modelled as <c>auth.Teams</c> rows, so the company
+///                             itself acts as the team boundary.
+///
+/// The predicate only ever matches person-assigned rows (<c>AssignedType = '1'</c>); pool/group
+/// rows never match and are intentionally excluded from team-restricted scopes.
+///
+/// Fail-closed: if the identity value needed to resolve the boundary (Username for internal,
+/// CompanyId for external) is missing, the predicate is <c>1 = 0</c> — a scoped user sees nothing
+/// rather than everything.
+/// </summary>
+public static class TeamScopePredicate
+{
+    /// <summary>
+    /// Returns a parenthesised SQL predicate on <paramref name="assignedToCol"/> and registers the
+    /// parameter it needs on <paramref name="p"/>. The identity parameter (<c>@MeNorm</c> /
+    /// <c>@ScopeCompanyId</c>) is shared and registered idempotently — the boundary always resolves
+    /// against the same current user, so multiple scopes in one query (e.g. the Monitoring
+    /// top-breaches UNION) reuse a single parameter. Never returns null: on the fail-closed path it
+    /// returns <c>1 = 0</c>, so a caller that ANDs this fragment restricts to nothing rather than
+    /// leaking every row.
+    ///
+    /// <paramref name="requirePersonAssigned"/> prepends an <c>AssignedType = '1'</c> guard so
+    /// pool/group rows never match. Set it to false when the source already exposes only
+    /// person-assigned rows AND has no <c>AssignedType</c> column (e.g. <c>workflow.vw_TaskMonitor</c>),
+    /// otherwise the guard references a non-existent column.
+    /// </summary>
+    public static string Build(
+        ICurrentUserService user,
+        DynamicParameters p,
+        string assignedToCol = "AssignedTo",
+        bool requirePersonAssigned = true)
+    {
+        var guard = requirePersonAssigned ? "AssignedType = '1' AND " : "";
+
+        if (user.IsExternal)
+        {
+            var companyId = user.CompanyId;
+            if (companyId is null)
+                return "1 = 0";
+
+            if (!p.ParameterNames.Contains("ScopeCompanyId"))
+                p.Add("ScopeCompanyId", companyId.Value);
+
+            return $"""
+                ({guard}UPPER({assignedToCol}) IN (
+                    SELECT u.NormalizedUserName
+                    FROM auth.AspNetUsers u
+                    WHERE u.CompanyId = @ScopeCompanyId
+                ))
+                """;
+        }
+
+        var meNorm = user.Username?.ToUpperInvariant();
+        if (string.IsNullOrEmpty(meNorm))
+            return "1 = 0";
+
+        if (!p.ParameterNames.Contains("MeNorm"))
+            p.Add("MeNorm", meNorm);
+
+        // Internal: teammates via auth.TeamMembers/auth.Teams. AssignedTo is compared via UPPER()
+        // because the source stores it raw while auth.NormalizedUserName is uppercase.
+        return $"""
+            ({guard}UPPER({assignedToCol}) IN (
+                SELECT tmateU.NormalizedUserName
+                FROM auth.TeamMembers myTm
+                INNER JOIN auth.AspNetUsers me ON me.Id = myTm.UserId AND me.NormalizedUserName = @MeNorm
+                INNER JOIN auth.Teams t ON t.Id = myTm.TeamId
+                INNER JOIN auth.TeamMembers tmate ON tmate.TeamId = t.Id
+                INNER JOIN auth.AspNetUsers tmateU ON tmateU.Id = tmate.UserId
+            ))
+            """;
+    }
+}

--- a/Tests/Unit/Common.Tests/Monitoring/MonitoringActivityMapTests.cs
+++ b/Tests/Unit/Common.Tests/Monitoring/MonitoringActivityMapTests.cs
@@ -175,15 +175,17 @@ public class MonitoringActivityMapTests
     }
 
     [Fact]
-    public void BuildActivityScopeSql_TeamScopeWithNoUsername_DropsTeamBranchAndFailsClosed()
+    public void BuildActivityScopeSql_TeamScopeWithNoUsername_FailsClosed()
     {
         var service = new MonitoringScopeService(new FakeCurrentUserService([], username: null));
         var parameters = new DynamicParameters();
 
-        // Team-only scope + no username ⇒ no visible activities (null fragment, no MeNorm leaked).
+        // Team-only scope + no username ⇒ the shared predicate fails closed to "1 = 0", so the
+        // team branch can never match. No MeNorm is leaked. (The clause is non-null so a caller
+        // ANDing it restricts to nothing rather than failing open.)
         var sql = service.BuildActivityScopeSql(new MonitoringScope([], ["x"]), parameters);
 
-        sql.Should().BeNull();
+        sql.Should().Contain("1 = 0");
         parameters.ParameterNames.Should().NotContain("MeNorm");
     }
 }

--- a/Tests/Unit/Workflow.Tests/Services/TaskMonitor/TaskMonitorScopeTests.cs
+++ b/Tests/Unit/Workflow.Tests/Services/TaskMonitor/TaskMonitorScopeTests.cs
@@ -1,0 +1,131 @@
+using System.Linq;
+using Dapper;
+using FluentAssertions;
+using NSubstitute;
+using Shared.Data;
+using Shared.Identity;
+using Workflow.Services.TaskMonitor;
+using Xunit;
+
+namespace Workflow.Tests.Services.TaskMonitor;
+
+public class TeamScopePredicateTests
+{
+    private static ICurrentUserService User(bool isExternal, Guid? companyId, string? username, params string[] permissions)
+    {
+        var u = Substitute.For<ICurrentUserService>();
+        u.IsExternal.Returns(isExternal);
+        u.CompanyId.Returns(companyId);
+        u.Username.Returns(username);
+        u.Permissions.Returns(permissions);
+        return u;
+    }
+
+    [Fact]
+    public void Build_ExternalUser_ScopesByCompanyId()
+    {
+        var companyId = Guid.NewGuid();
+        var p = new DynamicParameters();
+
+        var sql = TeamScopePredicate.Build(User(isExternal: true, companyId, username: "ext.admin1"), p);
+
+        sql.Should().Contain("auth.AspNetUsers");
+        sql.Should().Contain("CompanyId = @ScopeCompanyId");
+        p.ParameterNames.Should().Contain("ScopeCompanyId");
+        p.Get<Guid>("ScopeCompanyId").Should().Be(companyId);
+    }
+
+    [Fact]
+    public void Build_InternalUser_ScopesByTeamMembership()
+    {
+        var p = new DynamicParameters();
+
+        var sql = TeamScopePredicate.Build(User(isExternal: false, companyId: null, username: "int.chk1"), p);
+
+        sql.Should().Contain("auth.TeamMembers");
+        sql.Should().Contain("@MeNorm");
+        p.Get<string>("MeNorm").Should().Be("INT.CHK1");
+    }
+
+    [Fact]
+    public void Build_ExternalUserWithoutCompanyId_FailsClosed()
+    {
+        var p = new DynamicParameters();
+
+        var sql = TeamScopePredicate.Build(User(isExternal: true, companyId: null, username: "ext.admin1"), p);
+
+        sql.Should().Be("1 = 0");
+    }
+
+    [Fact]
+    public void Build_InternalUserWithoutUsername_FailsClosed()
+    {
+        var p = new DynamicParameters();
+
+        var sql = TeamScopePredicate.Build(User(isExternal: false, companyId: null, username: null), p);
+
+        sql.Should().Be("1 = 0");
+    }
+
+    [Fact]
+    public void Build_SameUserAcrossCalls_RegistersIdentityParamOnce()
+    {
+        var p = new DynamicParameters();
+        var user = User(isExternal: false, companyId: null, username: "int.chk1");
+
+        TeamScopePredicate.Build(user, p);
+        TeamScopePredicate.Build(user, p);
+
+        p.ParameterNames.Count(n => n == "MeNorm").Should().Be(1);
+    }
+}
+
+public class TaskMonitorScopeTests
+{
+    private const string Base = "TASK_MONITOR_VIEW";
+    private const string Team = "TASK_MONITOR_VIEW:TEAM";
+
+    private static TaskMonitorScope BuildScope(ICurrentUserService user)
+        => new(user, Substitute.For<ISqlConnectionFactory>());
+
+    private static ICurrentUserService UserWithPermissions(params string[] permissions)
+    {
+        var u = Substitute.For<ICurrentUserService>();
+        u.Permissions.Returns(permissions);
+        return u;
+    }
+
+    [Fact]
+    public void IsTeamScoped_TeamVariantOnly_True()
+        => BuildScope(UserWithPermissions(Team)).IsTeamScoped(Base).Should().BeTrue();
+
+    [Fact]
+    public void IsTeamScoped_BaseOnly_False()
+        => BuildScope(UserWithPermissions(Base)).IsTeamScoped(Base).Should().BeFalse();
+
+    [Fact]
+    public void IsTeamScoped_BothVariants_BaseWins_False()
+        => BuildScope(UserWithPermissions(Base, Team)).IsTeamScoped(Base).Should().BeFalse();
+
+    [Fact]
+    public void IsTeamScoped_NeitherVariant_False()
+        => BuildScope(UserWithPermissions("SOMETHING_ELSE")).IsTeamScoped(Base).Should().BeFalse();
+
+    [Fact]
+    public void BuildScopeClause_NotTeamScoped_ReturnsNull()
+        => BuildScope(UserWithPermissions(Base)).BuildScopeClause(Base, new DynamicParameters()).Should().BeNull();
+
+    [Fact]
+    public void BuildScopeClause_TeamScopedExternal_ReturnsCompanyPredicate()
+    {
+        var u = Substitute.For<ICurrentUserService>();
+        u.Permissions.Returns([Team]);
+        u.IsExternal.Returns(true);
+        u.CompanyId.Returns(Guid.NewGuid());
+
+        var clause = BuildScope(u).BuildScopeClause(Base, new DynamicParameters());
+
+        clause.Should().NotBeNull();
+        clause.Should().Contain("CompanyId = @ScopeCompanyId");
+    }
+}

--- a/Tests/Unit/Workflow.Tests/Tasks/Features/ReassignTask/ReassignTaskCommandHandlerTests.cs
+++ b/Tests/Unit/Workflow.Tests/Tasks/Features/ReassignTask/ReassignTaskCommandHandlerTests.cs
@@ -9,6 +9,7 @@ using Workflow.AssigneeSelection.Pipeline;
 using Workflow.AssigneeSelection.Teams;
 using Workflow.Data;
 using Workflow.Services.Groups;
+using Workflow.Services.TaskMonitor;
 using Workflow.Tasks.Features.ReassignTask;
 using Workflow.Tasks.Models;
 using Workflow.Workflow.Activities.Core;
@@ -26,6 +27,7 @@ public class ReassignTaskCommandHandlerTests : IDisposable
     private readonly WorkflowDbContext _dbContext;
     private readonly ICurrentUserService _currentUserService;
     private readonly IGroupMonitoringService _groupMonitoringService;
+    private readonly ITaskMonitorScope _taskMonitorScope;
     private readonly IWorkflowInstanceRepository _instanceRepository;
     private readonly IAssignmentPipeline _assignmentPipeline;
     private readonly ReassignTaskCommandHandler _handler;
@@ -39,6 +41,7 @@ public class ReassignTaskCommandHandlerTests : IDisposable
 
         _currentUserService = Substitute.For<ICurrentUserService>();
         _groupMonitoringService = Substitute.For<IGroupMonitoringService>();
+        _taskMonitorScope = Substitute.For<ITaskMonitorScope>();
         _instanceRepository = Substitute.For<IWorkflowInstanceRepository>();
         _assignmentPipeline = Substitute.For<IAssignmentPipeline>();
 
@@ -51,6 +54,7 @@ public class ReassignTaskCommandHandlerTests : IDisposable
             _dbContext,
             _currentUserService,
             _groupMonitoringService,
+            _taskMonitorScope,
             _instanceRepository,
             _assignmentPipeline,
             dateTimeProvider,
@@ -59,6 +63,8 @@ public class ReassignTaskCommandHandlerTests : IDisposable
         // Default happy-path stubs
         _currentUserService.Username.Returns("supervisor");
         _groupMonitoringService.IsUserSupervisedByAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _taskMonitorScope.IsTargetInScopeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(true);
     }
 
@@ -206,6 +212,23 @@ public class ReassignTaskCommandHandlerTests : IDisposable
 
         result.IsSuccess.Should().BeFalse();
         result.ErrorMessage.Should().Be("You do not supervise this user");
+    }
+
+    // ── Validation: task outside the team-scoped supervisor's team/company ─────
+
+    [Fact]
+    public async Task Handle_TaskOutsideTeamScope_ReturnsFail()
+    {
+        var task = await SeedTaskAsync("alice");
+        // Supervisor monitors alice's group, but alice is outside the supervisor's team/company scope.
+        _taskMonitorScope.IsTargetInScopeAsync("TASK_MONITOR_REASSIGN", "alice", Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var result = await _handler.Handle(
+            new ReassignTaskCommand(task.Id, "bob"), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Be("This task is outside your team/company scope");
     }
 
     // ── Validation: new assignee not eligible ─────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `Shared/Identity/TeamScopePredicate` (fail-closed `1=0` default) shared by Task Monitor and Monitoring.
- New Workflow `ITaskMonitorScope`/`TaskMonitorScope` applied across the task query/command handlers; refactors `MonitoringScopeService` onto the shared predicate.
- Auth: prefix policies so `TASK_MONITOR_VIEW` and its `:TEAM` scoped variant satisfy the same endpoint.

## Test plan
- `dotnet build` — 0 errors.
- `dotnet test Tests/Unit/Workflow.Tests` and `Tests/Unit/Common.Tests` (TaskMonitorScope, reassign, monitoring map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)