### PR TITLE
Collateral alias model, host-id backfill, regulatory export, monitoring enrichment, webhook re-auth

### DIFF
--- a/Database/Scripts/Maintenance/BackfillPendingTaskOpenedAt.sql
+++ b/Database/Scripts/Maintenance/BackfillPendingTaskOpenedAt.sql
@@ -1,0 +1,42 @@
+/*==============================================================================
+  BackfillPendingTaskOpenedAt.sql
+  ------------------------------------------------------------------------------
+  Purpose : Populate workflow.PendingTasks.OpenedAt for tasks that were already
+            opened (InProgress) before the column was added. New opens self-
+            populate (OpenTask/StartTask -> PendingTask.StartWorking stamps
+            OpenedAt = DateTime.Now on the first InProgress transition); this
+            one-time script fills the historical rows so the Monitoring "Open
+            Date" column shows a value instead of "—".
+
+  Run this MANUALLY (SSMS / sqlcmd). It is NOT part of DbUp/EF migrations.
+
+  DEFAULT VALUE:
+    We never recorded when these historical tasks were actually opened, so there
+    is no true source. Per request, OpenedAt is defaulted to AssignedAt — the
+    earliest defensible lower bound (a task can only be opened at or after it was
+    assigned). Treat these backfilled values as approximate.
+
+  SCOPE — only OPENED tasks:
+    Only tasks currently InProgress have been opened. Tasks still in 'Assigned'
+    have NOT been opened yet and are intentionally left NULL so they stamp a real
+    OpenedAt the first time a user opens them.
+
+  IDEMPOTENT: only touches rows where OpenedAt IS NULL and TaskStatus =
+    'InProgress'. Re-running affects 0 rows.
+==============================================================================*/
+
+SET NOCOUNT ON;
+-- Ensure any runtime error aborts and rolls back the transaction rather than leaving it
+-- open (holding locks on live workflow.PendingTasks) for an operator to clean up by hand.
+SET XACT_ABORT ON;
+
+BEGIN TRANSACTION;
+
+UPDATE workflow.PendingTasks
+SET    OpenedAt = AssignedAt
+WHERE  OpenedAt IS NULL
+  AND  TaskStatus = 'InProgress';
+
+PRINT CONCAT('Backfilled OpenedAt on ', @@ROWCOUNT, ' opened pending task(s).');
+
+COMMIT TRANSACTION;

--- a/Database/Scripts/Views/Appraisal/vw_AppraisalEvaluationList.sql
+++ b/Database/Scripts/Views/Appraisal/vw_AppraisalEvaluationList.sql
@@ -43,7 +43,14 @@ SELECT
                     + (ISNULL(w.W4, 0) * ISNULL(e.Criteria4Rating, 0))
                     + (ISNULL(w.W5, 0) * ISNULL(e.Criteria5Rating, 0))
             AS DECIMAL(5, 2))
-        END                                 AS TotalScore
+        END                                 AS TotalScore,
+
+    -- Internal followup staff: the bank-side user attached to the current external
+    -- assignment (AppraisalAssignment.InternalAppraiserId, stored as a username).
+    -- Name is resolved from auth.AspNetUsers, mirroring vw_AppraisalEvaluationHeader.
+    ext.InternalAppraiserId                 AS InternalFollowupStaffId,
+    NULLIF(LTRIM(RTRIM(CONCAT(u.FirstName, ' ', u.LastName))), '')
+                                            AS InternalFollowupStaffName
 
 FROM appraisal.Appraisals a
 
@@ -60,6 +67,7 @@ FROM appraisal.Appraisals a
             aa.AppraisalId,
             aa.ExternalAppraiserName,
             aa.AssigneeCompanyId,
+            aa.InternalAppraiserId,
             aa.SubmittedAt,
             ROW_NUMBER() OVER (PARTITION BY aa.AppraisalId ORDER BY aa.AssignedAt DESC, aa.CreatedAt DESC, aa.Id DESC) AS rn
         FROM appraisal.AppraisalAssignments aa
@@ -67,6 +75,10 @@ FROM appraisal.Appraisals a
           AND aa.AssignmentStatus NOT IN ('Rejected', 'Cancelled')
     ) ext
 ON ext.AppraisalId = a.Id AND ext.rn = 1
+
+    -- Internal followup staff display name (person-assigned; username -> AspNetUsers)
+    LEFT JOIN auth.AspNetUsers u
+    ON u.NormalizedUserName = UPPER(ext.InternalAppraiserId)
 
     -- Final appraised value
     LEFT JOIN appraisal.ValuationAnalyses va ON va.AppraisalId = a.Id

--- a/Database/Scripts/Views/Collateral/vw_RegulatoryExport.sql
+++ b/Database/Scripts/Views/Collateral/vw_RegulatoryExport.sql
@@ -57,20 +57,6 @@ LatestEngagement AS (
     FROM collateral.CollateralEngagements e
 ),
 
--- Previous engagement per master: the 2nd-most-recent (rn=2 of the same DESC order as Latest).
--- Feeds the "Application Id" field (the previous appraisal number, not the earliest). NULL when the
--- master has only one engagement → writer emits blank.
-PreviousEngagement AS (
-    SELECT
-        e.CollateralMasterId,
-        e.AppraisalNumber  AS PreviousAppraisalNumber,
-        ROW_NUMBER() OVER (
-            PARTITION BY e.CollateralMasterId
-            ORDER BY e.AppraisalDate DESC, e.CreatedAt DESC, e.Id DESC
-        ) AS rn
-    FROM collateral.CollateralEngagements e
-),
-
 -- Latest Progressive (construction-inspection) engagement per master
 LatestProgressiveEngagement AS (
     SELECT
@@ -106,9 +92,6 @@ SELECT
     m.Id                                                        AS CollateralMasterId,
     m.CollateralType,
     m.HostCollateralId,
-
-    -- Previous engagement (2nd-most-recent) → "Application Id" field
-    prev.PreviousAppraisalNumber,
 
     -- Earliest engagement (feeds first valuation date + origination value)
     ee.EarliestAppraisalDate,
@@ -203,11 +186,6 @@ LEFT JOIN EarliestEngagement ee
 LEFT JOIN LatestEngagement le
     ON  le.CollateralMasterId = m.Id
     AND le.rn                 = 1
-
--- Previous engagement (rn=2 → the 2nd-most-recent)
-LEFT JOIN PreviousEngagement prev
-    ON  prev.CollateralMasterId = m.Id
-    AND prev.rn                 = 2
 
 -- Latest Progressive engagement (rn=1)
 LEFT JOIN LatestProgressiveEngagement pe

--- a/Database/Scripts/Views/Common/vw_MonitoringPendingTasks.sql
+++ b/Database/Scripts/Views/Common/vw_MonitoringPendingTasks.sql
@@ -51,9 +51,16 @@ SELECT
     pt.TaskDescription                                                          AS TaskDescription,
     r.Purpose                                                                   AS Purpose,
     rp.PropertyType                                                             AS PropertyType,
+    appl.Status                                                                 AS AppraisalStatus,
     pt.SlaStatus                                                                AS SlaStatus,
     appl.RequestedAt                                                            AS RequestedDate,
     pt.AssignedAt                                                               AS AssignedDate,
+    -- OpenDate: when the assignee first opened the task (first InProgress transition). Null while unopened.
+    pt.OpenedAt                                                                 AS OpenDate,
+    -- AppointmentDate: latest non-cancelled appointment for the active assignment. Null when none scheduled.
+    appt.AppointmentDateTime                                                    AS AppointmentDate,
+    -- SlaDurationHours: resolved SLA policy budget (e.g. 48) driving the due date. Null when no policy.
+    pt.SlaDurationHours                                                         AS SlaDurationHours,
     -- M1: PIC display name resolution.
     --     type='1' (person)  → "First Last" from auth.AspNetUsers; NULL if names are empty so
     --                          the FE can render the username as the primary line.
@@ -95,7 +102,7 @@ FROM workflow.PendingTasks pt
     -- C4 fix: OUTER APPLY TOP 1 prevents fan-out when a Request has multiple Appraisals
     OUTER APPLY (
         SELECT TOP 1 a2.Id, a2.AppraisalNumber,
-                     a2.RequestedAt, a2.Priority
+                     a2.RequestedAt, a2.Priority, a2.Status
         FROM appraisal.Appraisals a2
         WHERE a2.RequestId = r.Id
         ORDER BY a2.RequestedAt DESC, a2.Id DESC
@@ -116,7 +123,7 @@ FROM workflow.PendingTasks pt
     -- C4 fix: OUTER APPLY TOP 1 prevents fan-out from multiple active AppraisalAssignments
     --         during reassignment windows. Most-recent active External first, then any active.
     OUTER APPLY (
-        SELECT TOP 1 aa2.AssignmentType, aa2.AssignmentStatus, aa2.SubmittedAt,
+        SELECT TOP 1 aa2.Id, aa2.AssignmentType, aa2.AssignmentStatus, aa2.SubmittedAt,
                      aa2.AssigneeCompanyId
         FROM appraisal.AppraisalAssignments aa2
         WHERE aa2.AppraisalId = appl.Id
@@ -126,6 +133,14 @@ FROM workflow.PendingTasks pt
             CASE WHEN aa2.AssignmentType = 'External' THEN 0 ELSE 1 END,
             aa2.AssignedAt DESC, aa2.Id DESC
     ) aa
+    -- Appointment date for the active assignment; most-recent non-cancelled appointment.
+    OUTER APPLY (
+        SELECT TOP 1 ap.AppointmentDateTime
+        FROM appraisal.Appointments ap
+        WHERE ap.AssignmentId = aa.Id
+          AND ap.Status <> 'Cancelled'
+        ORDER BY ap.AppointmentDateTime DESC
+    ) appt
     -- M1: join user for display name (person-assigned tasks only)
     LEFT JOIN auth.AspNetUsers u
            ON u.NormalizedUserName = UPPER(pt.AssignedTo)

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/Appraisal.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/Appraisal.cs
@@ -964,15 +964,17 @@ public class Appraisal : Aggregate<Guid>
                 $"Cannot complete appraisal: property #{propertyNum} (Land) is missing land detail.");
         }
 
-        // Validate title: at least one title with a non-empty TitleNumber
+        // Required fields mirror the Land collateral dedup key:
+        // TitleNumber + TitleType + Province + District + SubDistrict. LandOffice is not a key field.
         if (detail.Titles.Count == 0 || detail.Titles.All(t => string.IsNullOrWhiteSpace(t.TitleNumber)))
         {
             missing.Add("TitleNumber (at least one title must have a non-empty TitleNumber)");
         }
 
-        // LandOffice stored as controlled-list dropdown value — treated as LandOfficeCode
-        if (string.IsNullOrWhiteSpace(detail.Address?.LandOffice))
-            missing.Add("LandOffice (LandOfficeCode)");
+        if (detail.Titles.Count == 0 || detail.Titles.All(t => string.IsNullOrWhiteSpace(t.TitleType)))
+        {
+            missing.Add("TitleType (at least one title must have a non-empty TitleType)");
+        }
 
         if (string.IsNullOrWhiteSpace(detail.Address?.Province))
             missing.Add("Province");
@@ -1002,10 +1004,9 @@ public class Appraisal : Aggregate<Guid>
                 $"Cannot complete appraisal: property #{propertyNum} (Condo) is missing condo detail.");
         }
 
-        // LandOffice stored as controlled-list dropdown value — treated as LandOfficeCode
-        if (string.IsNullOrWhiteSpace(detail.Address?.LandOffice))
-            missing.Add("LandOffice (LandOfficeCode)");
-
+        // Required fields mirror the Condo collateral dedup key:
+        // CondoRegistrationNumber + BuildingNumber + FloorNumber + RoomNumber + Province + District + SubDistrict.
+        // LandOffice and unit-deed TitleNumber/TitleType are not key fields (condo dedup uses BuiltOnTitleNumber).
         if (string.IsNullOrWhiteSpace(detail.CondoRegistrationNumber))
             missing.Add("CondoRegistrationNumber");
         if (string.IsNullOrWhiteSpace(detail.BuildingNumber))
@@ -1015,11 +1016,12 @@ public class Appraisal : Aggregate<Guid>
         if (string.IsNullOrWhiteSpace(detail.RoomNumber))
             missing.Add("RoomNumber (UnitNumber)");
 
-        // Unit deed identifiers required for collateral master dedup
-        if (string.IsNullOrWhiteSpace(detail.TitleNumber))
-            missing.Add("TitleNumber (unit deed number)");
-        if (string.IsNullOrWhiteSpace(detail.TitleType))
-            missing.Add("TitleType (unit deed type)");
+        if (string.IsNullOrWhiteSpace(detail.Address?.Province))
+            missing.Add("Province");
+        if (string.IsNullOrWhiteSpace(detail.Address?.District))
+            missing.Add("District (Amphur)");
+        if (string.IsNullOrWhiteSpace(detail.Address?.SubDistrict))
+            missing.Add("SubDistrict (Tambon)");
 
         if (missing.Count > 0)
         {

--- a/Modules/Auth/Auth/Infrastructure/Seed/MenuSeedData.cs
+++ b/Modules/Auth/Auth/Infrastructure/Seed/MenuSeedData.cs
@@ -145,6 +145,7 @@ public static class MenuSeedData
             {
                 new("main.collateral-master.catalog", "Catalog", "list", IconStyle.Solid, "text-cyan-500", "/admin/collateral-masters", "COLLATERAL_ADMIN", null),
                 new("main.collateral-master.backfill", "Backfill Report", "rotate", IconStyle.Solid, "text-cyan-500", "/admin/collateral-masters/backfill", "COLLATERAL_ADMIN", null),
+                new("main.collateral-master.host-id-backfill", "Host ID Backfill", "id-card", IconStyle.Solid, "text-cyan-500", "/admin/collateral-masters/host-id-backfill", "COLLATERAL_ADMIN", null),
             }),
         new("main.workflow-builder", "Workflow Builder", "diagram-project", IconStyle.Solid, "text-orange-500", "/workflow-builder", "WORKFLOW_MANAGE", "WORKFLOW_MANAGE",
             new List<MenuSeedNode>

--- a/Modules/Collateral/Collateral.Contracts/FileInterface/IRegulatoryExportQuery.cs
+++ b/Modules/Collateral/Collateral.Contracts/FileInterface/IRegulatoryExportQuery.cs
@@ -15,7 +15,6 @@ public interface IRegulatoryExportQuery
 /// Produced by <c>RegulatoryExportQuery</c> via <c>vw_RegulatoryExport</c>.
 /// </summary>
 public sealed record RegulatoryExportRow(
-    string? PreviousAppraisalNumber,
     string? LatestAppraisalNumber,
     string CollateralType,
     string? HostCollateralId,

--- a/Modules/Collateral/Collateral/Application/Features/CollateralMasters/BackfillHostCollateralId/BackfillHostCollateralIdEndpoint.cs
+++ b/Modules/Collateral/Collateral/Application/Features/CollateralMasters/BackfillHostCollateralId/BackfillHostCollateralIdEndpoint.cs
@@ -1,0 +1,49 @@
+using Collateral.CollateralMasters.Services;
+using Shared.Identity;
+using Shared.Time;
+
+namespace Collateral.Application.Features.CollateralMasters.BackfillHostCollateralId;
+
+/// <summary>
+/// POST /collateral-masters/admin/backfill-host-collateral-id
+/// Admin-only. Kicks off the standalone host-collateral-id backfill in the background.
+/// Returns JobId + StartedAt immediately without waiting for the job to finish.
+/// </summary>
+public class BackfillHostCollateralIdEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPost(
+                "/collateral-masters/admin/backfill-host-collateral-id",
+                (
+                    HostCollateralIdBackfillJob job,
+                    ICurrentUserService currentUser,
+                    IDateTimeProvider dateTimeProvider
+                ) =>
+                {
+                    if (!currentUser.IsInRole("Admin") && !currentUser.IsInRole("IntAdmin"))
+                        throw new UnauthorizedAccessException(
+                            "Only Admin users can trigger the host-collateral-id backfill job.");
+
+                    // Do not pass the request CancellationToken — this is fire-and-forget and the
+                    // request token cancels as soon as the response returns. The job runs under the
+                    // host's ApplicationStopping token instead (see HostCollateralIdBackfillJob.StartAsync).
+                    var jobId = job.StartAsync();
+                    var startedAt = dateTimeProvider.ApplicationNow;
+
+                    return Results.Ok(new BackfillHostCollateralIdResponse(jobId, startedAt));
+                }
+            )
+            .WithName("StartHostCollateralIdBackfill")
+            .Produces<BackfillHostCollateralIdResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .WithSummary("Start host-collateral-id backfill job (admin)")
+            .WithDescription(
+                "Copies the AS400 HostCollateralId already stamped on appraisal source rows onto the owning "
+                + "CollateralMaster (one per appraisal). Idempotent. Returns job id immediately.")
+            .WithTags("CollateralMaster")
+            .RequireAuthorization();
+    }
+}
+
+public record BackfillHostCollateralIdResponse(Guid JobId, DateTime StartedAt);

--- a/Modules/Collateral/Collateral/CollateralMasters/Models/CollateralMaster.cs
+++ b/Modules/Collateral/Collateral/CollateralMasters/Models/CollateralMaster.cs
@@ -258,6 +258,44 @@ public class CollateralMaster : Aggregate<Guid>
     }
 
     /// <summary>
+    /// Demotes an existing IsMaster row to a typed alias of the appraisal's primary collateral.
+    /// Used by the one-collateral-per-appraisal upsert path when a legacy standalone master
+    /// (e.g. a Condo/Machine/Leasehold master created before this model existed) is discovered
+    /// as a NON-primary component of an appraisal being (re)processed. The row keeps its own
+    /// type detail (CondoDetail/MachineDetail/LeaseholdDetail) — only IsMaster/ParentMasterId flip.
+    /// Guarded against demoting a row that already owns engagements: under the
+    /// one-collateral-per-appraisal invariant, only the primary ever accumulates engagements
+    /// (CollateralMasterUpsertService.AppendEngagement always targets the primary), so a non-primary
+    /// row reaching this method with engagements attached indicates a bug upstream — fail loudly
+    /// instead of silently orphaning engagement history.
+    /// </summary>
+    public void DemoteToAlias(Guid parentMasterId)
+    {
+        if (Engagements.Count > 0)
+            throw new InvalidOperationException(
+                $"Cannot demote CollateralMaster {Id} to an alias of {parentMasterId}: it already owns " +
+                $"{Engagements.Count} engagement(s). This should not happen under the one-collateral-per-appraisal " +
+                "model — investigate before retrying.");
+
+        IsMaster = false;
+        ParentMasterId = parentMasterId;
+    }
+
+    /// <summary>
+    /// Promotes a typed alias back to a standalone IsMaster — used when a component that was
+    /// previously demoted under a different appraisal's primary is now, in THIS appraisal, the
+    /// primary collateral in its own right (e.g. a Condo alias reappraised standalone). Aliases
+    /// never accumulate engagements (see DemoteToAlias's guard), so promotion is always safe.
+    /// Idempotent no-op if already a master.
+    /// </summary>
+    public void PromoteToMaster()
+    {
+        if (IsMaster) return;
+        IsMaster = true;
+        ParentMasterId = null;
+    }
+
+    /// <summary>
     /// Creates a PRJ (block-project) master. Always IsMaster=true, ParentMasterId=null.
     /// Attaches a fresh ProjectDetail; caller must subsequently call UpsertFromProjectAppraisal.
     /// </summary>
