### PR TITLE
feat(collateral): AppraisalValue from ValuationAnalyses + regulatory selling price + monitoring fix

### DIFF
--- a/Database/Scripts/Views/Collateral/vw_CollateralMasters.sql
+++ b/Database/Scripts/Views/Collateral/vw_CollateralMasters.sql
@@ -15,7 +15,8 @@ SELECT
     agg.LastAppraisedDate,
     -- PR-4: LastAppraisedValue now sourced from master detail AppraisalValue (IsMaster only).
     -- AppraisedValue column dropped from CollateralEngagements in PR-4.
-    COALESCE(ld.AppraisalValue, cd.AppraisalValue) AS LastAppraisedValue,
+    -- All master detail types carry the appraisal-level AppraisalValue (ValuationAnalyses total).
+    COALESCE(ld.AppraisalValue, cd.AppraisalValue, md.AppraisalValue, lhd.AppraisalValue) AS LastAppraisedValue,
 
     -- Land-specific columns (NULL when not Land type)
     ld.LandOfficeCode          AS Land_LandOfficeCode,

--- a/Database/Scripts/Views/Collateral/vw_RegulatoryExport.sql
+++ b/Database/Scripts/Views/Collateral/vw_RegulatoryExport.sql
@@ -9,10 +9,10 @@
 -- Representative building: Sequence=1 CollateralEngagementBuilding on the latest engagement.
 --   Used for BuildingTypeCode, BuildingArea, and parameter-table description lookup.
 --
