### PR TITLE
fix(workflow): bind RabbitMQ endpoint for AppraisalValueChangedIntegr…

### DIFF
--- a/Bootstrapper/Api/Program.cs
+++ b/Bootstrapper/Api/Program.cs
@@ -212,6 +212,18 @@ builder.Services.AddMassTransit(config =>
             e.UsePartitioner<AppointmentDateChangedIntegrationEvent>(partitioner, m => m.Message.AppraisalId);
         });
 
+        // Appraisal value changed — drives the approval-tier switch (meeting vs direct committee) by
+        // writing appraisalValue into WorkflowInstance.Variables. Partitioned by AppraisalId so multiple
+        // pricing recomputes for the same appraisal serialize (no out-of-order stale appraisalValue write).
+        // Consumer is [ExcludeFromConfigureEndpoints] to prevent ConfigureEndpoints from also creating an
+        // unordered auto-queue.
+        configurator.ReceiveEndpoint("workflow-appraisal-value-changed", e =>
+        {
+            var partitioner = e.CreatePartitioner(16);
+            e.ConfigureConsumer<AppraisalValueChangedIntegrationEventConsumer>(context);
+            e.UsePartitioner<AppraisalValueChangedIntegrationEvent>(partitioner, m => m.Message.AppraisalId);
+        });
+
         // #7 PMA external-sync status round-trip — the Integration module's WebhookDispatchConsumer
         // publishes this after every PMA save's delivery attempt. Partitioned by AppraisalId so
         // multiple round-tripped status events for the same appraisal serialize relative to EACH


### PR DESCRIPTION
…ationEventConsumer

The consumer that writes `appraisalValue` into WorkflowInstance.Variables is marked [ExcludeFromConfigureEndpoints] but had no matching manual ReceiveEndpoint, so ConfigureEndpoints skipped it and no queue was ever bound. The outbox relay published AppraisalValueChangedIntegrationEvent to an exchange with no bound queue — the message was silently dropped (outbox row still marked Processed), so `appraisalValue` never appeared in the workflow variables even when the appraisal had a computed appraised value.

Add a partitioned receive endpoint mirroring workflow-appointment-changed. Partition by AppraisalId so concurrent pricing recomputes for the same appraisal serialize and an out-of-order older event can't overwrite a newer appraisalValue.


Claude-Session: https://claude.ai/code/session_01AFf4SdmqB2aP3c1uRbbhWV