@@ -404,6 +442,44 @@ public class CollateralMaster : Aggregate<Guid>
         return master;
     }
 
+    /// <summary>
+    /// Creates an alias row for a Condo component that is NOT the appraisal's primary collateral
+    /// (one-collateral-per-appraisal model). Unlike Land aliases, a Condo alias keeps its OWN full
+    /// CondoDetail — only IsMaster/ParentMasterId mark it as structurally subordinate to the primary.
+    /// No domain event — alias creation is a structural detail, not a business event.
+    /// </summary>
+    public static CollateralMaster CreateCondoAlias(
+        Guid parentMasterId,
+        string ownerName,
+        string? landOfficeCode,
+        string condoRegistrationNumber,
+        string buildingNumber,
+        string floorNumber,
+        string roomNumber,
+        string province,
+        string district,
+        string subDistrict,
+        string? condoName)
+    {
+        var alias = new CollateralMaster
+        {
+            Id = Guid.CreateVersion7(),
+            CollateralType = CollateralTypes.Condo, // "U"
+            OwnerName = ownerName,
+            IsDeleted = false,
+            IsMaster = false,
+            ParentMasterId = parentMasterId,
+        };
+
+        alias.CondoDetail = new CondoDetail(
+            alias.Id,
+            landOfficeCode, condoRegistrationNumber, buildingNumber, floorNumber, roomNumber,
+            province, district, subDistrict, condoName,
+            isDeleted: false);
+
+        return alias;
+    }
+
     public static CollateralMaster CreateLeasehold(
         string lessee,
         string leaseRegistrationNo,
@@ -439,6 +515,44 @@ public class CollateralMaster : Aggregate<Guid>
         return master;
     }
 
+    /// <summary>
+    /// Creates an alias row for a Leasehold component that is NOT the appraisal's primary collateral
+    /// (one-collateral-per-appraisal model). Keeps its OWN full LeaseholdDetail (including the
+    /// UnderlyingMasterId FK, unrelated to the IsMaster/ParentMasterId hierarchy) — only
+    /// IsMaster/ParentMasterId mark it as structurally subordinate to the primary.
+    /// No domain event — alias creation is a structural detail, not a business event.
+    /// </summary>
+    public static CollateralMaster CreateLeaseholdAlias(
+        Guid parentMasterId,
+        string lessee,
+        string leaseRegistrationNo,
+        Guid underlyingMasterId,
+        string lessor,
+        DateOnly leaseTermStart,
+        string? collateralType = null)
+    {
+        var effectiveType = string.IsNullOrWhiteSpace(collateralType)
+            ? CollateralTypes.Leasehold
+            : collateralType;
+
+        var alias = new CollateralMaster
+        {
+            Id = Guid.CreateVersion7(),
+            CollateralType = effectiveType,
+            OwnerName = lessee,
+            IsDeleted = false,
+            IsMaster = false,
+            ParentMasterId = parentMasterId,
+        };
+
+        alias.LeaseholdDetail = new LeaseholdDetail(
+            alias.Id,
+            leaseRegistrationNo, underlyingMasterId, lessor, lessee, leaseTermStart,
+            isDeleted: false);
+
+        return alias;
+    }
+
     public static CollateralMaster CreateMachine(
         string ownerName,
         string? machineRegistrationNo,
@@ -464,6 +578,39 @@ public class CollateralMaster : Aggregate<Guid>
 
         master.AddDomainEvent(new CollateralMasterCreatedEvent(master.Id, master.CollateralType));
         return master;
+    }
+
+    /// <summary>
+    /// Creates an alias row for a Machine component that is NOT the appraisal's primary collateral
+    /// (one-collateral-per-appraisal model). Keeps its OWN full MachineDetail — only
+    /// IsMaster/ParentMasterId mark it as structurally subordinate to the primary.
+    /// No domain event — alias creation is a structural detail, not a business event.
+    /// </summary>
+    public static CollateralMaster CreateMachineAlias(
+        Guid parentMasterId,
+        string ownerName,
+        string? machineRegistrationNo,
+        string? serialNo,
+        string? brand,
+        string? model,
+        string? manufacturer)
+    {
+        var alias = new CollateralMaster
+        {
+            Id = Guid.CreateVersion7(),
+            CollateralType = CollateralTypes.Machine,
+            OwnerName = ownerName,
+            IsDeleted = false,
+            IsMaster = false,
+            ParentMasterId = parentMasterId,
+        };
+
+        alias.MachineDetail = new MachineDetail(
+            alias.Id,
+            machineRegistrationNo, serialNo, brand, model, manufacturer,
+            isDeleted: false);
+
+        return alias;
     }
 
     /// <summary>