--- DOPA code: joined from parameter.DopaSubDistricts on the stored SubDistrict name (Land/LB/LS*
---   types only; Condo has no sub-district column on CondoDetails). If multiple DOPA rows share the
---   same NameTh, MIN(Code) is returned (deterministic best-effort; the spec says blank on ambiguity
---   but a stable single code is harmless and more useful).
+-- DOPA code: LandDetails.SubDistrict / CondoDetails.SubDistrict store the 6-digit sub-district geocode
+--   (the FE address picker's SubDistrictCode), NOT the Thai name. It is matched against
+--   parameter.DopaSubDistricts.Code (the PK) to validate it, so an unknown/legacy value yields blank
+--   rather than a truncated string in the 6-char field. Land/LB/LS*/Condo types only.
 --
 -- Numeric range guards (mirror CollateralResult LifeYear pattern — one bad value must not abort run):
 --   ConstructionProgressPercent: out of [0,100] → NULL (writer formats as 0.00)
@@ -50,6 +50,7 @@ LatestEngagement AS (
         e.AppraisalDate       AS LatestAppraisalDate,
         e.AppraisalValue      AS LatestAppraisalValue,
         e.AppraisalCompanyId  AS LatestAppraisalCompanyId,
+        e.RequestId           AS LatestRequestId,
         ROW_NUMBER() OVER (
             PARTITION BY e.CollateralMasterId
             ORDER BY e.AppraisalDate DESC, e.CreatedAt DESC
@@ -103,6 +104,10 @@ SELECT
     le.LatestAppraisalDate,
     le.LatestAppraisalValue,
     le.LatestAppraisalCompanyId,
+
+    -- Selling price (market price field): the request-level TotalSellingPrice of the master's latest
+    -- engagement's originating request (one row per request → deterministic per master).
+    rd.TotalSellingPrice                                         AS SellingPrice,
 
     -- Latest Progressive engagement date
     pe.LatestProgressiveAppraisalDate,
@@ -161,16 +166,16 @@ SELECT
         ELSE NULL
     END                                                           AS BuildingTypeDescription,
 
-    -- DOPA 6-digit sub-district code. Sourced from the official parameter.DopaSubDistricts table
-    -- (the "DOPA Location" field), NOT TitleSubDistricts (the title-deed address list). Land/LB/LS*
-    -- types use LandDetails.SubDistrict; condo (U) uses CondoDetails.SubDistrict (it has its own
-    -- address columns). MIN(Code) is a deterministic best-effort when multiple DOPA rows share NameTh.
+    -- DOPA 6-digit sub-district code. LandDetails.SubDistrict / CondoDetails.SubDistrict store the
+    -- 6-digit sub-district geocode (identical across parameter.TitleSubDistricts / DopaSubDistricts).
+    -- Validated against parameter.DopaSubDistricts.Code (the PK) so an unknown value yields blank.
+    -- Land/LB/LS* types use LandDetails.SubDistrict; condo (U) uses CondoDetails.SubDistrict.
     CASE
         WHEN m.CollateralType IN ('L', 'LB', 'LSL', 'LSB', 'LS', 'U')
             THEN (
-                SELECT MIN(dsd.Code)
+                SELECT dsd.Code
                 FROM parameter.DopaSubDistricts dsd
-                WHERE dsd.NameTh = COALESCE(ld.SubDistrict, cd.SubDistrict)
+                WHERE dsd.Code = COALESCE(ld.SubDistrict, cd.SubDistrict)
             )
         ELSE NULL
     END                                                           AS DopaCode
@@ -186,6 +191,10 @@ LEFT JOIN EarliestEngagement ee
 LEFT JOIN LatestEngagement le
     ON  le.CollateralMasterId = m.Id
     AND le.rn                 = 1
+
+-- Request detail of the latest engagement's originating request → selling price (one row per request)
+LEFT JOIN request.RequestDetails rd
+    ON  rd.RequestId = le.LatestRequestId
 
 -- Latest Progressive engagement (rn=1)
 LEFT JOIN LatestProgressiveEngagement pe

--- a/Database/Scripts/Views/Common/vw_MonitoringPendingTasks.sql
+++ b/Database/Scripts/Views/Common/vw_MonitoringPendingTasks.sql
@@ -22,7 +22,7 @@ AS
 --
 -- MonitoringType discriminator:
 --   'External' when the current AppraisalAssignment is AssignmentType=External,
---               Status NOT IN ('Pending','Cancelled'), SubmittedAt IS NULL
+--               Status NOT IN ('Rejected','Cancelled'), SubmittedAt IS NULL
 --   'Internal' otherwise
 --
 -- OLA columns use wall-clock DATEDIFF(HOUR, ...) per FSD §2.6.8 semantics.
@@ -85,7 +85,7 @@ SELECT
     comp.Name                                                                   AS AppraisalCompanyName,
     CASE
         WHEN aa.AssignmentType = 'External'
-         AND aa.AssignmentStatus NOT IN ('Pending', 'Cancelled')
+         AND aa.AssignmentStatus NOT IN ('Rejected', 'Cancelled')
          AND aa.SubmittedAt IS NULL
         THEN 'External'
         ELSE 'Internal'
@@ -122,13 +122,15 @@ FROM workflow.PendingTasks pt
     ) rp
     -- C4 fix: OUTER APPLY TOP 1 prevents fan-out from multiple active AppraisalAssignments
     --         during reassignment windows. Most-recent active External first, then any active.
+    -- Note: intentionally NOT gated on SubmittedAt — an appraisal keeps its single active
+    --       assignment (Id stable) after submission, so AppointmentDate/company stay resolvable
+    --       through UnderReview/Verified. SubmittedAt still drives the MonitoringType CASE above.
     OUTER APPLY (
         SELECT TOP 1 aa2.Id, aa2.AssignmentType, aa2.AssignmentStatus, aa2.SubmittedAt,
                      aa2.AssigneeCompanyId
         FROM appraisal.AppraisalAssignments aa2
         WHERE aa2.AppraisalId = appl.Id
-          AND aa2.SubmittedAt IS NULL
-          AND aa2.AssignmentStatus NOT IN ('Pending', 'Cancelled')
+          AND aa2.AssignmentStatus NOT IN ('Rejected', 'Cancelled')
         ORDER BY
             CASE WHEN aa2.AssignmentType = 'External' THEN 0 ELSE 1 END,
             aa2.AssignedAt DESC, aa2.Id DESC

--- a/Modules/Collateral/Collateral.Contracts/FileInterface/IRegulatoryExportQuery.cs
+++ b/Modules/Collateral/Collateral.Contracts/FileInterface/IRegulatoryExportQuery.cs
@@ -23,6 +23,7 @@ public sealed record RegulatoryExportRow(
     decimal? ConstructionProgressPercent,
     decimal? LatestAppraisalValue,
     decimal? EarliestAppraisalValue,
+    decimal? SellingPrice,
     int? NumberOfFloors,
     int? BuildingAge,
     DateTime? LatestAppraisalDate,

--- a/Modules/Collateral/Collateral/CollateralMasters/Configurations/LeaseholdDetailConfiguration.cs
+++ b/Modules/Collateral/Collateral/CollateralMasters/Configurations/LeaseholdDetailConfiguration.cs
@@ -20,6 +20,9 @@ public class LeaseholdDetailConfiguration : IEntityTypeConfiguration<LeaseholdDe
         // Last-known
         builder.Property(d => d.LeaseTermMonths);
 
+        // Appraisal-level total from the latest appraisal (IsMaster-only). Mirrors Land/Condo detail.
+        builder.Property(d => d.AppraisalValue).HasPrecision(18, 2);
+
         // AppraisalSummary (owned — flat columns)
         builder.OwnsOne(d => d.AppraisalSummary, s =>
         {

--- a/Modules/Collateral/Collateral/CollateralMasters/Configurations/MachineDetailConfiguration.cs
+++ b/Modules/Collateral/Collateral/CollateralMasters/Configurations/MachineDetailConfiguration.cs
@@ -30,6 +30,9 @@ public class MachineDetailConfiguration : IEntityTypeConfiguration<MachineDetail
         // Useful-life years for the outbound Collateral Result interface (Life Year).
         builder.Property(d => d.LifeYear).HasPrecision(5, 1).IsRequired(false);
 
+        // Appraisal-level total from the latest appraisal (IsMaster-only). Mirrors Land/Condo detail.
+        builder.Property(d => d.AppraisalValue).HasPrecision(18, 2);
+
         builder.Property(d => d.IsDeleted).IsRequired().HasDefaultValue(false);
 
         // Filtered unique index — tier 1: when registration no is present

--- a/Modules/Collateral/Collateral/CollateralMasters/Models/CollateralMaster.cs
+++ b/Modules/Collateral/Collateral/CollateralMasters/Models/CollateralMaster.cs
@@ -70,7 +70,8 @@ public sealed record LeaseholdUpsertData(
     int? LeaseTermMonths,
     Guid AppraisalId,
     string AppraisalNumber,
-    DateTime AppraisalDate
+    DateTime AppraisalDate,
+    decimal? AppraisalValue // appraisal-level total (ValuationAnalyses); IsMaster-only
 );
 
 /// <summary>
@@ -82,7 +83,8 @@ public sealed record MachineUpsertData(
     string AppraisalNumber,
     DateTime AppraisalDate,
     // Useful-life years from the appraisal's machinery cost item (outbound Collateral Result).
-    decimal? LifeYear
+    decimal? LifeYear,
+    decimal? AppraisalValue // appraisal-level total (ValuationAnalyses); IsMaster-only
 );
 
 /// <summary>
@@ -691,6 +693,11 @@ public class CollateralMaster : Aggregate<Guid>
 
         LeaseholdDetail.UpdateLastKnown(data.LeaseTermEnd, data.LeaseTermMonths);
 
+        // AppraisalValue represents the whole collateral — written on the IsMaster row only, so a
+        // typed alias (one-collateral-per-appraisal model) does not claim the whole-appraisal total.
+        if (IsMaster)
+            LeaseholdDetail.SetAppraisalValue(data.AppraisalValue);
+
         LeaseholdDetail.UpdateAppraisalSummary(data.AppraisalId, data.AppraisalNumber, data.AppraisalDate);
     }
 
@@ -712,6 +719,11 @@ public class CollateralMaster : Aggregate<Guid>
         }
 
         MachineDetail.SetLifeYear(data.LifeYear);
+
+        // AppraisalValue represents the whole collateral — written on the IsMaster row only, so a
+        // typed alias (one-collateral-per-appraisal model) does not claim the whole-appraisal total.
+        if (IsMaster)
+            MachineDetail.SetAppraisalValue(data.AppraisalValue);
 
         MachineDetail.UpdateAppraisalSummary(data.AppraisalId, data.AppraisalNumber, data.AppraisalDate);
     }

--- a/Modules/Collateral/Collateral/CollateralMasters/Models/LeaseholdDetail.cs
+++ b/Modules/Collateral/Collateral/CollateralMasters/Models/LeaseholdDetail.cs
@@ -15,6 +15,12 @@ public class LeaseholdDetail
     public DateOnly? LeaseTermEnd { get; private set; }
     public int? LeaseTermMonths { get; private set; }
 
+    /// <summary>
+    /// Appraisal-level total from the latest appraisal (ValuationAnalyses.AppraisedValue). Represents the
+    /// whole collateral; written on the IsMaster row only (aliases stay NULL), mirroring Land/Condo.
+    /// </summary>
+    public decimal? AppraisalValue { get; private set; }
+
     // Appraisal summary (owned)
     public AppraisalSummary AppraisalSummary { get; private set; } = null!;
 
@@ -57,6 +63,8 @@ public class LeaseholdDetail
     {
         AppraisalSummary.Update(appraisalId, appraisalNumber, appraisedDate);
     }
+
+    internal void SetAppraisalValue(decimal? appraisalValue) => AppraisalValue = appraisalValue;
 
     internal void SetIsDeleted(bool isDeleted) => IsDeleted = isDeleted;
 

--- a/Modules/Collateral/Collateral/CollateralMasters/Models/MachineDetail.cs
+++ b/Modules/Collateral/Collateral/CollateralMasters/Models/MachineDetail.cs
@@ -22,6 +22,12 @@ public class MachineDetail
     /// </summary>
     public decimal? LifeYear { get; private set; }
 
+    /// <summary>
+    /// Appraisal-level total from the latest appraisal (ValuationAnalyses.AppraisedValue). Represents the
+    /// whole collateral; written on the IsMaster row only (aliases stay NULL), mirroring Land/Condo.
+    /// </summary>
+    public decimal? AppraisalValue { get; private set; }
+
     // Synced from CollateralMaster for filtered unique index support
     public bool IsDeleted { get; private set; }
 
@@ -60,6 +66,8 @@ public class MachineDetail
     }
 
     internal void SetLifeYear(decimal? lifeYear) => LifeYear = lifeYear;
+
+    internal void SetAppraisalValue(decimal? appraisalValue) => AppraisalValue = appraisalValue;
 
     internal void SetIsDeleted(bool isDeleted) => IsDeleted = isDeleted;
 

--- a/Modules/Collateral/Collateral/CollateralMasters/RegulatoryExport/RegulatoryExportQuery.cs
+++ b/Modules/Collateral/Collateral/CollateralMasters/RegulatoryExport/RegulatoryExportQuery.cs
@@ -24,6 +24,7 @@ public class RegulatoryExportQuery(ISqlConnectionFactory connectionFactory) : IR
         ConstructionProgressPercent: r.ConstructionProgressPercent,
         LatestAppraisalValue: r.LatestAppraisalValue,
         EarliestAppraisalValue: r.EarliestAppraisalValue,
+        SellingPrice: r.SellingPrice,
         NumberOfFloors: r.NumberOfFloors,
         BuildingAge: r.BuildingAge,
         LatestAppraisalDate: r.LatestAppraisalDate,
@@ -48,6 +49,7 @@ public class RegulatoryExportQuery(ISqlConnectionFactory connectionFactory) : IR
         public decimal? ConstructionProgressPercent { get; init; }
         public decimal? LatestAppraisalValue { get; init; }
         public decimal? EarliestAppraisalValue { get; init; }
+        public decimal? SellingPrice { get; init; }
         public int? NumberOfFloors { get; init; }
         public int? BuildingAge { get; init; }
         public DateTime? LatestAppraisalDate { get; init; }

--- a/Modules/Collateral/Collateral/CollateralMasters/Services/CollateralMasterUpsertService.cs
+++ b/Modules/Collateral/Collateral/CollateralMasters/Services/CollateralMasterUpsertService.cs
@@ -302,12 +302,13 @@ public class CollateralMasterUpsertService(
                 if (primaryLandProps.Count > 0)
                     landAreaInSqWa = primaryLandProps[0].LandIdentity?.LandArea;
 
-                // Group-level appraisal value — PricingInfo is the same instance across all
-                // properties in the group (set at group level; see AppraisalForCollateralResult).
-                // Use the first in-scope property of the primary group that carries a PricingInfo.
+                // Appraisal-level total from ValuationAnalyses (Σ across all PropertyGroups) — the
+                // reliably-maintained appraisal value; the engagement represents this whole appraisal.
+                // Fall back to the primary group's per-group PricingInfo value only if the total is absent.
                 var primaryPricingProp = primaryGroup.Properties
                     .FirstOrDefault(p => p.PricingInfo is not null);
-                var engagementAppraisalValue = primaryPricingProp?.PricingInfo?.AppraisalValue;
+                var engagementAppraisalValue = appraisal.AppraisedValue
+                                               ?? primaryPricingProp?.PricingInfo?.AppraisalValue;
 
                 AppendEngagement(primaryMaster, appraisal, snapshot, appraisedCollateralType, landAreaInSqWa, engagementAppraisalValue);
 
@@ -777,8 +778,10 @@ public class CollateralMasterUpsertService(
             UnitPrice: pricingInfo?.UnitPrice,
             // BuildingValue: cost approach only — from PricingFinalValue.BuildingValue (PR-8).
             BuildingValue: pricingInfo?.BuildingValue,
-            // AppraisalValue: from PricingFinalValue (all approaches) (PR-8).
-            AppraisalValue: pricingInfo?.AppraisalValue
+            // AppraisalValue: appraisal-level total from ValuationAnalyses (the reliably-maintained
+            // Σ across all PropertyGroups), stored on the IsMaster as the whole collateral's representor.
+            // Fall back to the per-group PricingFinalValue only if the total is somehow absent.
+            AppraisalValue: appraisal.AppraisedValue ?? pricingInfo?.AppraisalValue
         );
 
         master.UpsertFromLandAppraisal(upsertData);
@@ -930,8 +933,10 @@ public class CollateralMasterUpsertService(
             UnitPrice: pricingInfo?.UnitPrice,
             // BuildingValue: cost approach only — from PricingFinalValue.BuildingValue (PR-8).
             BuildingValue: pricingInfo?.BuildingValue,
-            // AppraisalValue: from PricingFinalValue (all approaches) (PR-8).
-            AppraisalValue: pricingInfo?.AppraisalValue
+            // AppraisalValue: appraisal-level total from ValuationAnalyses (the reliably-maintained
+            // Σ across all PropertyGroups), stored on the IsMaster as the whole collateral's representor.
+            // Fall back to the per-group PricingFinalValue only if the total is somehow absent.
+            AppraisalValue: appraisal.AppraisedValue ?? pricingInfo?.AppraisalValue
         );
 
         master.UpsertFromCondoAppraisal(upsertData);
@@ -996,7 +1001,9 @@ public class CollateralMasterUpsertService(
             AppraisalId: appraisal.AppraisalId,
             AppraisalNumber: appraisal.AppraisalNumber ?? string.Empty,
             AppraisalDate: appraisal.CompletedAt ?? dateTimeProvider.ApplicationNow,
-            LifeYear: m.LifeYear
+            LifeYear: m.LifeYear,
+            // Appraisal-level total from ValuationAnalyses; per-group PricingInfo as defensive fallback.
+            AppraisalValue: appraisal.AppraisedValue ?? p.PricingInfo?.AppraisalValue
         );
 
         master.UpsertFromMachineAppraisal(upsertData);
@@ -1162,7 +1169,9 @@ public class CollateralMasterUpsertService(
             LeaseTermMonths: leaseTermMonths,
             AppraisalId: appraisal.AppraisalId,
             AppraisalNumber: appraisal.AppraisalNumber ?? string.Empty,
-            AppraisalDate: appraisal.CompletedAt ?? dateTimeProvider.ApplicationNow
+            AppraisalDate: appraisal.CompletedAt ?? dateTimeProvider.ApplicationNow,
+            // Appraisal-level total from ValuationAnalyses; per-group PricingInfo as defensive fallback.
+            AppraisalValue: appraisal.AppraisedValue ?? p.PricingInfo?.AppraisalValue
         );
 
         // LATEST-wins: flip master CollateralType to the current appraisal's classification.
@@ -1297,7 +1306,9 @@ public class CollateralMasterUpsertService(
             decimal? buildingCost = isMasterRow.LandDetail?.BuildingValue
                                     ?? isMasterRow.CondoDetail?.BuildingValue;
             decimal? groupAppraisalValue = isMasterRow.LandDetail?.AppraisalValue
-                                           ?? isMasterRow.CondoDetail?.AppraisalValue;
+                                           ?? isMasterRow.CondoDetail?.AppraisalValue
+                                           ?? isMasterRow.MachineDetail?.AppraisalValue
+                                           ?? isMasterRow.LeaseholdDetail?.AppraisalValue;
 
             // Construction inspections for this group (land + buildings on those lands)
             var titleNumbers = group.Properties

--- a/Modules/Collateral/Collateral/Migrations/20260716152204_AddAppraisalValueToMachineLeasehold.Designer.cs
+++ b/Modules/Collateral/Collateral/Migrations/20260716152204_AddAppraisalValueToMachineLeasehold.Designer.cs
@@ -4,6 +4,7 @@ using Collateral.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Collateral.Migrations
 {
     [DbContext(typeof(CollateralDbContext))]
-    partial class CollateralDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260716152204_AddAppraisalValueToMachineLeasehold")]
+    partial class AddAppraisalValueToMachineLeasehold
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modules/Collateral/Collateral/Migrations/20260716152204_AddAppraisalValueToMachineLeasehold.cs
+++ b/Modules/Collateral/Collateral/Migrations/20260716152204_AddAppraisalValueToMachineLeasehold.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Collateral.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAppraisalValueToMachineLeasehold : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "AppraisalValue",
+                schema: "collateral",
+                table: "MachineDetails",
+                type: "decimal(18,2)",
+                precision: 18,
+                scale: 2,
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "AppraisalValue",
+                schema: "collateral",
+                table: "LeaseholdDetails",
+                type: "decimal(18,2)",
+                precision: 18,
+                scale: 2,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AppraisalValue",
+                schema: "collateral",
+                table: "MachineDetails");
+
+            migrationBuilder.DropColumn(
+                name: "AppraisalValue",
+                schema: "collateral",
+                table: "LeaseholdDetails");
+        }
+    }
+}

--- a/Modules/Integration/Integration/FileInterface/Format/RegulatoryExport/RegulatoryExcelWriter.cs
+++ b/Modules/Integration/Integration/FileInterface/Format/RegulatoryExport/RegulatoryExcelWriter.cs
@@ -97,7 +97,7 @@ public sealed class RegulatoryExcelWriter
         Money(ws.Cell(r, c++), OriginationValue(row));
         Number(ws.Cell(r, c++), row.NumberOfFloors);
         Number(ws.Cell(r, c++), row.BuildingAge);
-        c++; // Market Selling Price — not yet sourced
+        Money(ws.Cell(r, c++), row.SellingPrice);   // Market Selling Price (RequestDetails.TotalSellingPrice)
         Date(ws.Cell(r, c++), row.LatestAppraisalDate);
         Money(ws.Cell(r, c++), row.LatestAppraisalValue);
         c++; // Mortgage Value — not yet sourced

--- a/Modules/Integration/Integration/FileInterface/Format/RegulatoryExport/RegulatoryFileWriter.cs
+++ b/Modules/Integration/Integration/FileInterface/Format/RegulatoryExport/RegulatoryFileWriter.cs
@@ -134,7 +134,7 @@ public sealed class RegulatoryFileWriter
             ["AppraisalValueOrigination"]  = Money(originationValue),
             ["NumberOfFloors"]             = SmallInt(row.NumberOfFloors, 999),
             ["BuildingAge"]                = SmallInt(row.BuildingAge, 999),
-            ["MarketSellingPrice"]         = null,
+            ["MarketSellingPrice"]         = Money(row.SellingPrice),
             ["ValuationDate"]              = Date(row.LatestAppraisalDate),
             ["ValuationPrice"]             = Money(row.LatestAppraisalValue),
             ["MortgageValue"]              = null,

--- a/Tests/Unit/Collateral.Tests/RegulatoryExport/RegulatoryExcelWriterTests.cs
+++ b/Tests/Unit/Collateral.Tests/RegulatoryExport/RegulatoryExcelWriterTests.cs
@@ -21,6 +21,7 @@ public class RegulatoryExcelWriterTests
         ConstructionProgressPercent: null,
         LatestAppraisalValue: 2_000_000.00m,
         EarliestAppraisalValue: 1_000_000.00m,
+        SellingPrice: 3_000_000.00m,
         NumberOfFloors: 5,
         BuildingAge: 12,
         LatestAppraisalDate: new DateTime(2025, 1, 21),
@@ -75,6 +76,7 @@ public class RegulatoryExcelWriterTests
 
         // Money is a real decimal, NOT the implied-decimal ×100 the fixed-width file writes.
         Assert.Equal(2_000_000.00m, ws.Cell(3, 7).GetValue<decimal>());   // Appraisal Value as Completed
+        Assert.Equal(3_000_000.00m, ws.Cell(3, 11).GetValue<decimal>());  // Market Selling Price
         // Date is a real date cell.
         Assert.Equal(new DateTime(2025, 1, 21), ws.Cell(3, 12).GetDateTime()); // Valuation Date
         // Coded fields are readable text.

--- a/Tests/Unit/Collateral.Tests/RegulatoryExport/RegulatoryFileWriterTests.cs
+++ b/Tests/Unit/Collateral.Tests/RegulatoryExport/RegulatoryFileWriterTests.cs
@@ -29,6 +29,7 @@ public class RegulatoryFileWriterTests
         ConstructionProgressPercent: null,
         LatestAppraisalValue: 2_000_000.00m,
         EarliestAppraisalValue: 1_000_000.00m,
+        SellingPrice: 3_000_000.00m,
         NumberOfFloors: 5,
         BuildingAge: 12,
         LatestAppraisalDate: new DateTime(2025, 1, 21),
@@ -138,6 +139,15 @@ public class RegulatoryFileWriterTests
         var line = new RegulatoryFileWriter().BuildDetail(row);
 
         Assert.Equal(new string('0', 19), line[21..40]);
+    }
+
+    [Fact]
+    public void Field11_MarketSellingPrice_IsSellingPrice()
+    {
+        var line = new RegulatoryFileWriter().BuildDetail(SampleRow());
+
+        // pos 83-97 (index 82..97) = SellingPrice 3,000,000 ×100 = 300000000, zero-filled to 15.
+        Assert.Equal("300000000".PadLeft(15, '0'), line[82..97]);
     }
 
     [Fact]

