### PR TITLE
feat(collateral): block reappraisal due-list endpoint and maintenance view

### DIFF
--- a/Database/Scripts/Views/Collateral/vw_BlockMaintenanceList.sql
+++ b/Database/Scripts/Views/Collateral/vw_BlockMaintenanceList.sql
@@ -1,29 +1,41 @@
 CREATE
 OR ALTER
 VIEW collateral.vw_BlockMaintenanceList AS
-SELECT cm.Id                        AS CollateralMasterId,
-       pd.LastAppraisalNumber       AS AppraisalReportNo,
+SELECT cm.Id                  AS CollateralMasterId,
+       pd.LastAppraisalNumber AS AppraisalReportNo,
        cm.CustomerName,
        pd.ProjectName,
        pd.ProjectType,
        pd.Developer,
-       COUNT(pu.Id)                                          AS TotalUnits,
-       ISNULL(SUM(CAST(pu.IsSold AS INT)), 0)                AS SoldUnits,
-       COUNT(pu.Id) - ISNULL(SUM(CAST(pu.IsSold AS INT)), 0) AS UnsoldUnits,
-       cm.UpdatedAt                 AS UpdatedOn,
-       cm.UpdatedBy                 AS UpdatedBy
+       agg.TotalUnits,
+       agg.SoldUnits,
+       agg.UnsoldUnits,
+       la.UpdatedOn,
+       la.UpdatedBy
 FROM collateral.CollateralMasters cm
          INNER JOIN collateral.ProjectDetails pd ON pd.CollateralMasterId = cm.Id
-         LEFT JOIN collateral.ProjectUnits pu ON pu.CollateralMasterId = cm.Id
+         OUTER APPLY (
+    SELECT COUNT(pu.Id)                                          AS TotalUnits,
+           ISNULL(SUM(CAST(pu.IsSold AS INT)), 0)                AS SoldUnits,
+           COUNT(pu.Id) - ISNULL(SUM(CAST(pu.IsSold AS INT)), 0) AS UnsoldUnits
+    FROM collateral.ProjectUnits pu
+    WHERE pu.CollateralMasterId = cm.Id
+    ) agg
+         CROSS APPLY (
+    -- "Last Updated" = the most recent change to the project: the master row itself
+    -- or any of its unit rows (a unit sale-status edit stamps only the unit rows).
+    -- TOP 1 by UpdatedAt keeps the matching UpdatedBy (the actor), unlike a bare MAX().
+    SELECT TOP 1 x.UpdatedAt AS UpdatedOn, x.UpdatedBy AS UpdatedBy
+    FROM (
+             SELECT cm.UpdatedAt, cm.UpdatedBy
+             UNION ALL
+             SELECT pu.UpdatedAt, pu.UpdatedBy
+             FROM collateral.ProjectUnits pu
+             WHERE pu.CollateralMasterId = cm.Id
+         ) x
+    ORDER BY x.UpdatedAt DESC
+    ) la
 WHERE cm.CollateralType = 'PRJ'
   AND cm.IsMaster = 1
   AND cm.IsDeleted = 0
   AND pd.IsDeleted = 0
-GROUP BY cm.Id,
-         pd.LastAppraisalNumber,
-         cm.CustomerName,
-         pd.ProjectName,
-         pd.ProjectType,
-         pd.Developer,
-         cm.UpdatedAt,
-         cm.UpdatedBy

--- a/Modules/Collateral/Collateral/Application/Features/BlockReappraisal/BlockReappraisalEndpoints.cs
+++ b/Modules/Collateral/Collateral/Application/Features/BlockReappraisal/BlockReappraisalEndpoints.cs
@@ -20,6 +20,8 @@ public class BlockReappraisalEndpoints : ICarterModule
                     DateTime? lastAppraisedDateTo,
                     int? remainingDayMin,
                     int? remainingDayMax,
+                    string? sortBy,
+                    string? sortDir,
                     int? pageNumber,
                     int? pageSize,
                     ISender sender,
@@ -33,6 +35,8 @@ public class BlockReappraisalEndpoints : ICarterModule
                         LastAppraisedDateTo: lastAppraisedDateTo,
                         RemainingDayMin: remainingDayMin,
                         RemainingDayMax: remainingDayMax,
+                        SortBy: sortBy,
+                        SortDir: sortDir,
                         PaginationRequest: new PaginationRequest(pageNumber ?? 0, pageSize ?? 20));
 
                     var result = await sender.Send(query, cancellationToken);

--- a/Modules/Collateral/Collateral/Application/Features/BlockReappraisal/GetBlockReappraisalDueList/GetBlockReappraisalDueListQuery.cs
+++ b/Modules/Collateral/Collateral/Application/Features/BlockReappraisal/GetBlockReappraisalDueList/GetBlockReappraisalDueListQuery.cs
@@ -10,6 +10,8 @@ public record GetBlockReappraisalDueListQuery(
     DateTime? LastAppraisedDateTo,
     int? RemainingDayMin,
     int? RemainingDayMax,
+    string? SortBy,
+    string? SortDir,
     PaginationRequest PaginationRequest) : IQuery<GetBlockReappraisalDueListResult>;
 
 public record GetBlockReappraisalDueListResult(PaginatedResult<BlockReappraisalDueListItem> Items);

--- a/Modules/Collateral/Collateral/Application/Features/BlockReappraisal/GetBlockReappraisalDueList/GetBlockReappraisalDueListQueryHandler.cs
+++ b/Modules/Collateral/Collateral/Application/Features/BlockReappraisal/GetBlockReappraisalDueList/GetBlockReappraisalDueListQueryHandler.cs
@@ -47,11 +47,32 @@ public class GetBlockReappraisalDueListQueryHandler(
             ? "WHERE " + string.Join(" AND ", conditions)
             : "";
 
+        // Whitelist sortable columns to defeat SQL injection. DueDate is the stable
+        // tiebreaker (and the default order), so it is intentionally not selectable here.
+        var sortColumn = query.SortBy?.ToLowerInvariant() switch
+        {
+            "oldappraisalnumber"  => "OldAppraisalNumber",
+            "projectname"         => "ProjectName",
+            "projectsellingprice" => "ProjectSellingPrice",
+            "remainingunits"      => "RemainingUnits",
+            "lastappraiseddate"   => "LastAppraisedDate",
+            "remainingday"        => "RemainingDay",
+            _                     => null
+        };
+
+        var sortDir = string.Equals(query.SortDir, "asc", StringComparison.OrdinalIgnoreCase)
+            ? "ASC"
+            : "DESC";
+
+        var orderBy = sortColumn is not null
+            ? $"{sortColumn} {sortDir}, DueDate ASC"
+            : "DueDate ASC";
+
         var sql = $"SELECT * FROM collateral.vw_BlockReappraisalDueList {where}";
 
         var result = await connectionFactory.QueryPaginatedAsync<BlockReappraisalDueListItem>(
             sql,
-            "DueDate ASC",
+            orderBy,
             query.PaginationRequest,
             parameters);
 


### PR DESCRIPTION
## Summary
- Updates `BlockReappraisalEndpoints` and the `GetBlockReappraisalDueList` query/handler.
- Updates `vw_BlockMaintenanceList`.

Pairs with the frontend `feature/block-reappraisal` PR.

## Test plan
- `dotnet build` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)