--- a/Modules/Collateral/Collateral/CollateralMasters/RegulatoryExport/RegulatoryExportQuery.cs
+++ b/Modules/Collateral/Collateral/CollateralMasters/RegulatoryExport/RegulatoryExportQuery.cs
@@ -16,7 +16,6 @@ public class RegulatoryExportQuery(ISqlConnectionFactory connectionFactory) : IR
     }
 
     private static RegulatoryExportRow Map(RawRow r) => new(
-        PreviousAppraisalNumber: r.PreviousAppraisalNumber,
         LatestAppraisalNumber: r.LatestAppraisalNumber,
         CollateralType: r.CollateralType,
         HostCollateralId: r.HostCollateralId,
@@ -43,7 +42,6 @@ public class RegulatoryExportQuery(ISqlConnectionFactory connectionFactory) : IR
         public Guid CollateralMasterId { get; init; }
         public string CollateralType { get; init; } = null!;
         public string? HostCollateralId { get; init; }
-        public string? PreviousAppraisalNumber { get; init; }
         public string? LatestAppraisalNumber { get; init; }
         public string? LatestAppraisalType { get; init; }
         public bool IsUnderConstruction { get; init; }

--- a/Modules/Collateral/Collateral/CollateralMasters/Services/CollateralMasterUpsertService.cs
+++ b/Modules/Collateral/Collateral/CollateralMasters/Services/CollateralMasterUpsertService.cs
@@ -98,21 +98,52 @@ public class CollateralMasterUpsertService(
         var grouped = GroupPropertiesByGroup(inScopeProperties);
 
         // -----------------------------------------------------------------------
+        // One-collateral-per-appraisal: determine the SINGLE primary component up front.
+        // This is pure data (no DB access) so it's stable for the whole method:
+        //   - If ANY Land/LB property exists, the collapsed land master is UNCONDITIONALLY the
+        //     primary (land always wins — confirmed product rule).
+        //   - Otherwise, the group with the lowest GroupNumber is primary (ties keep the original
+        //     property order — same tie-break the snapshot builder already used).
+        // Every OTHER group's CollateralMaster becomes a typed ALIAS of the primary (IsMaster=false,
+        // ParentMasterId=primary.Id) while keeping its own type detail — see CreateCondoAlias /
+        // CreateMachineAlias / CreateLeaseholdAlias / CollateralMaster.DemoteToAlias.
+        // -----------------------------------------------------------------------
+        const string LandPrimaryGroupKey = "land:all";
+        string? primaryGroupKey = landOrLbProperties.Count > 0
+            ? LandPrimaryGroupKey
+            : grouped.Count > 0
+                ? grouped.OrderBy(g => g.GroupNumber ?? int.MaxValue).First().GroupKey
+                : null;
+
+        // Resolved once the primary group's master has been processed. Non-primary groups alias
+        // to this master's Id. Passes are ordered (primary group first within each pass) so this
+        // is populated before any non-primary group needs it — see the reordering below.
+        CollateralMaster? primaryMaster = null;
+
+        // -----------------------------------------------------------------------
         // Pass 1: Land + Condo + Machine — process each group
         // Pass-1 cache for Leasehold's underlying-resolution.
         // -----------------------------------------------------------------------
         var landMasterByPropertyId = new Dictionary<Guid, CollateralMaster>();
-        // Track IsMaster for each group so we can build the snapshot
+        // Track IsMaster for each group so we can build the snapshot. NOTE: a single group that
+        // holds two non-land types (e.g. Condo + Leasehold sharing a GroupNumber) overwrites this
+        // dict by GroupKey — the reconciliation step below must NOT rely on this dict alone, see
+        // resolvedNonLandMasters.
         var groupIsMasters = new Dictionary<string, CollateralMaster>(); // groupKey → IsMaster
         // Track newly-created + existing aliases for each land group (for snapshot + UnitPrice propagation)
         var groupAliases = new Dictionary<string, List<CollateralMaster>>(); // groupKey → alias list
         // Track the resolved CollateralType per group (for engagement stamping)
         var groupCollateralTypes = new Dictionary<string, string>(); // groupKey → CollateralType code
+        // Every non-land master/alias resolved or created in passes 1 & 2 — the reconciliation
+        // safety net below walks THIS list (not groupIsMasters, which can lose entries when one
+        // group holds two non-land types) so no resolved master is ever missed.
+        var resolvedNonLandMasters = new List<CollateralMaster>();
 
         // Land: ONE IsMaster per appraisal. All Land/LB titles across ALL groups collapse into a
         // single IsMaster + aliases set (first title = IsMaster, every other title = alias).
         // UpsertLandGroupAsync already does "first title → IsMaster, all remaining titles across all
         // passed properties → aliases", so feeding it the full land set yields exactly one master.
+        // Land is unconditionally the appraisal's primary when present — see primaryGroupKey above.
         CollateralMaster? landMaster = null;
         var landAliases = new List<CollateralMaster>();
         string? landCollateralType = null;
@@ -127,72 +158,131 @@ public class CollateralMasterUpsertService(
             landGroupNumber = grouped
                 .Where(g => g.Properties.Any(p => p.PropertyTypeCode is "L" or "LB"))
                 .Min(g => g.GroupNumber ?? int.MaxValue);
+            primaryMaster = landMaster;
         }
 
-        // Condo / Machine: unchanged — one IsMaster per group. A group that contains land is a land
-        // group; its condo/machine props are ignored (preserves the original land-wins else-if).
-        foreach (var group in grouped)
+        // Condo / Machine: one IsMaster row per appraisal overall — only the group matching
+        // primaryGroupKey stays IsMaster=true; every other non-land group becomes a typed alias of
+        // the primary. The primary-matching group (if it lives in this pass) is processed FIRST so
+        // primaryMaster is resolved before any alias creation needs its Id.
+        foreach (var group in grouped
+                     .Where(g => g.Properties.All(p => p.PropertyTypeCode is not "L" and not "LB"))
+                     .OrderBy(g => g.GroupKey == primaryGroupKey ? 0 : 1))
         {
-            if (group.Properties.Any(p => p.PropertyTypeCode is "L" or "LB"))
-                continue; // land handled above (one master per appraisal)
-
             var condoInGroup = group.Properties.Where(p => p.PropertyTypeCode == "U").ToList();
             var machineInGroup = group.Properties.Where(p => p.PropertyTypeCode == "MAC").ToList();
+            bool isPrimaryGroup = group.GroupKey == primaryGroupKey;
 
             if (condoInGroup.Count > 0)
             {
                 // Condo — typically one per group (singleton)
-                var master = await UpsertCondoAsync(condoInGroup.First(), appraisal, ct);
+                var master = await UpsertCondoAsync(condoInGroup.First(), appraisal, isPrimaryGroup, primaryMaster?.Id, ct);
                 groupIsMasters[group.GroupKey] = master;
+                resolvedNonLandMasters.Add(master);
+                if (isPrimaryGroup) primaryMaster = master;
             }
             else if (machineInGroup.Count > 0)
             {
-                var master = await UpsertMachineAsync(machineInGroup.First(), appraisal, ct);
+                var master = await UpsertMachineAsync(machineInGroup.First(), appraisal, isPrimaryGroup, primaryMaster?.Id, ct);
                 groupIsMasters[group.GroupKey] = master;
+                resolvedNonLandMasters.Add(master);
+                if (isPrimaryGroup) primaryMaster = master;
             }
         }
 
         // -----------------------------------------------------------------------
         // Pass 2: Leasehold (depends on underlying master already existing or created)
+        // Same primary-first reordering as pass 1.
         // -----------------------------------------------------------------------
-        var leaseholdGroups = grouped.Where(g =>
-            g.Properties.Any(p => p.PropertyTypeCode is "LSL" or "LSB" or "LS")).ToList();
+        var leaseholdGroups = grouped
+            .Where(g => g.Properties.Any(p => p.PropertyTypeCode is "LSL" or "LSB" or "LS"))
+            .OrderBy(g => g.GroupKey == primaryGroupKey ? 0 : 1)
+            .ToList();
 
         foreach (var group in leaseholdGroups)
         {
             var lhProperty = group.Properties.First(p => p.PropertyTypeCode is "LSL" or "LSB" or "LS");
-            var master = await UpsertLeaseholdAsync(lhProperty, appraisal, landOrLbProperties, condoProperties, landMasterByPropertyId, ct);
+            bool isPrimaryGroup = group.GroupKey == primaryGroupKey;
+            var master = await UpsertLeaseholdAsync(
+                lhProperty, appraisal, landOrLbProperties, condoProperties, landMasterByPropertyId,
+                isPrimaryGroup, primaryMaster?.Id, ct);
             groupIsMasters[group.GroupKey] = master;
+            resolvedNonLandMasters.Add(master);
+            if (isPrimaryGroup) primaryMaster = master;
+        }
+
+        // -----------------------------------------------------------------------
+        // Reconciliation safety net: enforce "exactly one IsMaster per appraisal" even in the rare
+        // ordering edge case where a non-primary group had to be resolved before the primary was
+        // known (e.g. the primary is a Leasehold-only group with no Land/Condo/Machine in the same
+        // appraisal — Leasehold is processed last, in pass 2). Also catches legacy standalone
+        // masters left over from before this model that a group's dedup key happened to match.
+        // Walks resolvedNonLandMasters (not groupIsMasters, which loses entries when a single
+        // group holds two non-land types — e.g. Condo + Leasehold sharing a GroupNumber — because
+        // the second type's write overwrites the first in that dict). Deduped by Id since the same
+        // master can appear more than once (e.g. resolved once per property that maps to it).
+        //
+        // CORE RULE: a row that already owns engagement history was appraised standalone as its
+        // OWN collateral — it must stay IsMaster (cross-appraisal reuse), never demoted. Only
+        // engagement-free rows may become aliases. No-ops for every row already created correctly
+        // via the alias factories above.
+        // -----------------------------------------------------------------------
+        if (primaryMaster is not null)
+        {
+            foreach (var groupMaster in resolvedNonLandMasters
+                         .GroupBy(m => m.Id)
+                         .Select(g => g.First()))
+            {
+                if (groupMaster.Id == primaryMaster.Id || !groupMaster.IsMaster)
+                    continue;
+
+                if (groupMaster.Engagements.Count == 0)
+                {
+                    groupMaster.DemoteToAlias(primaryMaster.Id);
+                    logger.LogInformation(
+                        "ProcessAppraisalAsync: demoted CollateralMaster {MasterId} ({Type}) to a typed alias " +
+                        "of primary {PrimaryId} for AppraisalId={AppraisalId}",
+                        groupMaster.Id, groupMaster.CollateralType, primaryMaster.Id, appraisalId);
+                }
+                else
+                {
+                    logger.LogWarning(
+                        "ProcessAppraisalAsync: {Type} master {MasterId} was appraised standalone (has " +
+                        "{Count} engagement(s)); keeping it as its own IsMaster rather than demoting under " +
+                        "primary {PrimaryId} for AppraisalId={AppraisalId}.",
+                        groupMaster.CollateralType, groupMaster.Id, groupMaster.Engagements.Count,
+                        primaryMaster.Id, appraisalId);
+                }
+            }
         }
 
         // -----------------------------------------------------------------------
         // Build the snapshot bucket list: ONE consolidated land bucket (all land titles across all
         // groups, under the single IsMaster) + every non-land group (condo / machine / leasehold).
         // This collapses all land groups into one snapshot group, matching the
-        // one-IsMaster-per-appraisal model. Non-land groups keep their own IsMaster.
+        // one-IsMaster-per-appraisal model. Non-land groups reference their own (possibly aliased)
+        // master row.
         // -----------------------------------------------------------------------
         var snapshotBuckets = new List<PropertyGroupBucket>();
         if (landMaster is not null)
         {
-            snapshotBuckets.Add(new PropertyGroupBucket("land:all", null, landGroupNumber, landOrLbProperties));
-            groupIsMasters["land:all"] = landMaster;
-            groupAliases["land:all"] = landAliases;
-            groupCollateralTypes["land:all"] = landCollateralType!;
+            snapshotBuckets.Add(new PropertyGroupBucket(LandPrimaryGroupKey, null, landGroupNumber, landOrLbProperties));
+            groupIsMasters[LandPrimaryGroupKey] = landMaster;
+            groupAliases[LandPrimaryGroupKey] = landAliases;
+            groupCollateralTypes[LandPrimaryGroupKey] = landCollateralType!;
         }
         snapshotBuckets.AddRange(grouped
             .Where(g => g.Properties.All(p => p.PropertyTypeCode is not "L" and not "LB")));
 
         // -----------------------------------------------------------------------
-        // Build the single engagement snapshot covering ALL groups.
-        // Primary = group with the lowest GroupNumber (or lowest implicit sequence for ungrouped).
+        // Build the single engagement snapshot covering ALL groups, anchored on the SAME primary
+        // resolved above (primaryGroupKey / primaryMaster) — one-collateral-per-appraisal model.
         // -----------------------------------------------------------------------
-        if (snapshotBuckets.Count > 0)
+        if (snapshotBuckets.Count > 0 && primaryGroupKey is not null)
         {
-            var groupSnapshots = BuildGroupSnapshots(snapshotBuckets, groupIsMasters, groupAliases, appraisal, buildingProperties);
+            var groupSnapshots = BuildGroupSnapshots(snapshotBuckets, groupIsMasters, groupAliases, appraisal, buildingProperties, primaryGroupKey);
 
-            // Primary IsMaster = IsMaster of the principal group (first in ordered list)
-            var primaryGroup = snapshotBuckets.OrderBy(g => g.GroupNumber ?? int.MaxValue).First();
-            var primaryMaster = groupIsMasters.GetValueOrDefault(primaryGroup.GroupKey);
+            var primaryGroup = snapshotBuckets.First(g => g.GroupKey == primaryGroupKey);
 
             if (primaryMaster is not null)
             {
@@ -365,12 +455,13 @@ public class CollateralMasterUpsertService(
         {
             case "L" or "LB":
             {
+                // Dedup key is TitleNumber + TitleType + Province + District + SubDistrict
+                // (+ nullable SurveyNumber/LandParcelNumber/Rawang). LandOffice is descriptive, not a key field.
                 var land = p.LandIdentity;
                 if (land is null || !land.Titles.Any(t => !string.IsNullOrWhiteSpace(t.TitleNumber)))
                     missing.Add("TitleNumber");
                 if (land is null || !land.Titles.Any(t => !string.IsNullOrWhiteSpace(t.TitleType)))
                     missing.Add("TitleType");
-                if (string.IsNullOrWhiteSpace(land?.LandOffice)) missing.Add("LandOfficeCode");
                 if (string.IsNullOrWhiteSpace(land?.Province)) missing.Add("Province");
                 if (string.IsNullOrWhiteSpace(land?.District)) missing.Add("District");
                 if (string.IsNullOrWhiteSpace(land?.SubDistrict)) missing.Add("SubDistrict");
@@ -716,9 +807,33 @@ public class CollateralMasterUpsertService(
         return (master, newAliases, resolvedCollateralType);
     }
 
+    /// <summary>
+    /// When the resolved master for the appraisal's PRIMARY group turns out to be a typed alias
+    /// (e.g. this component was demoted under a different primary in a prior appraisal, and this
+    /// appraisal's composition now makes it the primary in its own right), PROMOTES it back to a
+    /// standalone IsMaster instead of walking to its (foreign, unrelated) parent — an alias never
+    /// owns engagements (DemoteToAlias's guard), so promotion is always safe and correct: this row
+    /// IS the collateral this appraisal is valuing, not whatever it used to be aliased under.
+    /// </summary>
+    private CollateralMaster PromotePrimaryIfAlias(CollateralMaster master, string componentType)
+    {
+        if (master.IsMaster) return master;
+
+        logger.LogInformation(
+            "{ComponentType} master {MasterId} resolved as the appraisal's primary but was a typed " +
+            "alias (ParentMasterId={ParentId}); promoting it to a standalone IsMaster " +
+            "(one-collateral-per-appraisal model).",
+            componentType, master.Id, master.ParentMasterId);
+
+        master.PromoteToMaster();
+        return master;
+    }
+
     private async Task<CollateralMaster> UpsertCondoAsync(
         AppraisalPropertyForCollateral p,
         AppraisalForCollateralResult appraisal,
+        bool isPrimary,
+        Guid? primaryMasterId,
         CancellationToken ct)
     {
         var condo = p.CondoIdentity!;
@@ -730,36 +845,62 @@ public class CollateralMasterUpsertService(
 
         if (master is null)
         {
-            master = CollateralMaster.CreateCondo(
-                ownerName: condo.OwnerName ?? string.Empty,
-                landOfficeCode: condo.LandOffice,
-                condoRegistrationNumber: condo.CondoRegistrationNumber!,
-                buildingNumber: condo.BuildingNumber!,
-                floorNumber: condo.FloorNumber!,
-                roomNumber: condo.RoomNumber!,
-                province: condo.Province!,
-                district: condo.District!,
-                subDistrict: condo.SubDistrict!,
-                condoName: condo.CondoName);
+            // New component. Non-primary components are born as typed aliases of the appraisal's
+            // primary collateral (one-collateral-per-appraisal model) whenever the primary is
+            // already known; otherwise they're born as regular masters and the reconciliation
+            // step in ProcessAppraisalAsync demotes them once the primary is resolved.
+            master = !isPrimary && primaryMasterId is { } pid
+                ? CollateralMaster.CreateCondoAlias(
+                    parentMasterId: pid,
+                    ownerName: condo.OwnerName ?? string.Empty,
+                    landOfficeCode: condo.LandOffice,
+                    condoRegistrationNumber: condo.CondoRegistrationNumber!,
+                    buildingNumber: condo.BuildingNumber!,
+                    floorNumber: condo.FloorNumber!,
+                    roomNumber: condo.RoomNumber!,
+                    province: condo.Province!,
+                    district: condo.District!,
+                    subDistrict: condo.SubDistrict!,
+                    condoName: condo.CondoName)
+                : CollateralMaster.CreateCondo(
+                    ownerName: condo.OwnerName ?? string.Empty,
+                    landOfficeCode: condo.LandOffice,
+                    condoRegistrationNumber: condo.CondoRegistrationNumber!,
+                    buildingNumber: condo.BuildingNumber!,
+                    floorNumber: condo.FloorNumber!,
+                    roomNumber: condo.RoomNumber!,
+                    province: condo.Province!,
+                    district: condo.District!,
+                    subDistrict: condo.SubDistrict!,
+                    condoName: condo.CondoName);
             repo.Add(master);
         }
-
-        if (!master.IsMaster)
+        else if (isPrimary)
         {
-            // Condo dedup-key matched an alias row.
-            // Resolve to the parent IsMaster and process against that parent.
-            // Validation upstream at the Request module prevents invalid alias-alone submissions.
-            logger.LogWarning(
-                "Condo master {MasterId} is an alias with ParentMasterId={ParentId}. " +
-                "Resolving to parent IsMaster (graceful re-anchor, PR-7).",
-                master.Id, master.ParentMasterId!.Value);
-
-            var parent = await repo.FindByIdWithEngagementsAsync(master.ParentMasterId!.Value, ct);
-            if (parent is null)
-                throw new InvalidOperationException(
-                    $"Condo alias {master.Id} references ParentMasterId={master.ParentMasterId} which could not be found.");
-            master = parent;
+            master = PromotePrimaryIfAlias(master, "Condo");
         }
+        else if (master.IsMaster && primaryMasterId is { } parentId)
+        {
+            // Legacy standalone master (or a master created before the primary was known within
+            // this same call) discovered as a non-primary component. Only demote it to a typed
+            // alias when it has NEVER been engaged standalone — a row with engagement history IS
+            // a real collateral in its own right and must stay IsMaster (cross-appraisal reuse).
+            if (master.Engagements.Count == 0)
+            {
+                master.DemoteToAlias(parentId);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "ProcessAppraisalAsync: {Type} master {MasterId} was appraised standalone (has " +
+                    "{Count} engagement(s)); keeping it as its own IsMaster rather than demoting under " +
+                    "primary {PrimaryId} for AppraisalId={AppraisalId}.",
+                    master.CollateralType, master.Id, master.Engagements.Count, parentId, appraisal.AppraisalId);
+            }
+        }
+        // else: dedup key already resolved to an alias row — upsert detail directly on THAT row.
+        // Do NOT re-anchor to its parent (that assumed land-only aliases and is wrong for typed
+        // component aliases under the one-collateral-per-appraisal model).
 
         // Pricing values — sourced from PricingFinalValue of the selected approach (PR-8).
         var pricingInfo = p.PricingInfo;
@@ -800,6 +941,8 @@ public class CollateralMasterUpsertService(
     private async Task<CollateralMaster> UpsertMachineAsync(
         AppraisalPropertyForCollateral p,
         AppraisalForCollateralResult appraisal,
+        bool isPrimary,
+        Guid? primaryMasterId,
         CancellationToken ct)
     {
         var m = p.MachineryIdentity!;
@@ -809,15 +952,44 @@ public class CollateralMasterUpsertService(
 
         if (master is null)
         {
-            master = CollateralMaster.CreateMachine(
-                ownerName: m.OwnerName ?? string.Empty,
-                machineRegistrationNo: m.RegistrationNumber,
-                serialNo: m.SerialNo,
-                brand: m.Brand,
-                model: m.Model,
-                manufacturer: m.Manufacturer);
+            master = !isPrimary && primaryMasterId is { } pid
+                ? CollateralMaster.CreateMachineAlias(
+                    parentMasterId: pid,
+                    ownerName: m.OwnerName ?? string.Empty,
+                    machineRegistrationNo: m.RegistrationNumber,
+                    serialNo: m.SerialNo,
+                    brand: m.Brand,
+                    model: m.Model,
+                    manufacturer: m.Manufacturer)
+                : CollateralMaster.CreateMachine(
+                    ownerName: m.OwnerName ?? string.Empty,
+                    machineRegistrationNo: m.RegistrationNumber,
+                    serialNo: m.SerialNo,
+                    brand: m.Brand,
+                    model: m.Model,
+                    manufacturer: m.Manufacturer);
             repo.Add(master);
         }
+        else if (isPrimary)
+        {
+            master = PromotePrimaryIfAlias(master, "Machine");
+        }
+        else if (master.IsMaster && primaryMasterId is { } parentId)
+        {
+            if (master.Engagements.Count == 0)
+            {
+                master.DemoteToAlias(parentId);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "ProcessAppraisalAsync: {Type} master {MasterId} was appraised standalone (has " +
+                    "{Count} engagement(s)); keeping it as its own IsMaster rather than demoting under " +
+                    "primary {PrimaryId} for AppraisalId={AppraisalId}.",
+                    master.CollateralType, master.Id, master.Engagements.Count, parentId, appraisal.AppraisalId);
+            }
+        }
+        // else: dedup key already resolved to an alias row — upsert detail directly on THAT row.
 
         var upsertData = new MachineUpsertData(
             IncomingRegistrationNo: m.RegistrationNumber,
@@ -837,6 +1009,8 @@ public class CollateralMasterUpsertService(
         List<AppraisalPropertyForCollateral> landProperties,
         List<AppraisalPropertyForCollateral> condoProperties,
         Dictionary<Guid, CollateralMaster> landMasterByPropertyId,
+        bool isPrimary,
+        Guid? primaryMasterId,
         CancellationToken ct)
     {
         var lh = p.LeaseholdIdentity!;
@@ -928,18 +1102,47 @@ public class CollateralMasterUpsertService(
 
         if (leaseMaster is null)
         {
-            leaseMaster = CollateralMaster.CreateLeasehold(
-                lessee: lh.LesseeName!,
-                leaseRegistrationNo: lh.ContractNo!,
-                underlyingMasterId: underlyingMaster.Id,
-                lessor: lh.LessorName!,
-                leaseTermStart: leaseTermStart,
-                // Pass the resolved code so a fresh LS/LSB master is born with the right
-                // discriminator — UpdateCollateralType below then no-ops on the insert path
-                // and only fires CollateralTypeChangedEvent for true L→LB-style upgrades.
-                collateralType: p.PropertyTypeCode);
+            // Pass the resolved code so a fresh LS/LSB master is born with the right discriminator
+            // — UpdateCollateralType below then no-ops on the insert path and only fires
+            // CollateralTypeChangedEvent for true L→LB-style upgrades.
+            leaseMaster = !isPrimary && primaryMasterId is { } pid
+                ? CollateralMaster.CreateLeaseholdAlias(
+                    parentMasterId: pid,
+                    lessee: lh.LesseeName!,
+                    leaseRegistrationNo: lh.ContractNo!,
+                    underlyingMasterId: underlyingMaster.Id,
+                    lessor: lh.LessorName!,
+                    leaseTermStart: leaseTermStart,
+                    collateralType: p.PropertyTypeCode)
+                : CollateralMaster.CreateLeasehold(
+                    lessee: lh.LesseeName!,
+                    leaseRegistrationNo: lh.ContractNo!,
+                    underlyingMasterId: underlyingMaster.Id,
+                    lessor: lh.LessorName!,
+                    leaseTermStart: leaseTermStart,
+                    collateralType: p.PropertyTypeCode);
             repo.Add(leaseMaster);
         }
+        else if (isPrimary)
+        {
+            leaseMaster = PromotePrimaryIfAlias(leaseMaster, "Leasehold");
+        }
+        else if (leaseMaster.IsMaster && primaryMasterId is { } parentId)
+        {
+            if (leaseMaster.Engagements.Count == 0)
+            {
+                leaseMaster.DemoteToAlias(parentId);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "ProcessAppraisalAsync: {Type} master {MasterId} was appraised standalone (has " +
+                    "{Count} engagement(s)); keeping it as its own IsMaster rather than demoting under " +
+                    "primary {PrimaryId} for AppraisalId={AppraisalId}.",
+                    leaseMaster.CollateralType, leaseMaster.Id, leaseMaster.Engagements.Count, parentId, appraisal.AppraisalId);
+            }
+        }
+        // else: dedup key already resolved to an alias row — upsert detail directly on THAT row.
 
         DateOnly? leaseTermEnd = lh.LeaseEndDate.HasValue
             ? DateOnly.FromDateTime(lh.LeaseEndDate.Value)
@@ -981,14 +1184,9 @@ public class CollateralMasterUpsertService(
         IReadOnlyDictionary<string, CollateralMaster> groupIsMasters,
         IReadOnlyDictionary<string, List<CollateralMaster>> groupAliases,
         AppraisalForCollateralResult appraisal,
-        IReadOnlyList<AppraisalPropertyForCollateral> allBuildingProperties)
+        IReadOnlyList<AppraisalPropertyForCollateral> allBuildingProperties,
+        string primaryGroupKey)
     {
-        // Principal group = lowest GroupNumber (or first in list if all null)
-        var primaryGroupKey = groups
-            .OrderBy(g => g.GroupNumber ?? int.MaxValue)
-            .First()
-            .GroupKey;
-
         var snapshots = new List<PropertyGroupSnapshot>();
 
         foreach (var group in groups.OrderBy(g => g.GroupNumber ?? int.MaxValue))
@@ -1067,7 +1265,10 @@ public class CollateralMasterUpsertService(
             }
             else
             {
-                // Non-land types: one entry per AppraisalProperty in the group
+                // Non-land types: one entry per AppraisalProperty in the group. Role reflects the
+                // row's ACTUAL IsMaster flag — a non-primary group's row may be a typed alias
+                // (one-collateral-per-appraisal model) even though it still carries its own detail.
+                var role = isMasterRow.IsMaster ? "isMaster" : "alias";
                 foreach (var prop in group.Properties)
                 {
                     if (prop.PropertyTypeCode == "U")
@@ -1075,19 +1276,19 @@ public class CollateralMasterUpsertService(
                         propertyEntries.Add(SnapshotBuilder.BuildCondoPropertyEntry(
                             isMasterRow.Id,
                             prop,
-                            role: "isMaster",
+                            role: role,
                             unitPrice: isMasterRow.CondoDetail?.UnitPrice ?? prop.PricingInfo?.UnitPrice));
                     }
                     else if (prop.PropertyTypeCode == "MAC")
                     {
-                        propertyEntries.Add(SnapshotBuilder.BuildMachinePropertyEntry(isMasterRow.Id, prop, role: "isMaster"));
+                        propertyEntries.Add(SnapshotBuilder.BuildMachinePropertyEntry(isMasterRow.Id, prop, role: role));
                     }
                     else if (prop.PropertyTypeCode is "LSL" or "LSB" or "LS")
                     {
                         var lhUnderlyingMasterId = isMasterRow.LeaseholdDetail?.UnderlyingMasterId ?? Guid.Empty;
                         var lhUnderlyingType = isMasterRow.LeaseholdDetail is not null ? "Land" : "Unknown";
                         propertyEntries.Add(SnapshotBuilder.BuildLeaseholdPropertyEntry(
-                            isMasterRow.Id, prop, role: "isMaster", lhUnderlyingMasterId, lhUnderlyingType));
+                            isMasterRow.Id, prop, role: role, lhUnderlyingMasterId, lhUnderlyingType));
                     }
                 }
             }

--- a/Modules/Collateral/Collateral/CollateralMasters/Services/HostCollateralIdBackfillJob.cs
+++ b/Modules/Collateral/Collateral/CollateralMasters/Services/HostCollateralIdBackfillJob.cs
@@ -1,0 +1,154 @@
+using System.Collections.Concurrent;
+using Dapper;
+using Microsoft.Extensions.Hosting;
+using Shared.Data;
+using Shared.Time;
+
+namespace Collateral.CollateralMasters.Services;
+
+// ---------------------------------------------------------------------------
+// Host-collateral-id backfill — status tracked in-memory per run
+// ---------------------------------------------------------------------------
+
+public record HostCollateralIdBackfillStatus(
+    Guid JobId,
+    DateTime StartedAt,
+    DateTime? CompletedAt,
+    BackfillJobState State,
+    int Updated,
+    int SkippedConflicts,
+    int AppraisalsWithNoMaster,
+    string? Error);
+
+/// <summary>
+/// One-shot background job that copies the AS400 <c>HostCollateralId</c> already stamped on the
+/// appraisal source detail rows onto the owning <c>collateral.CollateralMasters</c> row.
+///
+/// Standalone by design — it does NOT go through <see cref="ICollateralMasterUpsertService"/>. It runs a
+/// single idempotent cross-schema SQL statement (all modules share one database):
+///   - HostCollateralId is one-per-appraisal: gathered from the 5 in-scope source tables (Land titles,
+///     Building, Condo, Machinery, Lease) and de-duplicated per AppraisalId. Vehicle/Vessel are excluded.
+///   - The target master is the one that owns the appraisal's engagement
+///     (collateral.CollateralEngagements has a UNIQUE AppraisalId → CollateralMasterId).
+///   - Only rows where CollateralMasters.HostCollateralId IS NULL are written, so re-runs are no-ops.
+///   - Appraisals whose source rows carry more than one distinct HostCollateralId are skipped (reported).
+///
+/// Fire-and-forget, exactly like <see cref="CollateralBackfillJob"/>: it must NOT capture the HTTP
+/// request's CancellationToken (that token cancels when the response is sent). It runs under
+/// <see cref="IHostApplicationLifetime.ApplicationStopping"/> and opens its own DI scope.
+/// </summary>
+public class HostCollateralIdBackfillJob(
+    IServiceScopeFactory scopeFactory,
+    ILogger<HostCollateralIdBackfillJob> logger,
+    IDateTimeProvider dateTimeProvider,
+    IHostApplicationLifetime lifetime)
+{
+    private readonly ConcurrentDictionary<Guid, HostCollateralIdBackfillStatus> _jobs = new();
+
+    public HostCollateralIdBackfillStatus? GetJobStatus(Guid jobId)
+        => _jobs.TryGetValue(jobId, out var status) ? status : null;
+
+    /// <summary>
+    /// Starts the backfill in the background and returns the JobId immediately.
+    /// Any token passed here is intentionally ignored — see the class remarks.
+    /// </summary>
+    public Guid StartAsync(CancellationToken ct = default)
+    {
+        var jobId = Guid.CreateVersion7();
+        _jobs[jobId] = new HostCollateralIdBackfillStatus(
+            jobId, dateTimeProvider.ApplicationNow, null, BackfillJobState.Started, 0, 0, 0, null);
+
+        var jobToken = lifetime.ApplicationStopping;
+        _ = Task.Run(() => RunAsync(jobId, jobToken), jobToken);
+
+        return jobId;
+    }
+
+    private async Task RunAsync(Guid jobId, CancellationToken ct)
+    {
+        _jobs[jobId] = _jobs[jobId] with { State = BackfillJobState.InProgress };
+        logger.LogInformation("HostCollateralIdBackfillJob {JobId}: started", jobId);
+
+        try
+        {
+            using var scope = scopeFactory.CreateScope();
+            var connectionFactory = scope.ServiceProvider.GetRequiredService<ISqlConnectionFactory>();
+            var connection = connectionFactory.GetOpenConnection();
+
+            var counts = await connection.QuerySingleAsync<HostIdBackfillCounts>(
+                new CommandDefinition(BackfillSql, cancellationToken: ct));
+
+            _jobs[jobId] = _jobs[jobId] with
+            {
+                State = BackfillJobState.Completed,
+                CompletedAt = dateTimeProvider.ApplicationNow,
+                Updated = counts.Updated,
+                SkippedConflicts = counts.SkippedConflicts,
+                AppraisalsWithNoMaster = counts.AppraisalsWithNoMaster
+            };
+
+            logger.LogInformation(
+                "HostCollateralIdBackfillJob {JobId}: finished. Updated={Updated} SkippedConflicts={SkippedConflicts} AppraisalsWithNoMaster={NoMaster}",
+                jobId, counts.Updated, counts.SkippedConflicts, counts.AppraisalsWithNoMaster);
+
+            if (counts.SkippedConflicts > 0)
+                logger.LogWarning(
+                    "HostCollateralIdBackfillJob {JobId}: {Count} appraisal(s) skipped because their source rows carry more than one distinct HostCollateralId.",
+                    jobId, counts.SkippedConflicts);
+        }
+        catch (Exception ex)
+        {
+            _jobs[jobId] = _jobs[jobId] with
+            {
+                State = BackfillJobState.Completed,
+                CompletedAt = dateTimeProvider.ApplicationNow,
+                Error = ex.Message
+            };
+            logger.LogError(ex, "HostCollateralIdBackfillJob {JobId}: failed", jobId);
+        }
+    }
+
+    private sealed record HostIdBackfillCounts(int Updated, int SkippedConflicts, int AppraisalsWithNoMaster);
+
+    // One idempotent cross-schema batch. HostCollateralId is one-per-appraisal, resolved from the 5
+    // in-scope source tables and stamped onto the master that owns the appraisal's (unique) engagement.
+    private const string BackfillSql = """
+        SELECT p.AppraisalId,
+               MAX(h.HostCollateralId)            AS HostCollateralId,
+               COUNT(DISTINCT h.HostCollateralId) AS DistinctCount
+        INTO #HostIdPerAppraisal
+        FROM (
+            SELECT lad.AppraisalPropertyId AS AppraisalPropertyId, lt.HostCollateralId
+            FROM appraisal.LandTitles lt
+            JOIN appraisal.LandAppraisalDetails lad ON lad.Id = lt.LandAppraisalDetailId
+            WHERE lt.HostCollateralId IS NOT NULL
+            UNION ALL SELECT AppraisalPropertyId, HostCollateralId FROM appraisal.BuildingAppraisalDetails  WHERE HostCollateralId IS NOT NULL
+            UNION ALL SELECT AppraisalPropertyId, HostCollateralId FROM appraisal.CondoAppraisalDetails     WHERE HostCollateralId IS NOT NULL
+            UNION ALL SELECT AppraisalPropertyId, HostCollateralId FROM appraisal.MachineryAppraisalDetails WHERE HostCollateralId IS NOT NULL
+            UNION ALL SELECT AppraisalPropertyId, HostCollateralId FROM appraisal.LeaseAgreementDetails     WHERE HostCollateralId IS NOT NULL
+        ) h
+        JOIN appraisal.AppraisalProperties p ON p.Id = h.AppraisalPropertyId
+        GROUP BY p.AppraisalId;
+
+        DECLARE @Updated int;
+
+        UPDATE cm SET cm.HostCollateralId = t.HostCollateralId
+        FROM collateral.CollateralMasters cm
+        JOIN collateral.CollateralEngagements ce ON ce.CollateralMasterId = cm.Id
+        JOIN #HostIdPerAppraisal t ON t.AppraisalId = ce.AppraisalId
+        WHERE cm.HostCollateralId IS NULL
+          AND t.DistinctCount = 1;
+
+        SET @Updated = @@ROWCOUNT;
+
+        SELECT
+            @Updated AS Updated,
+            (SELECT COUNT(*) FROM #HostIdPerAppraisal WHERE DistinctCount > 1) AS SkippedConflicts,
+            (SELECT COUNT(*) FROM #HostIdPerAppraisal t
+                WHERE t.DistinctCount = 1
+                  AND NOT EXISTS (SELECT 1 FROM collateral.CollateralEngagements ce WHERE ce.AppraisalId = t.AppraisalId)
+            ) AS AppraisalsWithNoMaster;
+
+        DROP TABLE #HostIdPerAppraisal;
+        """;
+}

--- a/Modules/Collateral/Collateral/CollateralModule.cs
+++ b/Modules/Collateral/Collateral/CollateralModule.cs
@@ -32,6 +32,7 @@ public static class CollateralModule
 
         // Singleton: in-memory job state must survive across requests
         services.AddSingleton<CollateralBackfillJob>();
+        services.AddSingleton<HostCollateralIdBackfillJob>();
 
         // Scoped: Hangfire instantiates per execution via DI scope
         services.AddScoped<BlockReappraisalJob>();

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluationStaff/GetPendingEvaluationStaffEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluationStaff/GetPendingEvaluationStaffEndpoint.cs
@@ -1,0 +1,30 @@
+using Carter;
+using Common.Application.Features.Monitoring.Shared;
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Common.Application.Features.Monitoring.GetPendingEvaluationStaff;
+
+public class GetPendingEvaluationStaffEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet(
+                "/monitoring/pending-evaluations/staff",
+                async (ISender sender, CancellationToken cancellationToken) =>
+                {
+                    var result = await sender.Send(new GetPendingEvaluationStaffQuery(), cancellationToken);
+                    return Results.Ok(result);
+                })
+            .WithName("MonitoringGetPendingEvaluationStaff")
+            .Produces<IReadOnlyList<InternalFollowupStaffOption>>()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .WithSummary("Monitoring: Pending Evaluation internal followup staff options")
+            .WithDescription("Returns the distinct internal followup staff on the Pending Evaluation list, for the filter autocomplete. Requires any MONITORING:PENDING_EVALUATION* permission.")
+            .WithTags("Monitoring")
+            .RequireAuthorization(MonitoringPermissions.PolicyPendingEvaluation);
+    }
+}

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluationStaff/GetPendingEvaluationStaffQuery.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluationStaff/GetPendingEvaluationStaffQuery.cs
@@ -1,0 +1,5 @@
+using Shared.CQRS;
+
+namespace Common.Application.Features.Monitoring.GetPendingEvaluationStaff;
+
+public record GetPendingEvaluationStaffQuery : IQuery<IReadOnlyList<InternalFollowupStaffOption>>;

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluationStaff/GetPendingEvaluationStaffQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluationStaff/GetPendingEvaluationStaffQueryHandler.cs
@@ -1,0 +1,32 @@
+using Dapper;
+using Shared.CQRS;
+using Shared.Data;
+
+namespace Common.Application.Features.Monitoring.GetPendingEvaluationStaff;
+
+/// <summary>
+/// Returns the distinct internal followup staff that appear on the Pending Evaluation surface,
+/// for the filter autocomplete. Sourced from appraisal.vw_AppraisalEvaluationList so the options
+/// are scoped to the same universe the list filters over (no orphaned choices). Staff with no
+/// resolvable name still surface with the username as the label so they remain selectable.
+/// </summary>
+public class GetPendingEvaluationStaffQueryHandler(ISqlConnectionFactory connectionFactory)
+    : IQueryHandler<GetPendingEvaluationStaffQuery, IReadOnlyList<InternalFollowupStaffOption>>
+{
+    public async Task<IReadOnlyList<InternalFollowupStaffOption>> Handle(
+        GetPendingEvaluationStaffQuery query,
+        CancellationToken cancellationToken)
+    {
+        const string sql = @"
+SELECT DISTINCT
+    InternalFollowupStaffId   AS Value,
+    COALESCE(InternalFollowupStaffName, InternalFollowupStaffId) AS Label
+FROM appraisal.vw_AppraisalEvaluationList
+WHERE InternalFollowupStaffId IS NOT NULL
+ORDER BY Label";
+
+        var conn = connectionFactory.GetOpenConnection();
+        var options = await conn.QueryAsync<InternalFollowupStaffOption>(sql);
+        return options.ToList();
+    }
+}

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluationStaff/InternalFollowupStaffOption.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluationStaff/InternalFollowupStaffOption.cs
@@ -1,0 +1,8 @@
+namespace Common.Application.Features.Monitoring.GetPendingEvaluationStaff;
+
+/// <summary>
+/// Autocomplete option for the internal-followup-staff filter on the Pending Evaluation tab.
+/// Value is the staff username (matches the list filter's InternalFollowupStaff param);
+/// Label is the resolved display name.
+/// </summary>
+public record InternalFollowupStaffOption(string Value, string Label);

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/GetPendingEvaluationsEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/GetPendingEvaluationsEndpoint.cs
@@ -22,10 +22,11 @@ public class GetPendingEvaluationsEndpoint : ICarterModule
                     string? sortDir,
                     string? appraisalCompanyId,
                     string[]? appraisalStatus,
+                    string? internalFollowupStaff,
                     ISender sender,
                     CancellationToken cancellationToken) =>
                 {
-                    var filter = new PendingEvaluationFilter(evaluationStatus, search, sortBy, sortDir, appraisalCompanyId, appraisalStatus);
+                    var filter = new PendingEvaluationFilter(evaluationStatus, search, sortBy, sortDir, appraisalCompanyId, appraisalStatus, internalFollowupStaff);
                     var result = await sender.Send(new GetPendingEvaluationsQuery(pagination, filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/GetPendingEvaluationsQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/GetPendingEvaluationsQueryHandler.cs
@@ -37,7 +37,9 @@ SELECT
     AppraisalValue,
     EvaluationId,
     EvaluationStatus,
-    TotalScore
+    TotalScore,
+    InternalFollowupStaffId,
+    InternalFollowupStaffName
 FROM appraisal.vw_AppraisalEvaluationList";
         var conditions = new List<string>();
         var parameters = new DynamicParameters();
@@ -71,6 +73,13 @@ FROM appraisal.vw_AppraisalEvaluationList";
         {
             conditions.Add("AppraisalStatus IN @AppraisalStatuses");
             parameters.Add("AppraisalStatuses", filter.AppraisalStatus);
+        }
+
+        // Exact match on the internal followup staff username (autocomplete-selected value).
+        if (!string.IsNullOrWhiteSpace(filter.InternalFollowupStaff))
+        {
+            conditions.Add("InternalFollowupStaffId = @InternalFollowupStaff");
+            parameters.Add("InternalFollowupStaff", filter.InternalFollowupStaff.Trim());
         }
 
         sql += " WHERE " + string.Join(" AND ", conditions);

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/GetPendingEvaluationsSummaryEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/GetPendingEvaluationsSummaryEndpoint.cs
@@ -18,10 +18,11 @@ public class GetPendingEvaluationsSummaryEndpoint : ICarterModule
                     string? search,
                     string? appraisalCompanyId,
                     string[]? appraisalStatus,
+                    string? internalFollowupStaff,
                     ISender sender,
                     CancellationToken cancellationToken) =>
                 {
-                    var filter = new PendingEvaluationFilter(evaluationStatus, search, null, null, appraisalCompanyId, appraisalStatus);
+                    var filter = new PendingEvaluationFilter(evaluationStatus, search, null, null, appraisalCompanyId, appraisalStatus, internalFollowupStaff);
                     var result = await sender.Send(new GetPendingEvaluationsSummaryQuery(filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/GetPendingEvaluationsSummaryQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/GetPendingEvaluationsSummaryQueryHandler.cs
@@ -50,6 +50,12 @@ public class GetPendingEvaluationsSummaryQueryHandler(ISqlConnectionFactory conn
             parameters.Add("AppraisalStatuses", filter.AppraisalStatus);
         }
 
+        if (!string.IsNullOrWhiteSpace(filter.InternalFollowupStaff))
+        {
+            conditions.Add("InternalFollowupStaffId = @InternalFollowupStaff");
+            parameters.Add("InternalFollowupStaff", filter.InternalFollowupStaff.Trim());
+        }
+
         var where = "WHERE " + string.Join(" AND ", conditions);
         var sql = $"SELECT COUNT(*) FROM appraisal.vw_AppraisalEvaluationList {where}";
 

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/PendingEvaluationDto.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/PendingEvaluationDto.cs
@@ -12,5 +12,7 @@ public record PendingEvaluationDto(
     decimal? AppraisalValue,
     Guid? EvaluationId,
     string? EvaluationStatus,
-    decimal? TotalScore
+    decimal? TotalScore,
+    string? InternalFollowupStaffId,
+    string? InternalFollowupStaffName
 );

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/PendingEvaluationFilter.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/PendingEvaluationFilter.cs
@@ -6,5 +6,6 @@ public record PendingEvaluationFilter(
     string? SortBy,
     string? SortDir,
     string? AppraisalCompanyId,
-    string[]? AppraisalStatus
+    string[]? AppraisalStatus,
+    string? InternalFollowupStaff
 );

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalEndpoint.cs
@@ -24,6 +24,7 @@ public class GetPendingExternalEndpoint : ICarterModule
                     string? sortDir,
                     string[]? slaBucket,
                     string? pic,
+                    string? picType,
                     string[]? purpose,
                     string[]? propertyType,
                     string[]? taskType,
@@ -31,7 +32,7 @@ public class GetPendingExternalEndpoint : ICarterModule
                     ISender sender,
                     CancellationToken cancellationToken) =>
                 {
-                    var filter = new PendingExternalFilter(slaStatus, search, activityId, sortBy, sortDir, slaBucket, pic, purpose, propertyType, taskType, appraisalCompanyId);
+                    var filter = new PendingExternalFilter(slaStatus, search, activityId, sortBy, sortDir, slaBucket, pic, picType, purpose, propertyType, taskType, appraisalCompanyId);
                     var result = await sender.Send(new GetPendingExternalQuery(pagination, filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalGroupedEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalGroupedEndpoint.cs
@@ -20,6 +20,7 @@ public class GetPendingExternalGroupedEndpoint : ICarterModule
                     string[]? activityId,
                     string[]? slaBucket,
                     string? pic,
+                    string? picType,
                     string[]? purpose,
                     string[]? propertyType,
                     string[]? taskType,
@@ -30,7 +31,7 @@ public class GetPendingExternalGroupedEndpoint : ICarterModule
                     if (string.IsNullOrWhiteSpace(groupBy) || groupBy.ToLowerInvariant() is not ("pic" or "company" or "activity"))
                         return Results.BadRequest("groupBy is required and must be one of: pic, company, activity.");
 
-                    var filter = new PendingExternalFilter(slaStatus, search, activityId, null, null, slaBucket, pic, purpose, propertyType, taskType, appraisalCompanyId);
+                    var filter = new PendingExternalFilter(slaStatus, search, activityId, null, null, slaBucket, pic, picType, purpose, propertyType, taskType, appraisalCompanyId);
                     var result = await sender.Send(new GetPendingExternalGroupedQuery(groupBy, filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalGroupedQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalGroupedQueryHandler.cs
@@ -50,8 +50,13 @@ public class GetPendingExternalGroupedQueryHandler(
 
         if (!string.IsNullOrWhiteSpace(filter.Pic))
         {
-            conditions.Add("PIC LIKE @Pic ESCAPE '\\'");
-            parameters.Add("Pic", "%" + EscapeLike(filter.Pic.Trim()) + "%");
+            conditions.Add("AssignedTo = @Pic");
+            parameters.Add("Pic", filter.Pic.Trim());
+            if (!string.IsNullOrWhiteSpace(filter.PicType))
+            {
+                conditions.Add("AssignedType = @PicType");
+                parameters.Add("PicType", filter.PicType.Trim());
+            }
         }
 
         if (filter.Purpose is { Length: > 0 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalQueryHandler.cs
@@ -21,7 +21,8 @@ public class GetPendingExternalQueryHandler(
     {
         "AppraisalNumber", "CustomerName", "TaskType", "Purpose", "PropertyType",
         "SlaStatus", "Priority", "AssignedDate", "RequestedDate",
-        "OlaActualHours", "OlaVarianceHours", "Movement", "PIC", "AppraisalCompanyName"
+        "OlaActualHours", "OlaVarianceHours", "Movement", "PIC", "AppraisalCompanyName",
+        "OpenDate", "AppointmentDate", "AppraisalStatus"
     };
 
     public async Task<PaginatedResult<PendingTaskDto>> Handle(
@@ -54,7 +55,11 @@ SELECT
     AppraisalCompanyName,
     MonitoringType,
     AssignedTo,
-    AssignedType
+    AssignedType,
+    OpenDate,
+    AppointmentDate,
+    SlaDurationHours,
+    AppraisalStatus
 FROM common.vw_MonitoringPendingTasks";
         var conditions = new List<string> { "MonitoringType = 'External'" };
         var parameters = new DynamicParameters();
@@ -86,8 +91,13 @@ FROM common.vw_MonitoringPendingTasks";
 
         if (!string.IsNullOrWhiteSpace(filter.Pic))
         {
-            conditions.Add("PIC LIKE @Pic ESCAPE '\\'");
-            parameters.Add("Pic", "%" + EscapeLike(filter.Pic.Trim()) + "%");
+            conditions.Add("AssignedTo = @Pic");
+            parameters.Add("Pic", filter.Pic.Trim());
+            if (!string.IsNullOrWhiteSpace(filter.PicType))
+            {
+                conditions.Add("AssignedType = @PicType");
+                parameters.Add("PicType", filter.PicType.Trim());
+            }
         }
 
         if (filter.Purpose is { Length: > 0 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalSummaryEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalSummaryEndpoint.cs
@@ -19,6 +19,7 @@ public class GetPendingExternalSummaryEndpoint : ICarterModule
                     string[]? activityId,
                     string[]? slaBucket,
                     string? pic,
+                    string? picType,
                     string[]? purpose,
                     string[]? propertyType,
                     string[]? taskType,
@@ -26,7 +27,7 @@ public class GetPendingExternalSummaryEndpoint : ICarterModule
                     ISender sender,
                     CancellationToken cancellationToken) =>
                 {
-                    var filter = new PendingExternalFilter(slaStatus, search, activityId, null, null, slaBucket, pic, purpose, propertyType, taskType, appraisalCompanyId);
+                    var filter = new PendingExternalFilter(slaStatus, search, activityId, null, null, slaBucket, pic, picType, purpose, propertyType, taskType, appraisalCompanyId);
                     var result = await sender.Send(new GetPendingExternalSummaryQuery(filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalSummaryQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalSummaryQueryHandler.cs
@@ -50,8 +50,13 @@ public class GetPendingExternalSummaryQueryHandler(
 
         if (!string.IsNullOrWhiteSpace(filter.Pic))
         {
-            conditions.Add("PIC LIKE @Pic ESCAPE '\\'");
-            parameters.Add("Pic", "%" + EscapeLike(filter.Pic.Trim()) + "%");
+            conditions.Add("AssignedTo = @Pic");
+            parameters.Add("Pic", filter.Pic.Trim());
+            if (!string.IsNullOrWhiteSpace(filter.PicType))
+            {
+                conditions.Add("AssignedType = @PicType");
+                parameters.Add("PicType", filter.PicType.Trim());
+            }
         }
 
         if (filter.Purpose is { Length: > 0 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/PendingExternalFilter.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/PendingExternalFilter.cs
@@ -8,6 +8,7 @@ public record PendingExternalFilter(
     string? SortDir,
     string[]? SlaBucket,
     string? Pic,
+    string? PicType,
     string[]? Purpose,
     string[]? PropertyType,
     string[]? TaskType,

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsEndpoint.cs
@@ -21,15 +21,17 @@ public class GetPendingFollowupsEndpoint : ICarterModule
                     string[]? slaStatus,
                     string[]? slaBucket,
                     string? pic,
+                    string? picType,
                     string[]? purpose,
                     string[]? propertyType,
                     string[]? taskType,
+                    string[]? appraisalCompanyId,
                     string? sortBy,
                     string? sortDir,
                     ISender sender,
                     CancellationToken cancellationToken) =>
                 {
-                    var filter = new PendingFollowupFilter(slaStatus, search, sortBy, sortDir, slaBucket, pic, purpose, propertyType, taskType);
+                    var filter = new PendingFollowupFilter(slaStatus, search, sortBy, sortDir, slaBucket, pic, picType, purpose, propertyType, taskType, appraisalCompanyId);
                     var result = await sender.Send(new GetPendingFollowupsQuery(pagination, filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsGroupedEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsGroupedEndpoint.cs
@@ -19,16 +19,18 @@ public class GetPendingFollowupsGroupedEndpoint : ICarterModule
                     string[]? slaStatus,
                     string[]? slaBucket,
                     string? pic,
+                    string? picType,
                     string[]? purpose,
                     string[]? propertyType,
                     string[]? taskType,
+                    string[]? appraisalCompanyId,
                     ISender sender,
                     CancellationToken cancellationToken) =>
                 {
                     if (string.IsNullOrWhiteSpace(groupBy) || groupBy.ToLowerInvariant() is not ("pic" or "company" or "activity"))
                         return Results.BadRequest("groupBy is required and must be one of: pic, company, activity.");
 
-                    var filter = new PendingFollowupFilter(slaStatus, search, null, null, slaBucket, pic, purpose, propertyType, taskType);
+                    var filter = new PendingFollowupFilter(slaStatus, search, null, null, slaBucket, pic, picType, purpose, propertyType, taskType, appraisalCompanyId);
                     var result = await sender.Send(new GetPendingFollowupsGroupedQuery(groupBy, filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsGroupedQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsGroupedQueryHandler.cs
@@ -41,8 +41,13 @@ public class GetPendingFollowupsGroupedQueryHandler(ISqlConnectionFactory connec
 
         if (!string.IsNullOrWhiteSpace(filter.Pic))
         {
-            conditions.Add("PIC LIKE @Pic ESCAPE '\\'");
-            parameters.Add("Pic", "%" + EscapeLike(filter.Pic.Trim()) + "%");
+            conditions.Add("AssignedTo = @Pic");
+            parameters.Add("Pic", filter.Pic.Trim());
+            if (!string.IsNullOrWhiteSpace(filter.PicType))
+            {
+                conditions.Add("AssignedType = @PicType");
+                parameters.Add("PicType", filter.PicType.Trim());
+            }
         }
 
         if (filter.Purpose is { Length: > 0 })
@@ -61,6 +66,12 @@ public class GetPendingFollowupsGroupedQueryHandler(ISqlConnectionFactory connec
         {
             conditions.Add("TaskType IN @TaskTypes");
             parameters.Add("TaskTypes", filter.TaskType);
+        }
+
+        if (filter.AppraisalCompanyId is { Length: > 0 })
+        {
+            conditions.Add("AppraisalCompanyId IN @AppraisalCompanyIds");
+            parameters.Add("AppraisalCompanyIds", filter.AppraisalCompanyId);
         }
 
         var where = "WHERE " + string.Join(" AND ", conditions);

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsQueryHandler.cs
@@ -20,7 +20,8 @@ public class GetPendingFollowupsQueryHandler(ISqlConnectionFactory connectionFac
     {
         "AppraisalNumber", "CustomerName", "TaskType", "Purpose", "PropertyType",
         "SlaStatus", "Priority", "AssignedDate", "RequestedDate",
-        "OlaActualHours", "OlaVarianceHours", "Movement", "PIC"
+        "OlaActualHours", "OlaVarianceHours", "Movement", "PIC",
+        "OpenDate", "AppointmentDate", "AppraisalStatus"
     };
 
     public async Task<PaginatedResult<PendingTaskDto>> Handle(
@@ -51,7 +52,11 @@ SELECT
     AppraisalCompanyName,
     MonitoringType,
     AssignedTo,
-    AssignedType
+    AssignedType,
+    OpenDate,
+    AppointmentDate,
+    SlaDurationHours,
+    AppraisalStatus
 FROM common.vw_MonitoringPendingTasks";
 
         var conditions = new List<string> { "ActivityId IN @ActivityIds" };
@@ -75,8 +80,13 @@ FROM common.vw_MonitoringPendingTasks";
 
         if (!string.IsNullOrWhiteSpace(filter.Pic))
         {
-            conditions.Add("PIC LIKE @Pic ESCAPE '\\'");
-            parameters.Add("Pic", "%" + EscapeLike(filter.Pic.Trim()) + "%");
+            conditions.Add("AssignedTo = @Pic");
+            parameters.Add("Pic", filter.Pic.Trim());
+            if (!string.IsNullOrWhiteSpace(filter.PicType))
+            {
+                conditions.Add("AssignedType = @PicType");
+                parameters.Add("PicType", filter.PicType.Trim());
+            }
         }
 
         if (filter.Purpose is { Length: > 0 })
@@ -95,6 +105,12 @@ FROM common.vw_MonitoringPendingTasks";
         {
             conditions.Add("TaskType IN @TaskTypes");
             parameters.Add("TaskTypes", filter.TaskType);
+        }
+
+        if (filter.AppraisalCompanyId is { Length: > 0 })
+        {
+            conditions.Add("AppraisalCompanyId IN @AppraisalCompanyIds");
+            parameters.Add("AppraisalCompanyIds", filter.AppraisalCompanyId);
         }
 
         sql += " WHERE " + string.Join(" AND ", conditions);

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsSummaryEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsSummaryEndpoint.cs
@@ -18,13 +18,15 @@ public class GetPendingFollowupsSummaryEndpoint : ICarterModule
                     string[]? slaStatus,
                     string[]? slaBucket,
                     string? pic,
+                    string? picType,
                     string[]? purpose,
                     string[]? propertyType,
                     string[]? taskType,
+                    string[]? appraisalCompanyId,
                     ISender sender,
                     CancellationToken cancellationToken) =>
                 {
-                    var filter = new PendingFollowupFilter(slaStatus, search, null, null, slaBucket, pic, purpose, propertyType, taskType);
+                    var filter = new PendingFollowupFilter(slaStatus, search, null, null, slaBucket, pic, picType, purpose, propertyType, taskType, appraisalCompanyId);
                     var result = await sender.Send(new GetPendingFollowupsSummaryQuery(filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsSummaryQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsSummaryQueryHandler.cs
@@ -41,8 +41,13 @@ public class GetPendingFollowupsSummaryQueryHandler(ISqlConnectionFactory connec
 
         if (!string.IsNullOrWhiteSpace(filter.Pic))
         {
-            conditions.Add("PIC LIKE @Pic ESCAPE '\\'");
-            parameters.Add("Pic", "%" + EscapeLike(filter.Pic.Trim()) + "%");
+            conditions.Add("AssignedTo = @Pic");
+            parameters.Add("Pic", filter.Pic.Trim());
+            if (!string.IsNullOrWhiteSpace(filter.PicType))
+            {
+                conditions.Add("AssignedType = @PicType");
+                parameters.Add("PicType", filter.PicType.Trim());
+            }
         }
 
         if (filter.Purpose is { Length: > 0 })
@@ -61,6 +66,12 @@ public class GetPendingFollowupsSummaryQueryHandler(ISqlConnectionFactory connec
         {
             conditions.Add("TaskType IN @TaskTypes");
             parameters.Add("TaskTypes", filter.TaskType);
+        }
+
+        if (filter.AppraisalCompanyId is { Length: > 0 })
+        {
+            conditions.Add("AppraisalCompanyId IN @AppraisalCompanyIds");
+            parameters.Add("AppraisalCompanyIds", filter.AppraisalCompanyId);
         }
 
         var where = "WHERE " + string.Join(" AND ", conditions);

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/PendingFollowupFilter.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/PendingFollowupFilter.cs
@@ -7,7 +7,9 @@ public record PendingFollowupFilter(
     string? SortDir,
     string[]? SlaBucket,
     string? Pic,
+    string? PicType,
     string[]? Purpose,
     string[]? PropertyType,
-    string[]? TaskType
+    string[]? TaskType,
+    string[]? AppraisalCompanyId
 );

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalEndpoint.cs
@@ -23,13 +23,14 @@ public class GetPendingInternalEndpoint : ICarterModule
                     string? sortDir,
                     string[]? slaBucket,
                     string? pic,
+                    string? picType,
                     string[]? purpose,
                     string[]? propertyType,
                     string[]? taskType,
                     ISender sender,
                     CancellationToken cancellationToken) =>
                 {
-                    var filter = new PendingInternalFilter(slaStatus, search, activityId, sortBy, sortDir, slaBucket, pic, purpose, propertyType, taskType);
+                    var filter = new PendingInternalFilter(slaStatus, search, activityId, sortBy, sortDir, slaBucket, pic, picType, purpose, propertyType, taskType);
                     var result = await sender.Send(new GetPendingInternalQuery(pagination, filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalGroupedEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalGroupedEndpoint.cs
@@ -20,6 +20,7 @@ public class GetPendingInternalGroupedEndpoint : ICarterModule
                     string[]? activityId,
                     string[]? slaBucket,
                     string? pic,
+                    string? picType,
                     string[]? purpose,
                     string[]? propertyType,
                     string[]? taskType,
@@ -29,7 +30,7 @@ public class GetPendingInternalGroupedEndpoint : ICarterModule
                     if (string.IsNullOrWhiteSpace(groupBy) || groupBy.ToLowerInvariant() is not ("pic" or "company" or "activity"))
                         return Results.BadRequest("groupBy is required and must be one of: pic, company, activity.");
 
-                    var filter = new PendingInternalFilter(slaStatus, search, activityId, null, null, slaBucket, pic, purpose, propertyType, taskType);
+                    var filter = new PendingInternalFilter(slaStatus, search, activityId, null, null, slaBucket, pic, picType, purpose, propertyType, taskType);
                     var result = await sender.Send(new GetPendingInternalGroupedQuery(groupBy, filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalGroupedQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalGroupedQueryHandler.cs
@@ -55,8 +55,13 @@ public class GetPendingInternalGroupedQueryHandler(
 
         if (!string.IsNullOrWhiteSpace(filter.Pic))
         {
-            conditions.Add("PIC LIKE @Pic ESCAPE '\\'");
-            parameters.Add("Pic", "%" + EscapeLike(filter.Pic.Trim()) + "%");
+            conditions.Add("AssignedTo = @Pic");
+            parameters.Add("Pic", filter.Pic.Trim());
+            if (!string.IsNullOrWhiteSpace(filter.PicType))
+            {
+                conditions.Add("AssignedType = @PicType");
+                parameters.Add("PicType", filter.PicType.Trim());
+            }
         }
 
         if (filter.Purpose is { Length: > 0 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalQueryHandler.cs
@@ -19,7 +19,8 @@ public class GetPendingInternalQueryHandler(
     {
         "AppraisalNumber", "CustomerName", "TaskType", "Purpose", "PropertyType",
         "SlaStatus", "Priority", "AssignedDate", "RequestedDate",
-        "OlaActualHours", "OlaVarianceHours", "Movement", "PIC"
+        "OlaActualHours", "OlaVarianceHours", "Movement", "PIC",
+        "OpenDate", "AppointmentDate", "AppraisalStatus"
     };
 
     public async Task<PaginatedResult<PendingTaskDto>> Handle(
@@ -54,7 +55,11 @@ SELECT
     AppraisalCompanyName,
     MonitoringType,
     AssignedTo,
-    AssignedType
+    AssignedType,
+    OpenDate,
+    AppointmentDate,
+    SlaDurationHours,
+    AppraisalStatus
 FROM common.vw_MonitoringPendingTasks";
         var conditions = new List<string> { "MonitoringType = 'Internal'" };
         var parameters = new DynamicParameters();
@@ -88,8 +93,13 @@ FROM common.vw_MonitoringPendingTasks";
 
         if (!string.IsNullOrWhiteSpace(filter.Pic))
         {
-            conditions.Add("PIC LIKE @Pic ESCAPE '\\'");
-            parameters.Add("Pic", "%" + EscapeLike(filter.Pic.Trim()) + "%");
+            conditions.Add("AssignedTo = @Pic");
+            parameters.Add("Pic", filter.Pic.Trim());
+            if (!string.IsNullOrWhiteSpace(filter.PicType))
+            {
+                conditions.Add("AssignedType = @PicType");
+                parameters.Add("PicType", filter.PicType.Trim());
+            }
         }
 
         if (filter.Purpose is { Length: > 0 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalSummaryEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalSummaryEndpoint.cs
@@ -19,13 +19,14 @@ public class GetPendingInternalSummaryEndpoint : ICarterModule
                     string[]? activityId,
                     string[]? slaBucket,
                     string? pic,
+                    string? picType,
                     string[]? purpose,
                     string[]? propertyType,
                     string[]? taskType,
                     ISender sender,
                     CancellationToken cancellationToken) =>
                 {
-                    var filter = new PendingInternalFilter(slaStatus, search, activityId, null, null, slaBucket, pic, purpose, propertyType, taskType);
+                    var filter = new PendingInternalFilter(slaStatus, search, activityId, null, null, slaBucket, pic, picType, purpose, propertyType, taskType);
                     var result = await sender.Send(new GetPendingInternalSummaryQuery(filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalSummaryQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalSummaryQueryHandler.cs
@@ -56,8 +56,13 @@ public class GetPendingInternalSummaryQueryHandler(
 
         if (!string.IsNullOrWhiteSpace(filter.Pic))
         {
-            conditions.Add("PIC LIKE @Pic ESCAPE '\\'");
-            parameters.Add("Pic", "%" + EscapeLike(filter.Pic.Trim()) + "%");
+            conditions.Add("AssignedTo = @Pic");
+            parameters.Add("Pic", filter.Pic.Trim());
+            if (!string.IsNullOrWhiteSpace(filter.PicType))
+            {
+                conditions.Add("AssignedType = @PicType");
+                parameters.Add("PicType", filter.PicType.Trim());
+            }
         }
 
         if (filter.Purpose is { Length: > 0 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/PendingInternalFilter.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/PendingInternalFilter.cs
@@ -8,6 +8,7 @@ public record PendingInternalFilter(
     string? SortDir,
     string[]? SlaBucket,
     string? Pic,
+    string? PicType,
     string[]? Purpose,
     string[]? PropertyType,
     string[]? TaskType

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/PendingTaskDto.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/PendingTaskDto.cs
@@ -22,5 +22,9 @@ public record PendingTaskDto(
     string? AppraisalCompanyName,
     string MonitoringType,
     string? AssignedTo,
-    string? AssignedType
+    string? AssignedType,
+    DateTime? OpenDate,
+    DateTime? AppointmentDate,
+    int? SlaDurationHours,
+    string? AppraisalStatus
 );

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsEndpoint.cs
@@ -24,10 +24,11 @@ public class GetPendingQuotationsEndpoint : ICarterModule
                     string? sortDir,
                     DateOnly? cutOffTimeFrom,
                     DateOnly? cutOffTimeTo,
+                    string? appraisalCompanyId,
                     ISender sender,
                     CancellationToken cancellationToken) =>
                 {
-                    var filter = new PendingQuotationFilter(status, quotationNo, appraisalNo, customerName, sortBy, sortDir, cutOffTimeFrom, cutOffTimeTo);
+                    var filter = new PendingQuotationFilter(status, quotationNo, appraisalNo, customerName, sortBy, sortDir, cutOffTimeFrom, cutOffTimeTo, appraisalCompanyId);
                     var result = await sender.Send(new GetPendingQuotationsQuery(pagination, filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsQueryHandler.cs
@@ -124,6 +124,16 @@ OUTER APPLY (
             parameters.Add("CutOffTimeTo", filter.CutOffTimeTo.Value.ToDateTime(TimeOnly.MaxValue));
         }
 
+        // Optional filter: quotations that invited a specific appraisal company.
+        if (!string.IsNullOrWhiteSpace(filter.AppraisalCompanyId))
+        {
+            conditions.Add(@"EXISTS (
+    SELECT 1 FROM appraisal.QuotationInvitations qi
+    WHERE qi.QuotationRequestId = q.Id
+      AND qi.CompanyId = @AppraisalCompanyId)");
+            parameters.Add("AppraisalCompanyId", filter.AppraisalCompanyId);
+        }
+
         sql += " WHERE " + string.Join(" AND ", conditions);
 
         // Default RequestDate DESC; q.Id is a stable tiebreaker (never a sort key → no duplicate trap).

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsSummaryEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsSummaryEndpoint.cs
@@ -18,10 +18,11 @@ public class GetPendingQuotationsSummaryEndpoint : ICarterModule
                     string? quotationNo,
                     string? appraisalNo,
                     string? customerName,
+                    string? appraisalCompanyId,
                     ISender sender,
                     CancellationToken cancellationToken) =>
                 {
-                    var filter = new PendingQuotationFilter(status, quotationNo, appraisalNo, customerName, null, null);
+                    var filter = new PendingQuotationFilter(status, quotationNo, appraisalNo, customerName, null, null, null, null, appraisalCompanyId);
                     var result = await sender.Send(new GetPendingQuotationsSummaryQuery(filter), cancellationToken);
                     return Results.Ok(result);
                 })

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsSummaryQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/GetPendingQuotationsSummaryQueryHandler.cs
@@ -60,6 +60,16 @@ public class GetPendingQuotationsSummaryQueryHandler(ISqlConnectionFactory conne
             parameters.Add("CustomerNamePattern", "%" + EscapeLike(filter.CustomerName.Trim()) + "%");
         }
 
+        // Keep the count consistent with the list handler's invited-company predicate.
+        if (!string.IsNullOrWhiteSpace(filter.AppraisalCompanyId))
+        {
+            conditions.Add(@"EXISTS (
+    SELECT 1 FROM appraisal.QuotationInvitations qi
+    WHERE qi.QuotationRequestId = q.Id
+      AND qi.CompanyId = @AppraisalCompanyId)");
+            parameters.Add("AppraisalCompanyId", filter.AppraisalCompanyId);
+        }
+
         var where = "WHERE " + string.Join(" AND ", conditions);
         var sql = $"SELECT COUNT(*) FROM appraisal.vw_QuotationList q {where}";
 

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/PendingQuotationFilter.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingQuotations/PendingQuotationFilter.cs
@@ -8,5 +8,6 @@ public record PendingQuotationFilter(
     string? SortBy,
     string? SortDir,
     DateOnly? CutOffTimeFrom = null,
-    DateOnly? CutOffTimeTo = null
+    DateOnly? CutOffTimeTo = null,
+    string? AppraisalCompanyId = null
 );

--- a/Modules/Integration/Integration/Application/Services/WebhookService.cs
+++ b/Modules/Integration/Integration/Application/Services/WebhookService.cs
@@ -120,25 +120,28 @@ public class WebhookService(
         var httpMethod = new HttpMethod(
             string.IsNullOrWhiteSpace(subscription.HttpMethod) ? "POST" : subscription.HttpMethod);
 
-        var request = new HttpRequestMessage(httpMethod, subscription.CallbackUrl)
+        // Builds a fresh request each call — an HttpRequestMessage cannot be resent once sent, so the
+        // 401 re-auth retry below rebuilds it. forceFreshToken drops the cached token first so the
+        // retry mints a new one. Auth setup lives here (called INSIDE the try) so a token-fetch/config
+        // failure (bad config, LOS token endpoint down, missing HMAC secret) resolves to a normal
+        // delivery Failure rather than throwing out of DeliverWebhookAsync — otherwise the caller
+        // (e.g. WebhookDispatchConsumer's per-title loop) would see an unhandled exception and a
+        // property could get stuck at "Pending" instead of resolving to Failed.
+        async Task<HttpRequestMessage> BuildRequestAsync(bool forceFreshToken)
         {
-            Content = new StringContent(delivery.Payload, Encoding.UTF8, "application/json")
-        };
+            var req = new HttpRequestMessage(httpMethod, subscription.CallbackUrl)
+            {
+                Content = new StringContent(delivery.Payload, Encoding.UTF8, "application/json")
+            };
+            req.Headers.Add("X-Event-Type", delivery.EventType);
 
-        request.Headers.Add("X-Event-Type", delivery.EventType);
-
-        try
-        {
-            // Auth header setup lives INSIDE the try: a token-fetch failure (bad config, LOS token
-            // endpoint down) or a missing HMAC secret must resolve to a normal delivery Failure
-            // (caught below, RecordFailure + WebhookDeliveryOutcome(false, ...)) rather than throw
-            // out of DeliverWebhookAsync — otherwise the caller (e.g. WebhookDispatchConsumer's
-            // per-title loop) would see an unhandled exception instead of a clean failed outcome,
-            // and a property could get stuck at "Pending" instead of resolving to Failed.
             if (subscription.AuthType == WebhookAuthType.TokenBearer)
             {
+                if (forceFreshToken)
+                    tokenProvider.InvalidateToken(subscription.Id);
+
                 var (tokenType, accessToken) = await tokenProvider.GetTokenAsync(subscription, cancellationToken);
-                request.Headers.Authorization = new AuthenticationHeaderValue(tokenType, accessToken);
+                req.Headers.Authorization = new AuthenticationHeaderValue(tokenType, accessToken);
             }
             else
             {
@@ -150,17 +153,44 @@ public class WebhookService(
                 var signedPayload = $"{unixTimestamp}.{delivery.Payload}";
                 var signature = GenerateSignature(signedPayload, subscription.SecretKey);
 
-                request.Headers.Add("X-Timestamp", unixTimestamp.ToString(CultureInfo.InvariantCulture));
-                request.Headers.Add("X-Signature", $"sha256={signature}");
+                req.Headers.Add("X-Timestamp", unixTimestamp.ToString(CultureInfo.InvariantCulture));
+                req.Headers.Add("X-Signature", $"sha256={signature}");
             }
 
+            return req;
+        }
+
+        HttpRequestMessage? request = null;
+        try
+        {
             var client = httpClientFactory.CreateClient("Webhook");
+
+            request = await BuildRequestAsync(forceFreshToken: false);
 
             // The resilience pipeline retries internally; when SendAsync returns we have the final outcome.
             // WebhookAttemptCounterHandler increments the count on each wire attempt.
             var response = await client.SendAsync(request, cancellationToken);
-
             var attempts = ReadAttemptCount(request);
+
+            // One-shot re-auth retry: a 401 on a token-bearer subscription means the cached token was
+            // rejected (expired/revoked). AddStandardResilienceHandler does NOT retry 401 (non-transient),
+            // so we handle it here — invalidate, mint a fresh token, and resend the update exactly ONCE.
+            // Each node self-heals on its own stale token; a genuinely bad credential 401s twice -> Failed.
+            if (subscription.AuthType == WebhookAuthType.TokenBearer &&
+                response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                logger.LogWarning(
+                    "Webhook token rejected (401) for subscription {SubscriptionId} ({SystemCode}); re-fetching token and retrying once",
+                    subscription.Id, subscription.SystemCode);
+
+                request.Dispose();
+                response.Dispose();
+
+                request = await BuildRequestAsync(forceFreshToken: true);
+                response = await client.SendAsync(request, cancellationToken);
+                attempts += ReadAttemptCount(request);
+            }
+
             subscription.RecordDelivery(dateTimeProvider.ApplicationNow);
 
             if (response.IsSuccessStatusCode)
@@ -179,18 +209,12 @@ public class WebhookService(
             }
             else
             {
-                // A 401 on a token-bearer subscription means the cached token was rejected
-                // (expired/revoked) — invalidate it. AddStandardResilienceHandler does NOT retry
-                // 401 (it's not a transient status), so this does not trigger an in-attempt retry;
-                // it just ensures the NEXT delivery attempt (the following PMA save, or a manual
-                // RetryWebhookDelivery) fetches a fresh token instead of reusing the rejected one.
+                // Still failing after the (at most one) re-auth retry. If it's a persistent 401 on a
+                // token-bearer subscription, drop the cached token so the NEXT delivery also starts fresh.
                 if (subscription.AuthType == WebhookAuthType.TokenBearer &&
                     response.StatusCode == HttpStatusCode.Unauthorized)
                 {
                     tokenProvider.InvalidateToken(subscription.Id);
-                    logger.LogWarning(
-                        "Webhook token rejected (401) for subscription {SubscriptionId} ({SystemCode}); cached token invalidated",
-                        subscription.Id, subscription.SystemCode);
                 }
 
                 delivery.RecordFailure((int)response.StatusCode, attempts, null);
@@ -214,7 +238,7 @@ public class WebhookService(
                 subscription.CallbackUrl,
                 delivery.EventType);
 
-            delivery.RecordFailure(0, ReadAttemptCount(request), ex.Message);
+            delivery.RecordFailure(0, request is null ? 0 : ReadAttemptCount(request), ex.Message);
             await PersistDeliveryAsync(delivery, cancellationToken);
 
             return new WebhookDeliveryOutcome(false, ex.Message);

--- a/Modules/Integration/Integration/FileInterface/Format/RegulatoryExport/RegulatoryExcelWriter.cs
+++ b/Modules/Integration/Integration/FileInterface/Format/RegulatoryExport/RegulatoryExcelWriter.cs
@@ -23,8 +23,8 @@ public sealed class RegulatoryExcelWriter
     private static readonly string[] Headers =
     [
         "Collateral Type",
-        "Previous Appraisal No.",
-        "Latest Appraisal No.",
+        "Application Id (Appraisal No.)",
+        "Newest Application Id (Appraisal No.)",
         "HOST Collateral ID",
         "Under Construction",
         "Construction Progress (%)",
@@ -87,7 +87,8 @@ public sealed class RegulatoryExcelWriter
         var c = 1;
 
         ws.Cell(r, c++).Value = row.CollateralType;
-        ws.Cell(r, c++).Value = row.PreviousAppraisalNumber ?? "";
+        // Both Application Id and Newest Application Id carry the latest appraisal number (matches the file).
+        ws.Cell(r, c++).Value = row.LatestAppraisalNumber ?? "";
         ws.Cell(r, c++).Value = row.LatestAppraisalNumber ?? "";
         ws.Cell(r, c++).Value = row.HostCollateralId ?? "";
         ws.Cell(r, c++).Value = UnderConstructionText(row);
@@ -141,21 +142,22 @@ public sealed class RegulatoryExcelWriter
         row.CollateralType is CollateralTypes.Land or CollateralTypes.Leasehold;
 
     // Mirrors RegulatoryFileWriter's Under Construction rule (Y/N/L/blank), rendered as readable text.
+    // Only land / building / land&building types are in-group; condo (and everything else) → blank.
     private static string UnderConstructionText(RegulatoryExportRow row)
     {
         if (IsBareLand(row))
             return "Vacant land (L)";
-        if (IsBuildingType(row) || IsCondo(row))
+        if (IsBuildingType(row))
             return row.IsUnderConstruction ? "Under construction (Y)" : "Completed (N)";
         return "";
     }
 
-    // Mirrors RegulatoryFileWriter's Construction Progress rule.
+    // Mirrors RegulatoryFileWriter's Construction Progress rule (condo and other non-land/building → 0.00).
     private static decimal? ConstructionProgress(RegulatoryExportRow row)
     {
         if (IsBareLand(row))
             return 100m;
-        if (IsBuildingType(row) || IsCondo(row))
+        if (IsBuildingType(row))
             return row.ConstructionProgressPercent ?? 0m;
         return 0m;
     }

--- a/Modules/Integration/Integration/FileInterface/Format/RegulatoryExport/RegulatoryFileWriter.cs
+++ b/Modules/Integration/Integration/FileInterface/Format/RegulatoryExport/RegulatoryFileWriter.cs
@@ -69,10 +69,12 @@ public sealed class RegulatoryFileWriter
 
         bool isCondoType = row.CollateralType == CollateralTypes.Condo;
 
-        bool isLandOrBuildingOrLB = isLandType || isBuildingType || isCondoType;
+        // Under-construction and construction-progress apply only to land / building / land&building
+        // types. Condo (and everything else) → blank / 0.00.
+        bool isLandOrBuilding = isLandType || isBuildingType;
 
         string underConstruction;
-        if (!isLandOrBuildingOrLB)
+        if (!isLandOrBuilding)
         {
             underConstruction = string.Empty;
         }
@@ -80,17 +82,14 @@ public sealed class RegulatoryFileWriter
         {
             underConstruction = "L";
         }
-        else if (isBuildingType)
-        {
-            underConstruction = row.IsUnderConstruction ? "Y" : "N";
-        }
         else
         {
+            // Remaining in-group types are building types (LB / LSB / LS).
             underConstruction = row.IsUnderConstruction ? "Y" : "N";
         }
 
         string constructionProgress;
-        if (!isLandOrBuildingOrLB)
+        if (!isLandOrBuilding)
         {
             constructionProgress = Money(0m)!;
         }
@@ -124,7 +123,9 @@ public sealed class RegulatoryFileWriter
         var values = new Dictionary<string, string?>
         {
             ["RecordType"]                 = "D",
-            ["ApplicationId"]              = row.PreviousAppraisalNumber,
+            // Both Application Id and Newest Application Id carry the latest appraisal number — the
+            // bank always sends the latest report number in both fields.
+            ["ApplicationId"]              = row.LatestAppraisalNumber,
             ["NewestApplicationId"]        = row.LatestAppraisalNumber,
             ["CollateralIdHost"]           = row.HostCollateralId,
             ["UnderConstruction"]          = underConstruction,
@@ -176,5 +177,5 @@ public sealed class RegulatoryFileWriter
             : null;
 
     private static string? Date(DateTime? value) =>
-        value.HasValue ? DateOnly.FromDateTime(value.Value).ToString("ddMMyyyy", CultureInfo.InvariantCulture) : null;
+        value.HasValue ? DateOnly.FromDateTime(value.Value).ToString("yyyyMMdd", CultureInfo.InvariantCulture) : null;
 }

--- a/Modules/Workflow/Workflow/Data/Configurations/PendingTaskConfiguration.cs
+++ b/Modules/Workflow/Workflow/Data/Configurations/PendingTaskConfiguration.cs
@@ -29,6 +29,9 @@ public class PendingTaskConfiguration : IEntityTypeConfiguration<PendingTask>
         builder.Property(p => p.LockedAt)
             .IsRequired(false);
 
+        builder.Property(p => p.OpenedAt)
+            .IsRequired(false);
+
         builder.Property(p => p.WorkflowInstanceId);
 
         builder.Property(p => p.ActivityId)

--- a/Modules/Workflow/Workflow/Infrastructure/Migrations/20260715054053_AddPendingTaskOpenedAt.Designer.cs
+++ b/Modules/Workflow/Workflow/Infrastructure/Migrations/20260715054053_AddPendingTaskOpenedAt.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Workflow.Data;
 
@@ -11,9 +12,11 @@ using Workflow.Data;
 namespace Workflow.Infrastructure.Migrations
 {
     [DbContext(typeof(WorkflowDbContext))]
-    partial class WorkflowDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260715054053_AddPendingTaskOpenedAt")]
+    partial class AddPendingTaskOpenedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modules/Workflow/Workflow/Infrastructure/Migrations/20260715054053_AddPendingTaskOpenedAt.cs
+++ b/Modules/Workflow/Workflow/Infrastructure/Migrations/20260715054053_AddPendingTaskOpenedAt.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Workflow.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPendingTaskOpenedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "OpenedAt",
+                schema: "workflow",
+                table: "PendingTasks",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OpenedAt",
+                schema: "workflow",
+                table: "PendingTasks");
+        }
+    }
+}

--- a/Modules/Workflow/Workflow/Tasks/Models/PendingTask.cs
+++ b/Modules/Workflow/Workflow/Tasks/Models/PendingTask.cs
@@ -13,6 +13,13 @@ public class PendingTask : Aggregate<Guid>
     public DateTime AssignedAt { get; private set; }
     public string? WorkingBy { get; private set; }
     public DateTime? LockedAt { get; private set; }
+
+    /// <summary>
+    /// The moment the assignee first opened the task (first transition to InProgress). Stamped once
+    /// in <see cref="StartWorking"/> and never overwritten, so it records the initial open time even
+    /// if the task is later re-opened. Null while the task is still Assigned/unopened.
+    /// </summary>
+    public DateTime? OpenedAt { get; private set; }
     public Guid WorkflowInstanceId { get; private set; }
     public string ActivityId { get; private set; } = default!;
     public DateTime? DueAt { get; private set; }
@@ -134,6 +141,8 @@ public class PendingTask : Aggregate<Guid>
     {
         WorkingBy = username;
         TaskStatus = TaskStatus.InProgress;
+        // Record the first-open timestamp; keep the original once set even if re-opened later.
+        OpenedAt ??= DateTime.Now;
         AddDomainEvent(new TaskStartedDomainEvent(CorrelationId, AssignedTo, AssignedAt, previousAssignedTo));
     }
 

--- a/Tests/Integration/Collateral.Integration.Tests/CollateralUpsertServiceTests.cs
+++ b/Tests/Integration/Collateral.Integration.Tests/CollateralUpsertServiceTests.cs
@@ -1526,10 +1526,14 @@ public class CollateralUpsertServiceTests(IntegrationTestFixture fixture)
     }
 
     // -----------------------------------------------------------------------
-    // Condo_Leasehold_Machine_AreSingletonGroups_IsMasterTrueParentMasterIdNull
+    // Condo_Machine_NoLand_ExactlyOnePrimary_OtherBecomesTypedAlias
+    // One-collateral-per-appraisal model: when Condo and Machine coexist with no Land in the
+    // same appraisal, exactly ONE of them stays IsMaster=true (the primary, owning the single
+    // engagement); the other becomes a typed alias (IsMaster=false, ParentMasterId=primary.Id)
+    // while keeping its own type detail intact.
     // -----------------------------------------------------------------------
     [Fact]
-    public async Task Condo_Leasehold_Machine_AreSingletonGroups_IsMasterTrueParentMasterIdNull()
+    public async Task Condo_Machine_NoLand_ExactlyOnePrimary_OtherBecomesTypedAlias()
     {
         var tag = Guid.NewGuid().ToString("N")[..8];
         Guid appraisalId;
@@ -1555,21 +1559,535 @@ public class CollateralUpsertServiceTests(IntegrationTestFixture fixture)
         // Condo
         var condo = await collateralDb.CollateralMasters
             .Include(m => m.CondoDetail)
+            .Include(m => m.Engagements)
             .FirstOrDefaultAsync(m => m.CondoDetail != null &&
                                       m.CondoDetail.CondoRegistrationNumber == $"SING-CR-{tag}",
                 TestContext.Current.CancellationToken);
         Assert.NotNull(condo);
-        Assert.True(condo.IsMaster, "Condo must be IsMaster=true");
-        Assert.Null(condo.ParentMasterId);
 
         // Machine
         var machine = await collateralDb.CollateralMasters
             .Include(m => m.MachineDetail)
+            .Include(m => m.Engagements)
             .FirstOrDefaultAsync(m => m.MachineDetail != null &&
                                       m.MachineDetail.MachineRegistrationNo == $"SING-REG-{tag}",
                 TestContext.Current.CancellationToken);
         Assert.NotNull(machine);
-        Assert.True(machine.IsMaster, "Machine must be IsMaster=true");
+
+        // Exactly one of the two ends up IsMaster=true (the appraisal's primary).
+        Assert.NotEqual(condo!.IsMaster, machine!.IsMaster);
+
+        var primary = condo.IsMaster ? condo : machine;
+        var alias = condo.IsMaster ? machine : condo;
+
+        Assert.Null(primary.ParentMasterId);
+        Assert.Single(primary.Engagements);
+
+        Assert.False(alias.IsMaster);
+        Assert.Equal(primary.Id, alias.ParentMasterId);
+        Assert.Empty(alias.Engagements);
+
+        // The alias keeps its OWN type detail — nothing was collapsed/dropped.
+        Assert.NotNull(condo.CondoDetail);
+        Assert.NotNull(machine.MachineDetail);
+    }
+
+    // -----------------------------------------------------------------------
+    // Task (a): Land + Machinery multi-component appraisal → exactly ONE IsMaster (the collapsed
+    // land master); the machinery group is persisted as a typed alias (IsMaster=0,
+    // ParentMasterId=primary, MachineDetail intact).
+    // -----------------------------------------------------------------------
+    [Fact]
+    public async Task LandAndMachinery_OneIsMaster_MachineryBecomesTypedAlias()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var titleNo = $"LM-{tag}";
+        var regNo = $"LM-REG-{tag}";
+        Guid appraisalId;
+
+        using (var seedScope = CreateScope())
+        {
+            var appraisalDb = GetAppraisalDbContext(seedScope);
+            var a = CreateAppraisalSeed(Guid.NewGuid());
+            SeedLandProperty(a, "LO-001", "BKK", "D1", "S1", titleNo, "Chanote");
+            SeedMachineryProperty(a, registrationNo: regNo,
+                serialNo: "S1", brand: "BRAND-M", model: "M1", manufacturer: "MFR-M");
+            appraisalDb.Appraisals.Add(a);
+            await appraisalDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+            appraisalId = a.Id;
+        }
+
+        await ProcessAppraisalInNewScopeAsync(appraisalId);
+
+        using var assertScope = CreateScope();
+        var collateralDb = GetCollateralDbContext(assertScope);
+
+        var landMaster = await collateralDb.CollateralMasters
+            .Include(m => m.LandDetail)
+            .Include(m => m.Engagements)
+            .FirstAsync(m => m.LandDetail != null && m.LandDetail.TitleNumber == titleNo,
+                TestContext.Current.CancellationToken);
+
+        var machine = await collateralDb.CollateralMasters
+            .Include(m => m.MachineDetail)
+            .Include(m => m.Engagements)
+            .FirstAsync(m => m.MachineDetail != null && m.MachineDetail.MachineRegistrationNo == regNo,
+                TestContext.Current.CancellationToken);
+
+        // Land is unconditionally the primary when present.
+        Assert.True(landMaster.IsMaster);
+        Assert.Null(landMaster.ParentMasterId);
+        Assert.Single(landMaster.Engagements);
+
+        // Machinery is a typed alias of the land master, but keeps its own MachineDetail.
+        Assert.False(machine.IsMaster);
+        Assert.Equal(landMaster.Id, machine.ParentMasterId);
+        Assert.Empty(machine.Engagements);
+        Assert.NotNull(machine.MachineDetail);
+        Assert.Equal(regNo, machine.MachineDetail!.MachineRegistrationNo);
+
+        // Exactly one IsMaster row across the whole appraisal's components.
+        var allRows = await collateralDb.CollateralMasters
+            .Where(m => m.Id == landMaster.Id || m.Id == machine.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(1, allRows.Count(m => m.IsMaster));
+
+        // Exactly one engagement for the whole appraisal.
+        var engCount = await collateralDb.CollateralEngagements
+            .CountAsync(e => e.AppraisalId == appraisalId, TestContext.Current.CancellationToken);
+        Assert.Equal(1, engCount);
+    }
+
+    // -----------------------------------------------------------------------
+    // Task (b): Reappraising the SAME land+machinery collateral resolves the same primary + the
+    // same alias row — no duplicate masters/aliases created, and the second run is idempotent.
+    // -----------------------------------------------------------------------
+    [Fact]
+    public async Task LandAndMachinery_Reappraisal_ResolvesSamePrimaryAndAlias_Idempotent()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var titleNo = $"LMR-{tag}";
+        var regNo = $"LMR-REG-{tag}";
+        Guid a1Id, a2Id;
+
+        using (var seedScope = CreateScope())
+        {
+            var appraisalDb = GetAppraisalDbContext(seedScope);
+            var a1 = CreateAppraisalSeed(Guid.NewGuid());
+            SeedLandProperty(a1, "LO-001", "BKK", "D1", "S1", titleNo, "Chanote");
+            SeedMachineryProperty(a1, registrationNo: regNo,
+                serialNo: "S1", brand: "BRAND-M", model: "M1", manufacturer: "MFR-M");
+            appraisalDb.Appraisals.Add(a1);
+            await appraisalDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+            a1Id = a1.Id;
+        }
+        await ProcessAppraisalInNewScopeAsync(a1Id);
+
+        Guid landId1, machineId1;
+        using (var checkScope = CreateScope())
+        {
+            var collateralDb = GetCollateralDbContext(checkScope);
+            landId1 = (await collateralDb.CollateralMasters
+                .Include(m => m.LandDetail)
+                .FirstAsync(m => m.LandDetail != null && m.LandDetail.TitleNumber == titleNo,
+                    TestContext.Current.CancellationToken)).Id;
+            machineId1 = (await collateralDb.CollateralMasters
+                .Include(m => m.MachineDetail)
+                .FirstAsync(m => m.MachineDetail != null && m.MachineDetail.MachineRegistrationNo == regNo,
+                    TestContext.Current.CancellationToken)).Id;
+        }
+
+        // Reappraisal — SAME land title + SAME machine registration (same physical collateral).
+        using (var seedScope = CreateScope())
+        {
+            var appraisalDb = GetAppraisalDbContext(seedScope);
+            var a2 = CreateAppraisalSeed(Guid.NewGuid());
+            SeedLandProperty(a2, "LO-001", "BKK", "D1", "S1", titleNo, "Chanote");
+            SeedMachineryProperty(a2, registrationNo: regNo,
+                serialNo: "S1", brand: "BRAND-M", model: "M1", manufacturer: "MFR-M");
+            appraisalDb.Appraisals.Add(a2);
+            await appraisalDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+            a2Id = a2.Id;
+        }
+        await ProcessAppraisalInNewScopeAsync(a2Id);
+
+        // Re-run the SAME (second) appraisal again — must be a idempotent no-op.
+        await ProcessAppraisalInNewScopeAsync(a2Id);
+
+        using var assertScope = CreateScope();
+        var collateralDbAssert = GetCollateralDbContext(assertScope);
+
+        var landRows = await collateralDbAssert.CollateralMasters
+            .Include(m => m.LandDetail)
+            .Include(m => m.Engagements)
+            .Where(m => m.LandDetail != null && m.LandDetail.TitleNumber == titleNo)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        var machineRows = await collateralDbAssert.CollateralMasters
+            .Include(m => m.MachineDetail)
+            .Include(m => m.Engagements)
+            .Where(m => m.MachineDetail != null && m.MachineDetail.MachineRegistrationNo == regNo)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        // No duplicate masters/aliases — same rows resolved every time.
+        Assert.Single(landRows);
+        Assert.Single(machineRows);
+        Assert.Equal(landId1, landRows[0].Id);
+        Assert.Equal(machineId1, machineRows[0].Id);
+
+        var landMaster = landRows[0];
+        var machine = machineRows[0];
+
+        Assert.True(landMaster.IsMaster);
+        Assert.False(machine.IsMaster);
+        Assert.Equal(landMaster.Id, machine.ParentMasterId);
+
+        // Two engagements total (one per distinct appraisal), both on the primary; the
+        // re-run of a2 did not add a third.
+        Assert.Equal(2, landMaster.Engagements.Count);
+        Assert.Contains(landMaster.Engagements, e => e.AppraisalId == a1Id);
+        Assert.Contains(landMaster.Engagements, e => e.AppraisalId == a2Id);
+        Assert.Empty(machine.Engagements);
+    }
+
+    // -----------------------------------------------------------------------
+    // Task (c): Standalone single-type appraisals (pure Condo, pure Machine) still produce ONE
+    // IsMaster with no alias — the sole component is trivially the primary.
+    // -----------------------------------------------------------------------
+    [Fact]
+    public async Task StandaloneCondo_IsMasterTrueNoAlias()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        Guid appraisalId;
+
+        using (var seedScope = CreateScope())
+        {
+            var appraisalDb = GetAppraisalDbContext(seedScope);
+            var a = CreateAppraisalSeed(Guid.NewGuid());
+            SeedCondoProperty(a, "LO-BKK", $"STC-{tag}", "B1", "5", "501",
+                $"STC-T-{tag}", "Chanote", "Bangkok");
+            appraisalDb.Appraisals.Add(a);
+            await appraisalDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+            appraisalId = a.Id;
+        }
+
+        await ProcessAppraisalInNewScopeAsync(appraisalId);
+
+        using var assertScope = CreateScope();
+        var collateralDb = GetCollateralDbContext(assertScope);
+
+        var condo = await collateralDb.CollateralMasters
+            .Include(m => m.CondoDetail)
+            .Include(m => m.Engagements)
+            .FirstAsync(m => m.CondoDetail != null && m.CondoDetail.CondoRegistrationNumber == $"STC-{tag}",
+                TestContext.Current.CancellationToken);
+
+        Assert.True(condo.IsMaster);
+        Assert.Null(condo.ParentMasterId);
+        Assert.Single(condo.Engagements);
+
+        var engCount = await collateralDb.CollateralEngagements
+            .CountAsync(e => e.AppraisalId == appraisalId, TestContext.Current.CancellationToken);
+        Assert.Equal(1, engCount);
+    }
+
+    [Fact]
+    public async Task StandaloneMachine_IsMasterTrueNoAlias()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var regNo = $"STM-{tag}";
+        Guid appraisalId;
+
+        using (var seedScope = CreateScope())
+        {
+            var appraisalDb = GetAppraisalDbContext(seedScope);
+            var a = CreateAppraisalSeed(Guid.NewGuid());
+            SeedMachineryProperty(a, registrationNo: regNo,
+                serialNo: "S1", brand: "BRAND-X", model: "M1", manufacturer: "MFR-X");
+            appraisalDb.Appraisals.Add(a);
+            await appraisalDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+            appraisalId = a.Id;
+        }
+
+        await ProcessAppraisalInNewScopeAsync(appraisalId);
+
+        using var assertScope = CreateScope();
+        var collateralDb = GetCollateralDbContext(assertScope);
+
+        var machine = await collateralDb.CollateralMasters
+            .Include(m => m.MachineDetail)
+            .Include(m => m.Engagements)
+            .FirstAsync(m => m.MachineDetail != null && m.MachineDetail.MachineRegistrationNo == regNo,
+                TestContext.Current.CancellationToken);
+
+        Assert.True(machine.IsMaster);
         Assert.Null(machine.ParentMasterId);
+        Assert.Single(machine.Engagements);
+
+        var engCount = await collateralDb.CollateralEngagements
+            .CountAsync(e => e.AppraisalId == appraisalId, TestContext.Current.CancellationToken);
+        Assert.Equal(1, engCount);
+    }
+
+    // -----------------------------------------------------------------------
+    // C1 regression guard — role change: a component that was appraised STANDALONE (has its own
+    // engagement history) must never be demoted, even when a later appraisal makes it a
+    // non-primary component alongside Land. Old behavior (before the C1 fix) threw
+    // InvalidOperationException from DemoteToAlias here, permanently failing A2.
+    // -----------------------------------------------------------------------
+    [Fact]
+    public async Task Machine_StandaloneThenLandPrimary_MachineKeepsIsMasterAndOwnEngagement()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var regNo = $"RC-{tag}";
+        var titleNo = $"RC-LAND-{tag}";
+        Guid a1Id, a2Id;
+
+        // A1: machine-only appraisal — machine M becomes IsMaster with engagement E1.
+        using (var seedScope = CreateScope())
+        {
+            var appraisalDb = GetAppraisalDbContext(seedScope);
+            var a1 = CreateAppraisalSeed(Guid.NewGuid());
+            SeedMachineryProperty(a1, registrationNo: regNo,
+                serialNo: "S1", brand: "BRAND-RC", model: "M1", manufacturer: "MFR-RC");
+            appraisalDb.Appraisals.Add(a1);
+            await appraisalDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+            a1Id = a1.Id;
+        }
+        await ProcessAppraisalInNewScopeAsync(a1Id);
+
+        Guid machineId;
+        using (var checkScope = CreateScope())
+        {
+            var collateralDb = GetCollateralDbContext(checkScope);
+            var machine = await collateralDb.CollateralMasters
+                .Include(m => m.MachineDetail)
+                .Include(m => m.Engagements)
+                .FirstAsync(m => m.MachineDetail != null && m.MachineDetail.MachineRegistrationNo == regNo,
+                    TestContext.Current.CancellationToken);
+            Assert.True(machine.IsMaster);
+            Assert.Single(machine.Engagements);
+            machineId = machine.Id;
+        }
+
+        // A2: land + the SAME machine — land is the (unconditional) primary, so the machine is
+        // now a non-primary component. It must NOT be demoted (it has engagement history).
+        using (var seedScope = CreateScope())
+        {
+            var appraisalDb = GetAppraisalDbContext(seedScope);
+            var a2 = CreateAppraisalSeed(Guid.NewGuid());
+            SeedLandProperty(a2, "LO-001", "BKK", "D1", "S1", titleNo, "Chanote");
+            SeedMachineryProperty(a2, registrationNo: regNo,
+                serialNo: "S1", brand: "BRAND-RC", model: "M1", manufacturer: "MFR-RC");
+            appraisalDb.Appraisals.Add(a2);
+            await appraisalDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+            a2Id = a2.Id;
+        }
+
+        // Must NOT throw — this was the C1 regression (DemoteToAlias threw on M here).
+        await ProcessAppraisalInNewScopeAsync(a2Id);
+
+        using var assertScope = CreateScope();
+        var collateralDbAssert = GetCollateralDbContext(assertScope);
+
+        var landMaster = await collateralDbAssert.CollateralMasters
+            .Include(m => m.LandDetail)
+            .Include(m => m.Engagements)
+            .FirstAsync(m => m.LandDetail != null && m.LandDetail.TitleNumber == titleNo,
+                TestContext.Current.CancellationToken);
+
+        var machineReloaded = await collateralDbAssert.CollateralMasters
+            .Include(m => m.MachineDetail)
+            .Include(m => m.Engagements)
+            .FirstAsync(m => m.Id == machineId, TestContext.Current.CancellationToken);
+
+        // Land is A2's new primary, owning exactly one (new) engagement for A2.
+        Assert.True(landMaster.IsMaster);
+        Assert.Single(landMaster.Engagements);
+        Assert.Contains(landMaster.Engagements, e => e.AppraisalId == a2Id);
+
+        // The machine master STAYS IsMaster (appraised standalone in A1) and RETAINS E1 — it was
+        // not demoted, and A2 did not add a second engagement to it.
+        Assert.True(machineReloaded.IsMaster);
+        Assert.Null(machineReloaded.ParentMasterId);
+        Assert.Single(machineReloaded.Engagements);
+        Assert.Contains(machineReloaded.Engagements, e => e.AppraisalId == a1Id);
+
+        // Two distinct IsMaster rows now legitimately exist — expected and correct under the
+        // "engagement history makes a row a real collateral" rule.
+        Assert.NotEqual(landMaster.Id, machineReloaded.Id);
+    }
+
+    // -----------------------------------------------------------------------
+    // W1 regression guard — role change back: a component demoted to a (no-engagement) alias
+    // under a different primary must be PROMOTED back to a standalone IsMaster when a later
+    // appraisal makes it, in its own right, the primary — never walked to its old (foreign)
+    // parent, which would misattribute the engagement to an unrelated collateral.
+    // -----------------------------------------------------------------------
+    [Fact]
+    public async Task Condo_DemotedThenReappraisedStandalone_IsPromotedBackToMaster()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var titleNo = $"PR-LAND-{tag}";
+        var condoRegNo = $"PR-{tag}";
+        Guid a1Id, a2Id;
+
+        // A1: land + condo — land is primary; the condo has no engagement of its own, so it is
+        // demoted to a typed alias of the land master.
+        using (var seedScope = CreateScope())
+        {
+            var appraisalDb = GetAppraisalDbContext(seedScope);
+            var a1 = CreateAppraisalSeed(Guid.NewGuid());
+            SeedLandProperty(a1, "LO-001", "BKK", "D1", "S1", titleNo, "Chanote");
+            SeedCondoProperty(a1, "LO-BKK", condoRegNo, "B1", "5", "501", $"PR-T-{tag}", "Chanote", "Bangkok");
+            appraisalDb.Appraisals.Add(a1);
+            await appraisalDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+            a1Id = a1.Id;
+        }
+        await ProcessAppraisalInNewScopeAsync(a1Id);
+
+        Guid condoId;
+        using (var checkScope = CreateScope())
+        {
+            var collateralDb = GetCollateralDbContext(checkScope);
+            var condo = await collateralDb.CollateralMasters
+                .Include(m => m.CondoDetail)
+                .Include(m => m.Engagements)
+                .FirstAsync(m => m.CondoDetail != null && m.CondoDetail.CondoRegistrationNumber == condoRegNo,
+                    TestContext.Current.CancellationToken);
+            Assert.False(condo.IsMaster);
+            Assert.NotNull(condo.ParentMasterId);
+            Assert.Empty(condo.Engagements);
+            condoId = condo.Id;
+        }
+
+        // A2: condo-only reappraisal — the SAME condo is now, in its own right, this appraisal's
+        // primary. It must be promoted back to IsMaster, not resolved to its old (foreign) parent.
+        using (var seedScope = CreateScope())
+        {
+            var appraisalDb = GetAppraisalDbContext(seedScope);
+            var a2 = CreateAppraisalSeed(Guid.NewGuid());
+            SeedCondoProperty(a2, "LO-BKK", condoRegNo, "B1", "5", "501", $"PR-T-{tag}", "Chanote", "Bangkok");
+            appraisalDb.Appraisals.Add(a2);
+            await appraisalDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+            a2Id = a2.Id;
+        }
+        await ProcessAppraisalInNewScopeAsync(a2Id);
+
+        using var assertScope = CreateScope();
+        var collateralDbAssert = GetCollateralDbContext(assertScope);
+
+        var condoReloaded = await collateralDbAssert.CollateralMasters
+            .Include(m => m.CondoDetail)
+            .Include(m => m.Engagements)
+            .FirstAsync(m => m.Id == condoId, TestContext.Current.CancellationToken);
+
+        Assert.True(condoReloaded.IsMaster);
+        Assert.Null(condoReloaded.ParentMasterId);
+        Assert.Single(condoReloaded.Engagements);
+        Assert.Contains(condoReloaded.Engagements, e => e.AppraisalId == a2Id);
+    }
+
+    // -----------------------------------------------------------------------
+    // W2 regression guard — Leasehold-as-primary ordering: the lowest-GroupNumber group is a
+    // Leasehold group (processed last, in pass 2), while a SEPARATE Machine group (pass 1,
+    // non-primary) also exists. Exactly one IsMaster (the leasehold) must result; the machine
+    // becomes a typed alias; one engagement lands on the leasehold.
+    //
+    // The leasehold's own underlying Condo is pre-seeded directly (no engagement) so pass 1's
+    // independent processing of that same Condo property and the leasehold's underlying-
+    // resolution both resolve to the SAME already-persisted row within the unit of work — this
+    // sidesteps an unrelated, pre-existing gap where the underlying-Condo lookup (unlike Land's
+    // landMasterByPropertyId cache) doesn't see an Added-but-unsaved row from earlier in the
+    // same SaveChanges batch.
+    // -----------------------------------------------------------------------
+    [Fact]
+    public async Task LeaseholdOnlyPrimary_NoLand_MachineNonPrimaryGroupBecomesTypedAlias()
+    {
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var condoRegNo = $"LHU-{tag}";
+        var contractNo = $"LHC-{tag}";
+        var machineRegNo = $"LHM-{tag}";
+
+        using (var preSeedScope = CreateScope())
+        {
+            var collateralDb = GetCollateralDbContext(preSeedScope);
+            var underlyingCondo = CollateralMaster.CreateCondo(
+                ownerName: "Test Owner",
+                landOfficeCode: "LO-BKK",
+                condoRegistrationNumber: condoRegNo,
+                buildingNumber: "B1",
+                floorNumber: "5",
+                roomNumber: "501",
+                province: "Bangkok",
+                district: "Test District",
+                subDistrict: "Test Subdistrict",
+                condoName: null);
+            collateralDb.CollateralMasters.Add(underlyingCondo);
+            await collateralDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        Guid appraisalId;
+        using (var seedScope = CreateScope())
+        {
+            var appraisalDb = GetAppraisalDbContext(seedScope);
+            var a = CreateAppraisalSeed(Guid.NewGuid());
+
+            // Leasehold property — its own group, GroupNumber=1 (lowest → primary).
+            var lhProp = a.AddLeaseAgreementLandProperty();
+            lhProp.LeaseAgreementDetail!.Update(
+                contractNo: contractNo,
+                lessorName: "Landlord Co",
+                lesseeName: "Tenant Inc",
+                leaseStartDate: new DateTime(2022, 1, 1));
+            var lhGroup = a.CreateGroup("Leasehold Group");
+            lhGroup.AddProperty(lhProp.Id);
+
+            // The pre-seeded condo, present in THIS appraisal too (required for
+            // UpsertLeaseholdAsync's no-land underlying-resolution fallback). Left ungrouped.
+            SeedCondoProperty(a, "LO-BKK", condoRegNo, "B1", "5", "501", "N/A", "Chanote", "Bangkok");
+
+            // Machine property — its OWN group, GroupNumber=2 (non-primary, unrelated to the lease).
+            var machineProp = SeedMachineryProperty(a, registrationNo: machineRegNo,
+                serialNo: "S1", brand: "BRAND-L", model: "M1", manufacturer: "MFR-L");
+            var machineGroup = a.CreateGroup("Machine Group");
+            machineGroup.AddProperty(machineProp.Id);
+
+            appraisalDb.Appraisals.Add(a);
+            await appraisalDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+            appraisalId = a.Id;
+        }
+
+        await ProcessAppraisalInNewScopeAsync(appraisalId);
+
+        using var assertScope = CreateScope();
+        var collateralDb2 = GetCollateralDbContext(assertScope);
+
+        var leaseMaster = await collateralDb2.CollateralMasters
+            .Include(m => m.LeaseholdDetail)
+            .Include(m => m.Engagements)
+            .FirstAsync(m => m.LeaseholdDetail != null && m.LeaseholdDetail.LeaseRegistrationNo == contractNo,
+                TestContext.Current.CancellationToken);
+
+        var machine = await collateralDb2.CollateralMasters
+            .Include(m => m.MachineDetail)
+            .Include(m => m.Engagements)
+            .FirstAsync(m => m.MachineDetail != null && m.MachineDetail.MachineRegistrationNo == machineRegNo,
+                TestContext.Current.CancellationToken);
+
+        // Leasehold is the appraisal's primary — owns the single engagement.
+        Assert.True(leaseMaster.IsMaster);
+        Assert.Null(leaseMaster.ParentMasterId);
+        Assert.Single(leaseMaster.Engagements);
+
+        // The separately-grouped Machine (pass-1, non-primary) becomes a typed alias, keeping
+        // its own MachineDetail.
+        Assert.False(machine.IsMaster);
+        Assert.Equal(leaseMaster.Id, machine.ParentMasterId);
+        Assert.Empty(machine.Engagements);
+        Assert.NotNull(machine.MachineDetail);
+
+        var engCount = await collateralDb2.CollateralEngagements
+            .CountAsync(e => e.AppraisalId == appraisalId, TestContext.Current.CancellationToken);
+        Assert.Equal(1, engCount);
     }
 }

--- a/Tests/Unit/Collateral.Tests/RegulatoryExport/RegulatoryExcelWriterTests.cs
+++ b/Tests/Unit/Collateral.Tests/RegulatoryExport/RegulatoryExcelWriterTests.cs
@@ -13,7 +13,6 @@ namespace Collateral.Tests.RegulatoryExport;
 public class RegulatoryExcelWriterTests
 {
     private static RegulatoryExportRow SampleRow() => new(
-        PreviousAppraisalNumber: "6800100",
         LatestAppraisalNumber: "6800123",
         CollateralType: CollateralTypes.LandWithBuilding,
         HostCollateralId: "6702522",

--- a/Tests/Unit/Collateral.Tests/RegulatoryExport/RegulatoryFileWriterTests.cs
+++ b/Tests/Unit/Collateral.Tests/RegulatoryExport/RegulatoryFileWriterTests.cs
@@ -7,7 +7,7 @@ namespace Collateral.Tests.RegulatoryExport;
 /// <summary>
 /// Pins <see cref="RegulatoryFileWriter"/> to the 300-char CAS-AS400-Regulatory layout, focusing on the
 /// corrected sourcing rules:
-///   • Field 2 (ApplicationId) = the PREVIOUS appraisal number (blank when none).
+///   • Field 2 (ApplicationId) = the LATEST appraisal number, same as field 3 (bank always sends latest).
 ///   • Field 8 (AppraisalValueOrigination) = earliest value when the latest engagement is a Progressive
 ///     (construction) inspection; otherwise the latest value.
 ///   • Field 10 (BuildingAge) = zero-filled building age (now sourced for all building types + condo).
@@ -21,7 +21,6 @@ namespace Collateral.Tests.RegulatoryExport;
 public class RegulatoryFileWriterTests
 {
     private static RegulatoryExportRow SampleRow() => new(
-        PreviousAppraisalNumber: "6800100",
         LatestAppraisalNumber: "6800123",
         CollateralType: CollateralTypes.LandWithBuilding, // "LB" → building fields populate
         HostCollateralId: "6702522",
@@ -52,21 +51,25 @@ public class RegulatoryFileWriterTests
     }
 
     [Fact]
-    public void Field2_ApplicationId_IsPreviousAppraisalNumber()
+    public void Field2And3_BothCarryLatestAppraisalNumber()
     {
         var line = new RegulatoryFileWriter().BuildDetail(SampleRow());
 
-        // pos 2-11 (index 1..11), left-aligned previous appraisal number.
-        Assert.Equal("6800100".PadRight(10), line[1..11]);
+        // pos 2-11 (index 1..11) ApplicationId and pos 12-21 (index 11..21) NewestApplicationId
+        // both left-aligned with the LATEST appraisal number.
+        Assert.Equal("6800123".PadRight(10), line[1..11]);
+        Assert.Equal("6800123".PadRight(10), line[11..21]);
     }
 
     [Fact]
-    public void Field2_ApplicationId_IsBlank_WhenNoPreviousEngagement()
+    public void Field5And6_AreBlankAndZero_ForCondo()
     {
-        var row = SampleRow() with { PreviousAppraisalNumber = null };
+        // Condo is NOT in the land/building/land&building group → Under Construction blank, progress 0.00.
+        var row = SampleRow() with { CollateralType = CollateralTypes.Condo, IsUnderConstruction = true };
         var line = new RegulatoryFileWriter().BuildDetail(row);
 
-        Assert.Equal(new string(' ', 10), line[1..11]);
+        Assert.Equal(' ', line[40]);                       // pos 41 UnderConstruction → blank
+        Assert.Equal("00000", line[41..46]);               // pos 42-46 ConstructionProgress → 0.00 (×100)
     }
 
     [Fact]
@@ -135,6 +138,15 @@ public class RegulatoryFileWriterTests
         var line = new RegulatoryFileWriter().BuildDetail(row);
 
         Assert.Equal(new string('0', 19), line[21..40]);
+    }
+
+    [Fact]
+    public void Field12_ValuationDate_IsYyyyMMdd()
+    {
+        var line = new RegulatoryFileWriter().BuildDetail(SampleRow());
+
+        // pos 98-105 (index 97..105), 8-char date, YYYYMMDD (2025-01-21 → "20250121").
+        Assert.Equal("20250121", line[97..105]);
     }
 
     [Fact]

--- a/docs/regulatory/regulatory-field-reference.md
+++ b/docs/regulatory/regulatory-field-reference.md
@@ -31,8 +31,9 @@ need to check the data that was sent.
 
 **Number formatting (important):** money/decimal fields are written as **implied-decimal, no decimal
 point** — the value is multiplied by 100 and left-padded with zeros. Example: `5,000,000.50` is written
-as `500000050`. A blank/absent numeric field is written as all zeros. Dates are `ddMMyyyy`; a blank date
-is spaces. (The Excel companion, by contrast, shows real decimals and `dd/MM/yyyy` dates for readability.)
+as `500000050`. A blank/absent numeric field is written as all zeros. Detail date fields are `YYYYMMDD`
+(e.g. `20250121`); a blank date is spaces. (The Excel companion, by contrast, shows real decimals and
+`dd/MM/yyyy` dates for readability.)
 
 ---
 
@@ -45,17 +46,17 @@ w/ Building (LS). "Land types" = Land (L), LB, Leasehold Land (LSL), LSB, LS.
 | # | Pos | Len | Field | Type | Where the value comes from / condition |
 |---|-----|-----|-------|------|----------------------------------------|
 | 1 | 1 | 1 | Record Type | string(1) | Constant `D` (Header `H`, Trailer `T`). |
-| 2 | 2–11 | 10 | Application Id (previous appraisal no.) | string(10) | The **previous** (2nd-most-recent) engagement's appraisal number for the master. Blank if the master has only one appraisal. |
+| 2 | 2–11 | 10 | Application Id (appraisal no.) | string(10) | The **latest** engagement's appraisal number — same value as field 3. The bank always sends the latest appraisal report number in this field. |
 | 3 | 12–21 | 10 | Newest Application Id (latest appraisal no.) | string(10) | The **latest** engagement's appraisal number. |
 | 4 | 22–40 | 19 | HOST Collateral ID | decimal(19,0) | `CollateralMaster.HostCollateralId`. Populated by the inbound host-mapping feed; **zeros until that feed provides it**. |
-| 5 | 41 | 1 | Collateral Under Construction | string(1) | `Y` / `N` / `L` / blank. **Rule:** not a land/building/condo type → blank; bare Land or Leasehold land → `L`; building types → `Y` if under construction else `N`; Condo → `Y`/`N`. "Under construction" comes from the land detail's *is-under-construction-at-last-appraisal* flag. |
-| 6 | 42–46 | 5 | Construction Progress % | decimal(5,2) | Not land/building/condo → `0.00`; bare Land/Leasehold → `100.00`; otherwise the land detail's overall construction-progress percent (bounded 0–100). |
+| 5 | 41 | 1 | Collateral Under Construction | string(1) | `Y` / `N` / `L` / blank. **Rule:** not a land / building / land&building type → blank (this includes **Condo**); bare Land or Leasehold land → `L`; building types → `Y` if under construction else `N`. "Under construction" comes from the land detail's *is-under-construction-at-last-appraisal* flag. |
+| 6 | 42–46 | 5 | Construction Progress % | decimal(5,2) | Not a land / building / land&building type → `0.00` (this includes **Condo**); bare Land/Leasehold → `100.00`; otherwise the land detail's overall construction-progress percent (bounded 0–100). |
 | 7 | 47–61 | 15 | Appraisal Value as Completed | decimal(15,2) | The **latest** engagement's appraisal value. |
 | 8 | 62–76 | 15 | Appraisal Value at Origination | decimal(15,2) | If the latest appraisal is a **Progressive** (construction) inspection → the **earliest** engagement's value (the first appraisal already estimated the as-completed value); otherwise the latest value. |
 | 9 | 77–79 | 3 | Number of Floors | decimal(3,0) | Building types → the representative building's floor count (bounded 0–999); otherwise `0`. |
 | 10 | 80–82 | 3 | Building Age (years) | decimal(3,0) | Building types → representative building's age; Condo → condo detail's building age; otherwise `0` (bounded 0–999). |
 | 11 | 83–97 | 15 | Market Selling Price | decimal(15,2) | **Not yet sourced — sent as zeros.** (Pending source confirmation.) |
-| 12 | 98–105 | 8 | Valuation Date | DDMMYYYY | The **latest** engagement's appraisal date. |
+| 12 | 98–105 | 8 | Valuation Date | YYYYMMDD | The **latest** engagement's appraisal date. |
 | 13 | 106–120 | 15 | Valuation Price in Baht | decimal(15,2) | The latest engagement's appraisal value (same figure as field 7). |
 | 14 | 121–135 | 15 | Mortgage Value | decimal(15,2) | **Not yet sourced — sent as zeros.** |
 | 15 | 136 | 1 | Appraiser Type | string(1) | `1` = external appraisal, `2` = internal. Determined by whether the latest engagement has an external appraisal-company id. |
@@ -66,10 +67,10 @@ w/ Building (LS). "Land types" = Land (L), LB, Leasehold Land (LSL), LSB, LS.
 | 20 | 152–158 | 7 | Area Utilization (building area) | decimal(7,2) | Building types → representative building's area; Condo → condo detail's usable area (≤ 99,999.99); otherwise zeros. |
 | 21 | 159–168 | 10 | Building Type ID | string(10) | Building types → representative building's building-type code; otherwise blank. |
 | 22 | 169–268 | 100 | Building Name | string(100) | Building types → the English description of the building-type code (from the BuildingType parameter table); otherwise blank. |
-| 23 | 269–276 | 8 | Expected Building Completion Date | DDMMYYYY | **Not yet sourced — sent blank.** |
-| 24 | 277–284 | 8 | Construction Review Date | DDMMYYYY | The latest **Progressive** (construction-inspection) engagement date. Blank if the master has none. |
-| 25 | 285–292 | 8 | First Valuation Date | DDMMYYYY | The **earliest** engagement's appraisal date. |
-| 26 | 293–300 | 8 | Latest Valuation Date | DDMMYYYY | The **latest** engagement's appraisal date. |
+| 23 | 269–276 | 8 | Expected Building Completion Date | YYYYMMDD | **Not yet sourced — sent blank.** |
+| 24 | 277–284 | 8 | Construction Review Date | YYYYMMDD | The latest **Progressive** (construction-inspection) engagement date. Blank if the master has none. |
+| 25 | 285–292 | 8 | First Valuation Date | YYYYMMDD | The **earliest** engagement's appraisal date. |
+| 26 | 293–300 | 8 | Latest Valuation Date | YYYYMMDD | The **latest** engagement's appraisal date. |
 
 **Widths sum to exactly 300.**
 
@@ -80,8 +81,7 @@ w/ Building (LS). "Land types" = Land (L), LB, Leasehold Land (LSL), LSB, LS.
 - **One record per active master collateral** (`IsDeleted = 0`, `IsMaster = 1`).
 - Most value/date fields are driven by the master's **engagements** (its appraisal history):
   - **Earliest** = engagement with the earliest appraisal date → first valuation date + origination value.
-  - **Latest** = engagement with the latest appraisal date → completed value, valuation date/price, latest date.
-  - **Previous** = the 2nd-most-recent engagement → the "Application Id" (previous appraisal number).
+  - **Latest** = engagement with the latest appraisal date → completed value, valuation date/price, latest date, and the appraisal number sent in **both** fields 2 and 3.
   - **Latest Progressive** = the latest engagement whose appraisal type is *Progressive* → construction review date.
 - **Representative building** (fields 9, 10, 20, 21, 22) = the first (`Sequence = 1`) building recorded on
   the **latest** engagement.


### PR DESCRIPTION
Bundles five independent, non-email changes carved out of the shared working tree. The email/notification feature is intentionally **excluded** and will follow in a separate PR. **Paired with a frontend PR** (host-id backfill page + monitoring UI) that must merge/deploy together — see the PIC filter note below.

## Changes
- **A. Collateral one-master-per-appraisal alias model** — enforce a single `IsMaster` collateral per appraisal with typed condo/machine/leasehold aliases; align Land/Condo required-field validation with the dedup keys.
- **B. HostCollateralId backfill** — admin one-shot job + `POST /collateral-masters/admin/backfill-host-collateral-id` (idempotent) to stamp the AS400 host collateral id onto each appraisal's owning master, plus admin menu entry. Relies on A's one-engagement-per-appraisal invariant.
- **C. Regulatory Export field mapping** — drop previous-appraisal-number, exclude condo from construction-progress logic, switch detail dates to `yyyyMMdd`.
- **D. Monitoring pending-task enrichment** — OpenDate / AppointmentDate / SLA columns + AppraisalStatus; PIC exact-match + `picType`; AppraisalCompany and InternalFollowupStaff filters; new `PendingTasks.OpenedAt` column + migration + one-time backfill script.
- **E. Webhook 401 re-auth retry** — one-shot token invalidation + resend on a rejected token-bearer webhook.

## Deploy checklist
- **EF migration:** `20260715054053_AddPendingTaskOpenedAt` (adds `workflow.PendingTasks.OpenedAt`; auto-applied).
- **View redeploys** (DbUp / manual): `vw_MonitoringPendingTasks.sql`, `vw_AppraisalEvaluationList.sql`, `vw_RegulatoryExport.sql`.
- **Manual one-time SQL:** `Database/Scripts/Maintenance/BackfillPendingTaskOpenedAt.sql` — run **after** migration + view deploy (idempotent; backfills `OpenedAt = AssignedAt` for existing InProgress tasks).
- **Operational trigger (idempotent):** `POST /collateral-masters/admin/backfill-host-collateral-id` (Admin/IntAdmin) after collateral-master data is present.
- **⚠️ Frontend coordination:** Monitoring PIC filter changed from `LIKE %..%` to **exact** `AssignedTo = @Pic` + new `picType`; the FE must send the exact username (matching the new staff autocomplete value) or PIC filtering breaks. Ship with the paired FE PR.

## Verification
- `dotnet build` succeeds on the branch with the email changes stashed out (self-contained, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)