--- a/docs/regulatory/regulatory-field-reference.md
+++ b/docs/regulatory/regulatory-field-reference.md
@@ -55,14 +55,14 @@ w/ Building (LS). "Land types" = Land (L), LB, Leasehold Land (LSL), LSB, LS.
 | 8 | 62–76 | 15 | Appraisal Value at Origination | decimal(15,2) | If the latest appraisal is a **Progressive** (construction) inspection → the **earliest** engagement's value (the first appraisal already estimated the as-completed value); otherwise the latest value. |
 | 9 | 77–79 | 3 | Number of Floors | decimal(3,0) | Building types → the representative building's floor count (bounded 0–999); otherwise `0`. |
 | 10 | 80–82 | 3 | Building Age (years) | decimal(3,0) | Building types → representative building's age; Condo → condo detail's building age; otherwise `0` (bounded 0–999). |
-| 11 | 83–97 | 15 | Market Selling Price | decimal(15,2) | **Not yet sourced — sent as zeros.** (Pending source confirmation.) |
+| 11 | 83–97 | 15 | Market Selling Price | decimal(15,2) | `request.RequestDetails.TotalSellingPrice` of the master's latest engagement's originating request (joined via `CollateralEngagement.RequestId`). Request-level — one value per request. Blank/zeros if none recorded. |
 | 12 | 98–105 | 8 | Valuation Date | YYYYMMDD | The **latest** engagement's appraisal date. |
 | 13 | 106–120 | 15 | Valuation Price in Baht | decimal(15,2) | The latest engagement's appraisal value (same figure as field 7). |
 | 14 | 121–135 | 15 | Mortgage Value | decimal(15,2) | **Not yet sourced — sent as zeros.** |
 | 15 | 136 | 1 | Appraiser Type | string(1) | `1` = external appraisal, `2` = internal. Determined by whether the latest engagement has an external appraisal-company id. |
 | 16 | 137 | 1 | Collateral Registration Flag | string(1) | **Not yet sourced — sent blank.** |
 | 17 | 138 | 1 | Land Ownership Flag | string(1) | **Not yet sourced — sent blank.** |
