### PR TITLE
feat(monitoring): enhance pending-quotations listing query and summary

### DIFF
--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsEndpoint.cs
@@ -17,7 +17,9 @@ public class GetPendingQuotationsEndpoint : ICarterModule
                 async (
                     [AsParameters] PaginationRequest pagination,
                     string[]? status,
-                    string? search,
+                    string? quotationNo,
+                    string? appraisalNo,
+                    string? customerName,
                     string? sortBy,
                     string? sortDir,
                     DateOnly? cutOffTimeFrom,
@@ -25,7 +27,7 @@ public class GetPendingQuotationsEndpoint : ICarterModule
                     ISender sender,
                     CancellationToken cancellationToken) =>
                 {
-                    var filter = new PendingQuotationFilter(status, search, sortBy, sortDir, cutOffTimeFrom, cutOffTimeTo);
+                    var filter = new PendingQuotationFilter(status, quotationNo, appraisalNo, customerName, sortBy, sortDir, cutOffTimeFrom, cutOffTimeTo);
                     var result = await sender.Send(new GetPendingQuotationsQuery(pagination, filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsQueryHandler.cs
@@ -6,78 +6,130 @@ using Shared.Pagination;
 namespace Common.Application.Features.Monitoring.GetPendingQuotations;
 
 /// <summary>
-/// Returns pending quotations from appraisal.vw_QuotationList (reused as-is per constraint D5).
+/// Returns pending quotations from appraisal.vw_QuotationList.
 /// No activity-ID scoping — this is an admin-level screen with a single permission.
+/// Customer names are derived inline (OUTER APPLY) and the RM code is resolved to a full name
+/// via a LEFT JOIN to auth.AspNetUsers — mirrors the quotation listing (GetQuotationsQueryHandler).
 /// </summary>
 public class GetPendingQuotationsQueryHandler(ISqlConnectionFactory connectionFactory)
     : IQueryHandler<GetPendingQuotationsQuery, PaginatedResult<PendingQuotationDto>>
 {
-    private static readonly HashSet<string> AllowedSortFields = new(StringComparer.OrdinalIgnoreCase)
+    // Whitelist of user-sortable keys → real (qualified) columns. Only these literal strings ever
+    // reach the ORDER BY, so user input can never inject.
+    private static readonly Dictionary<string, string> AllowedSortColumns = new(StringComparer.OrdinalIgnoreCase)
     {
-        "QuotationNumber", "Status", "RequestDate", "CutOffTime", "RequestedBy", "RmUsername",
-        "TotalAppraisals", "TotalCompaniesInvited", "TotalQuotationsReceived"
+        ["QuotationNumber"] = "q.QuotationNumber",
+        ["Status"] = "q.Status",
+        ["RequestDate"] = "q.RequestDate",
+        ["CutOffTime"] = "q.CutOffTime",
+        ["RequestedBy"] = "q.RequestedBy",
+        ["RmUsername"] = "q.RmUsername",
+        ["TotalAppraisals"] = "q.TotalAppraisals",
+        ["TotalCompaniesInvited"] = "q.TotalCompaniesInvited",
+        ["TotalQuotationsReceived"] = "q.TotalQuotationsReceived",
+        ["CustomerName"] = "cust.CustomerName",
     };
 
     public async Task<PaginatedResult<PendingQuotationDto>> Handle(
         GetPendingQuotationsQuery query,
         CancellationToken cancellationToken)
     {
-        // Explicit projection — column order MUST match PendingQuotationDto's positional record constructor.
+        // Column order MUST match PendingQuotationDto's positional record constructor.
+        // - RmFullName: NULL when the code doesn't resolve to a real name → the UI shows just the code.
+        // - cust.*: distinct customer names for the quotation (representative MIN + count + full list).
         var sql = @"
 SELECT
-    Id,
-    QuotationNumber,
-    Status,
-    RequestDate,
-    CutOffTime,
-    RequestedBy,
-    TotalAppraisals,
-    TotalCompaniesInvited,
-    TotalQuotationsReceived,
-    RmUsername
-FROM appraisal.vw_QuotationList";
+    q.Id,
+    q.QuotationNumber,
+    q.Status,
+    q.RequestDate,
+    q.CutOffTime,
+    q.RequestedBy,
+    q.TotalAppraisals,
+    q.TotalCompaniesInvited,
+    q.TotalQuotationsReceived,
+    q.RmUsername,
+    RmFullName = NULLIF(LTRIM(RTRIM(COALESCE(rmU.FirstName, '') + ' ' + COALESCE(rmU.LastName, ''))), ''),
+    cust.CustomerName,
+    cust.CustomerCount,
+    cust.CustomerNames
+FROM appraisal.vw_QuotationList q
+LEFT JOIN auth.AspNetUsers rmU ON rmU.UserName = q.RmUsername
+OUTER APPLY (
+    SELECT CustomerName = MIN(x.Name), CustomerCount = COUNT(*),
+           CustomerNames = STRING_AGG(x.Name, ', ') WITHIN GROUP (ORDER BY x.Name)
+    FROM (SELECT DISTINCT rc.Name
+          FROM appraisal.QuotationRequestAppraisals qra
+          JOIN appraisal.Appraisals a ON a.Id = qra.AppraisalId
+          JOIN request.RequestCustomers rc ON rc.RequestId = a.RequestId
+          WHERE qra.QuotationRequestId = q.Id) x
+) cust";
         var conditions = new List<string>();
         var parameters = new DynamicParameters();
 
         var filter = query.Filter;
 
         // Default: exclude terminal statuses to show only pending/open quotations.
-        // If specific statuses are requested, skip the exclusion list and filter exactly.
+        // If specific statuses are requested, filter exactly (multi-select IN).
         if (filter.Status is { Length: > 0 })
         {
-            conditions.Add("Status IN @Statuses");
+            conditions.Add("q.Status IN @Statuses");
             parameters.Add("Statuses", filter.Status);
         }
         else
         {
-            // Closed, Finalized, Cancelled are terminal states; exclude from the monitoring surface.
-            conditions.Add("Status NOT IN ('Closed', 'Finalized', 'Cancelled')");
+            conditions.Add("q.Status NOT IN ('Closed', 'Finalized', 'Cancelled')");
         }
 
-        if (!string.IsNullOrWhiteSpace(filter.Search))
+        // Per-field search — each an INDEPENDENT contains predicate AND-ed onto the query
+        // (mirrors the quotation listing). Appraisal-no / customer-name reach through the
+        // QuotationRequestAppraisals → Appraisals → RequestCustomers chain.
+        if (!string.IsNullOrWhiteSpace(filter.QuotationNo))
         {
-            conditions.Add("(QuotationNumber LIKE @Search ESCAPE '\\' OR RequestedBy LIKE @Search ESCAPE '\\')");
-            parameters.Add("Search", "%" + EscapeLike(filter.Search.Trim()) + "%");
+            conditions.Add(@"q.QuotationNumber LIKE @QuotationNoPattern ESCAPE '\'");
+            parameters.Add("QuotationNoPattern", "%" + EscapeLike(filter.QuotationNo.Trim()) + "%");
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.AppraisalNo))
+        {
+            conditions.Add(@"EXISTS (
+    SELECT 1 FROM appraisal.QuotationRequestAppraisals qra
+    JOIN appraisal.Appraisals a ON a.Id = qra.AppraisalId
+    WHERE qra.QuotationRequestId = q.Id
+      AND a.AppraisalNumber LIKE @AppraisalNoPattern ESCAPE '\')");
+            parameters.Add("AppraisalNoPattern", "%" + EscapeLike(filter.AppraisalNo.Trim()) + "%");
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.CustomerName))
+        {
+            conditions.Add(@"EXISTS (
+    SELECT 1 FROM appraisal.QuotationRequestAppraisals qra
+    JOIN appraisal.Appraisals a ON a.Id = qra.AppraisalId
+    JOIN request.RequestCustomers rc ON rc.RequestId = a.RequestId
+    WHERE qra.QuotationRequestId = q.Id
+      AND rc.Name LIKE @CustomerNamePattern ESCAPE '\')");
+            parameters.Add("CustomerNamePattern", "%" + EscapeLike(filter.CustomerName.Trim()) + "%");
         }
 
         // Optional filter: CutOffTime range — convert DateOnly → DateTime (Dapper rejects DateOnly)
         if (filter.CutOffTimeFrom.HasValue)
         {
-            conditions.Add("CutOffTime >= @CutOffTimeFrom");
+            conditions.Add("q.CutOffTime >= @CutOffTimeFrom");
             parameters.Add("CutOffTimeFrom", filter.CutOffTimeFrom.Value.ToDateTime(TimeOnly.MinValue));
         }
 
         if (filter.CutOffTimeTo.HasValue)
         {
-            conditions.Add("CutOffTime <= @CutOffTimeTo");
+            conditions.Add("q.CutOffTime <= @CutOffTimeTo");
             parameters.Add("CutOffTimeTo", filter.CutOffTimeTo.Value.ToDateTime(TimeOnly.MaxValue));
         }
 
         sql += " WHERE " + string.Join(" AND ", conditions);
 
-        var sortField = AllowedSortFields.Contains(filter.SortBy ?? "") ? filter.SortBy! : "RequestDate";
+        // Default RequestDate DESC; q.Id is a stable tiebreaker (never a sort key → no duplicate trap).
+        var sortColumn = AllowedSortColumns.TryGetValue(filter.SortBy ?? "", out var col) ? col : "q.RequestDate";
         var sortDir = string.Equals(filter.SortDir, "asc", StringComparison.OrdinalIgnoreCase) ? "ASC" : "DESC";
-        var orderBy = $"{sortField} {sortDir}";
+        var orderBy = $"{sortColumn} {sortDir}, q.Id DESC";
 
         return await connectionFactory.QueryPaginatedAsync<PendingQuotationDto>(sql, orderBy, query.Paging, parameters);
     }

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsSummaryEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsSummaryEndpoint.cs
@@ -15,11 +15,13 @@ public class GetPendingQuotationsSummaryEndpoint : ICarterModule
                 "/monitoring/quotations/summary",
                 async (
                     string[]? status,
-                    string? search,
+                    string? quotationNo,
+                    string? appraisalNo,
+                    string? customerName,
                     ISender sender,
                     CancellationToken cancellationToken) =>
                 {
-                    var filter = new PendingQuotationFilter(status, search, null, null);
+                    var filter = new PendingQuotationFilter(status, quotationNo, appraisalNo, customerName, null, null);
                     var result = await sender.Send(new GetPendingQuotationsSummaryQuery(filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsSummaryQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsSummaryQueryHandler.cs
@@ -24,22 +24,44 @@ public class GetPendingQuotationsSummaryQueryHandler(ISqlConnectionFactory conne
         var filter = query.Filter;
         if (filter.Status is { Length: > 0 })
         {
-            conditions.Add("Status IN @Statuses");
+            conditions.Add("q.Status IN @Statuses");
             parameters.Add("Statuses", filter.Status);
         }
         else
         {
-            conditions.Add("Status NOT IN ('Closed', 'Finalized', 'Cancelled')");
+            conditions.Add("q.Status NOT IN ('Closed', 'Finalized', 'Cancelled')");
         }
 
-        if (!string.IsNullOrWhiteSpace(filter.Search))
+        // Per-field search — keep the count consistent with the list handler's predicates.
+        if (!string.IsNullOrWhiteSpace(filter.QuotationNo))
         {
-            conditions.Add("(QuotationNumber LIKE @Search ESCAPE '\\' OR RequestedBy LIKE @Search ESCAPE '\\')");
-            parameters.Add("Search", "%" + EscapeLike(filter.Search.Trim()) + "%");
+            conditions.Add(@"q.QuotationNumber LIKE @QuotationNoPattern ESCAPE '\'");
+            parameters.Add("QuotationNoPattern", "%" + EscapeLike(filter.QuotationNo.Trim()) + "%");
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.AppraisalNo))
+        {
+            conditions.Add(@"EXISTS (
+    SELECT 1 FROM appraisal.QuotationRequestAppraisals qra
+    JOIN appraisal.Appraisals a ON a.Id = qra.AppraisalId
+    WHERE qra.QuotationRequestId = q.Id
+      AND a.AppraisalNumber LIKE @AppraisalNoPattern ESCAPE '\')");
+            parameters.Add("AppraisalNoPattern", "%" + EscapeLike(filter.AppraisalNo.Trim()) + "%");
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.CustomerName))
+        {
+            conditions.Add(@"EXISTS (
+    SELECT 1 FROM appraisal.QuotationRequestAppraisals qra
+    JOIN appraisal.Appraisals a ON a.Id = qra.AppraisalId
+    JOIN request.RequestCustomers rc ON rc.RequestId = a.RequestId
+    WHERE qra.QuotationRequestId = q.Id
+      AND rc.Name LIKE @CustomerNamePattern ESCAPE '\')");
+            parameters.Add("CustomerNamePattern", "%" + EscapeLike(filter.CustomerName.Trim()) + "%");
         }
 
         var where = "WHERE " + string.Join(" AND ", conditions);
-        var sql = $"SELECT COUNT(*) FROM appraisal.vw_QuotationList {where}";
+        var sql = $"SELECT COUNT(*) FROM appraisal.vw_QuotationList q {where}";
 
         var conn = connectionFactory.GetOpenConnection();
         var total = await conn.ExecuteScalarAsync<int>(sql, parameters);

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/PendingQuotationDto.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/PendingQuotationDto.cs
@@ -10,5 +10,9 @@ public record PendingQuotationDto(
     int TotalAppraisals,
     int TotalCompaniesInvited,
     int TotalQuotationsReceived,
-    string? RmUsername
+    string? RmUsername,
+    string? RmFullName,
+    string? CustomerName,
+    int CustomerCount,
+    string? CustomerNames
 );

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/PendingQuotationFilter.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/PendingQuotationFilter.cs
@@ -2,7 +2,9 @@ namespace Common.Application.Features.Monitoring.GetPendingQuotations;
 
 public record PendingQuotationFilter(
     string[]? Status,
-    string? Search,
+    string? QuotationNo,
+    string? AppraisalNo,
+    string? CustomerName,
     string? SortBy,
     string? SortDir,
     DateOnly? CutOffTimeFrom = null,


### PR DESCRIPTION
## Summary
- Extends `GetPendingQuotations` query + summary handlers, `PendingQuotationDto` and `PendingQuotationFilter` for the redesigned pending-quotations monitoring section.

Pairs with the frontend `feature/pending-quotations` PR.

## Test plan
- `dotnet build` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)