-| 18 | 139–144 | 6 | DOPA Location | string(6) | 6-digit DOPA sub-district code, matched by sub-district name against the official DOPA sub-district table. Land/building/condo types. |
+| 18 | 139–144 | 6 | DOPA Location | string(6) | 6-digit DOPA sub-district code. `LandDetails.SubDistrict` / `CondoDetails.SubDistrict` store the sub-district **geocode**, which is validated against `parameter.DopaSubDistricts.Code` (an unknown value → blank). Land/building/condo types. |
 | 19 | 145–151 | 7 | Land Area (Sq.Wa) | decimal(7,2) | Land types → the land detail's land area (must be ≤ 99,999.99); otherwise zeros. |
 | 20 | 152–158 | 7 | Area Utilization (building area) | decimal(7,2) | Building types → representative building's area; Condo → condo detail's usable area (≤ 99,999.99); otherwise zeros. |
 | 21 | 159–168 | 10 | Building Type ID | string(10) | Building types → representative building's building-type code; otherwise blank. |
@@ -85,6 +85,8 @@ w/ Building (LS). "Land types" = Land (L), LB, Leasehold Land (LSL), LSB, LS.
   - **Latest Progressive** = the latest engagement whose appraisal type is *Progressive* → construction review date.
 - **Representative building** (fields 9, 10, 20, 21, 22) = the first (`Sequence = 1`) building recorded on
   the **latest** engagement.
+- **Selling price** (field 11) = the latest engagement's originating request, via `CollateralEngagement.RequestId`
+  → `request.RequestDetails.TotalSellingPrice` (request-level, one value per request).
 
 ---
 
@@ -96,7 +98,6 @@ is not yet captured in the system. Each needs a source decision before it can be
 | # | Field | Status |
 |---|---|---|
 | 4 | HOST Collateral ID | Column exists; awaits the inbound host-mapping feed to populate it. |
-| 11 | Market Selling Price | No source column yet — needs a source decision. |
 | 14 | Mortgage Value | No source column yet — needs a source decision. |
 | 16 | Collateral Registration Flag | No source column yet — needs a source decision. |
 | 17 | Land Ownership Flag | No source column yet — needs a source decision. |


### PR DESCRIPTION
## Collateral AppraisalValue
- Source `AppraisalValue` on collateral masters from appraisal-level `ValuationAnalyses.AppraisedValue`
  (was the mostly-empty per-group `PricingFinalValue`) — Land, Condo, and the engagement.
- Add `AppraisalValue` to Machine + Leasehold master details — migration
  `AddAppraisalValueToMachineLeasehold` (`decimal(18,2) NULL`). IsMaster-only; typed aliases stay NULL.
- `vw_CollateralMasters.LastAppraisedValue` now COALESCEs Land/Condo/Machine/Leasehold.

## Regulatory export (also included)
- Market Selling Price (field 11) sourced from `request.RequestDetails.TotalSellingPrice` via
  `CollateralEngagement.RequestId` — view + `RegulatoryExportQuery` + file writers + tests.
- DOPA sub-district geocode-match clarified; field-reference doc updated.

## Monitoring (also included)
- `vw_MonitoringPendingTasks` assignment filter → `NOT IN ('Rejected','Cancelled')`; active assignment
  stays resolvable after submission.

## Notes
- The collateral migration is included but NOT applied — deploy runs `dotnet ef database update`.
- Filling existing-empty AppraisalValue rows is a separate follow-up (re-running the normal backfill
  won't fill them: the duplicate-engagement idempotency rolls back the whole SaveChanges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
