### PR TITLE
feat(notification): add RM emails for quotation shortlist, document follow-up, route-back

### DIFF
--- a/Modules/Appraisal/Appraisal.Contracts/Appraisals/GetAppraisalReferenceQuery.cs
+++ b/Modules/Appraisal/Appraisal.Contracts/Appraisals/GetAppraisalReferenceQuery.cs
@@ -15,4 +15,5 @@ public record AppraisalReferenceResult(
     string? AppraisalNumber,
     decimal? AppraisalValue,
     DateTime? AppointmentDate,
-    string? Status);
+    string? Status,
+    string? CustomerName = null);

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalReference/GetAppraisalReferenceQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalReference/GetAppraisalReferenceQueryHandler.cs
@@ -21,9 +21,12 @@ public class GetAppraisalReferenceQueryHandler(
         parameters.Add("AppraisalId", query.AppraisalId);
 
         const string sql = """
-            SELECT AppraisalNumber, AppraisalValue, AppointmentDate, Status
-            FROM appraisal.vw_AppraisalCopyTemplate
-            WHERE AppraisalId = @AppraisalId
+            SELECT t.AppraisalNumber, t.AppraisalValue, t.AppointmentDate, t.Status, c.Name AS CustomerName
+            FROM appraisal.vw_AppraisalCopyTemplate t
+            OUTER APPLY (SELECT TOP 1 Name
+                         FROM request.RequestCustomers
+                         WHERE RequestId = t.RequestId) c
+            WHERE t.AppraisalId = @AppraisalId
             """;
 
         var row = await connection.QueryFirstOrDefaultAsync<AppraisalReferenceRow>(sql, parameters);
@@ -31,7 +34,8 @@ public class GetAppraisalReferenceQueryHandler(
         if (row is null)
             return null;
 
-        return new AppraisalReferenceResult(row.AppraisalNumber, row.AppraisalValue, row.AppointmentDate, row.Status);
+        return new AppraisalReferenceResult(
+            row.AppraisalNumber, row.AppraisalValue, row.AppointmentDate, row.Status, row.CustomerName);
     }
 
     private class AppraisalReferenceRow
@@ -40,5 +44,6 @@ public class GetAppraisalReferenceQueryHandler(
         public decimal? AppraisalValue { get; set; }
         public DateTime? AppointmentDate { get; set; }
         public string? Status { get; set; }
+        public string? CustomerName { get; set; }
     }
 }

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/SendShortlistToRm/SendShortlistToRmCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/SendShortlistToRm/SendShortlistToRmCommandHandler.cs
@@ -1,4 +1,5 @@
 using Appraisal.Application.Features.Quotations.Shared;
+using Dapper;
 using Shared.Data.Outbox;
 using Shared.Identity;
 using Shared.Messaging.Events;
@@ -11,7 +12,8 @@ public class SendShortlistToRmCommandHandler(
     ICurrentUserService currentUser,
     IIntegrationEventOutbox outbox,
     IQuotationActivityLogger activityLogger,
-    IDateTimeProvider dateTimeProvider)
+    IDateTimeProvider dateTimeProvider,
+    ISqlConnectionFactory connectionFactory)
     : ICommandHandler<SendShortlistToRmCommand, SendShortlistToRmResult>
 {
     public async Task<SendShortlistToRmResult> Handle(
@@ -57,9 +59,120 @@ public class SendShortlistToRmCommandHandler(
             CompletedBy = currentUser.Username ?? currentUser.UserId?.ToString() ?? string.Empty
         }, correlationId: quotation.Id.ToString());
 
+        // Email the RM a fee-comparison table so they can pick the winner. Domain data (customer
+        // name, per-appraisal report numbers, per-company net fees) is resolved here; the RM email
+        // and company display names are resolved in the Notification consumer via IUserLookupService.
+        await PublishFeeNoticeEmailAsync(quotation, cancellationToken);
+
         return new SendShortlistToRmResult(
             quotation.Id,
             quotation.Status,
             quotation.ShortlistSentToRmAt!.Value);
+    }
+
+    private async Task PublishFeeNoticeEmailAsync(QuotationRequest quotation, CancellationToken ct)
+    {
+        var appraisalIds = quotation.Appraisals.Select(a => a.AppraisalId).ToList();
+        var shortlisted = quotation.Quotations.Where(q => q.IsShortlisted).ToList();
+
+        var reportNumbers = new Dictionary<Guid, string?>();
+        var provinces = new Dictionary<Guid, string?>();
+        var propertyTypeDesc = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        string? customerName = null;
+
+        if (appraisalIds.Count > 0)
+        {
+            var connection = connectionFactory.GetOpenConnection();
+
+            // Property-type code (e.g. "LB") → Thai description ("ที่ดินและสิ่งปลูกสร้าง"),
+            // via parameter.Parameters group 'PropertyType' (same as the RCAS report views).
+            var ptRows = await connection.QueryAsync(
+                "SELECT Code, Description FROM parameter.Parameters " +
+                "WHERE [Group] = 'PropertyType' AND [Language] = 'TH' AND [IsActive] = 1");
+            foreach (var r in ptRows)
+                propertyTypeDesc[(string)r.Code] = (string)r.Description;
+
+            // Report number + resolved province NAME per appraisal. Province is a geocode on
+            // LandAppraisalDetails, resolved to Thai via parameter.TitleProvinces (Code→NameTh),
+            // same as the report summary providers.
+            var rows0 = await connection.QueryAsync(
+                """
+                SELECT a.Id AS AppraisalId,
+                       a.AppraisalNumber,
+                       tprov.NameTh AS ProvinceName
+                FROM appraisal.Appraisals a
+                OUTER APPLY (
+                    SELECT TOP 1 lad.Province
+                    FROM appraisal.LandAppraisalDetails lad
+                    JOIN appraisal.AppraisalProperties ap ON ap.Id = lad.AppraisalPropertyId
+                    WHERE ap.AppraisalId = a.Id AND lad.Province IS NOT NULL
+                    ORDER BY ap.Id
+                ) p
+                LEFT JOIN parameter.TitleProvinces tprov ON tprov.Code = p.Province
+                WHERE a.Id IN @Ids
+                """,
+                new { Ids = appraisalIds });
+            foreach (var r in rows0)
+            {
+                reportNumbers[(Guid)r.AppraisalId] = (string?)r.AppraisalNumber;
+                var name = (string?)r.ProvinceName;
+                provinces[(Guid)r.AppraisalId] =
+                    string.IsNullOrWhiteSpace(name) ? null : "จังหวัด" + name;
+            }
+
+            // Resolve the customer via the appraisal (1:1 with a request), mirroring vw_AppraisalList.
+            // quotation.RequestId is null on the manual/bundle create path (QuotationRequest.Create),
+            // so key off an appraisal id — which always carries a RequestId — instead.
+            customerName = await connection.QueryFirstOrDefaultAsync<string?>(
+                """
+                SELECT TOP 1 rc.Name
+                FROM appraisal.Appraisals a
+                JOIN request.RequestCustomers rc ON rc.RequestId = a.RequestId
+                WHERE a.Id = @AppraisalId
+                """,
+                new { AppraisalId = appraisalIds[0] });
+        }
+
+        // Property-type code comes from the quotation's own display items (denormalized at create
+        // time), resolved to its Thai description; province name is the geocode resolved above.
+        var itemByAppraisal = quotation.Items
+            .GroupBy(i => i.AppraisalId)
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var columns = appraisalIds
+            .Select(id =>
+            {
+                itemByAppraisal.TryGetValue(id, out var item);
+                var ptCode = item?.PropertyType;
+                var ptText = string.IsNullOrWhiteSpace(ptCode)
+                    ? null
+                    : propertyTypeDesc.GetValueOrDefault(ptCode, ptCode);
+                return new QuotationEmailAppraisalColumn(
+                    id,
+                    reportNumbers.GetValueOrDefault(id),
+                    ptText,
+                    provinces.GetValueOrDefault(id));
+            })
+            .ToList();
+
+        var rows = shortlisted
+            .Select(q => new QuotationEmailCompanyRow(
+                q.CompanyId,
+                q.Items
+                    .Where(i => appraisalIds.Contains(i.AppraisalId))
+                    .GroupBy(i => i.AppraisalId)
+                    .ToDictionary(g => g.Key, g => g.Sum(i => i.NetAmount)),
+                q.Items.Sum(i => i.NetAmount)))
+            .ToList();
+
+        outbox.Publish(new ShortlistSentToRmEmailIntegrationEvent
+        {
+            QuotationRequestId = quotation.Id,
+            RmUsername = quotation.RmUsername,
+            AdminUsername = currentUser.Username,
+            CustomerName = customerName,
+            Columns = columns,
+            Rows = rows
+        }, correlationId: quotation.Id.ToString());
     }
 }

--- a/Modules/Notification/Notification/Application/EventHandlers/DocumentFollowupEmailHandler.cs
+++ b/Modules/Notification/Notification/Application/EventHandlers/DocumentFollowupEmailHandler.cs
@@ -1,0 +1,79 @@
+using Auth.Contracts.Users;
+using MassTransit;
+using Notification.Contracts.Email;
+using Notification.Data;
+using Notification.Infrastructure.Email.Templates;
+using Shared.Messaging.Events;
+using Shared.Messaging.Filters;
+
+namespace Notification.Application.EventHandlers;
+
+/// <summary>
+/// Consumes <see cref="DocumentFollowupEmailIntegrationEvent"/> and emails the RM that additional
+/// documents have been requested. RM email / display name and the acting user's signature name are
+/// resolved here via <see cref="IUserLookupService"/>.
+/// </summary>
+public sealed class DocumentFollowupEmailHandler(
+    IEmailSender emailSender,
+    IEmailTemplateRenderer templateRenderer,
+    IUserLookupService userLookupService,
+    InboxGuard<NotificationDbContext> inboxGuard,
+    ILogger<DocumentFollowupEmailHandler> logger)
+    : IConsumer<DocumentFollowupEmailIntegrationEvent>
+{
+    public async Task Consume(ConsumeContext<DocumentFollowupEmailIntegrationEvent> context)
+    {
+        if (await inboxGuard.TryClaimAsync(context.MessageId, GetType().Name, context.CancellationToken))
+            return;
+
+        var msg = context.Message;
+        var ct = context.CancellationToken;
+
+        try
+        {
+            var rm = string.IsNullOrWhiteSpace(msg.RmUsername)
+                ? null
+                : await userLookupService.GetRequestorAsync(msg.RmUsername, ct);
+
+            if (rm?.Email is null || string.IsNullOrWhiteSpace(rm.Email))
+            {
+                logger.LogWarning(
+                    "Skipping document-followup email: no RM email for RmUsername={RmUsername} (MessageId={MessageId})",
+                    msg.RmUsername, context.MessageId);
+                await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
+                return;
+            }
+
+            var adminName = await ResolveNameAsync(msg.ActingUsername, ct);
+            var subject = $"งานติดตามเอกสารของลูกค้าราย {msg.CustomerName ?? "-"}";
+            var items = msg.Items
+                .Select(i => new DocumentFollowupNoticeItem(i.DocumentName, i.Notes))
+                .ToList();
+            var model = new DocumentFollowupNoticeModel(
+                rm.Name, msg.CustomerName, msg.AppraisalNumber, items, adminName);
+            var html = templateRenderer.DocumentFollowupNotice(subject, model);
+
+            await emailSender.SendAsync(new EmailMessage(
+                Subject: subject,
+                HtmlBody: html,
+                To: [rm.Email],
+                Source: "DocumentFollowup",
+                ReferenceId: msg.FollowupId.ToString()), ct);
+
+            await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Error sending document-followup email (MessageId={MessageId})", context.MessageId);
+            throw;
+        }
+    }
+
+    private async Task<string> ResolveNameAsync(string? username, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(username)) return string.Empty;
+        var info = await userLookupService.GetRequestorAsync(username, ct);
+        return info?.Name ?? username;
+    }
+}

--- a/Modules/Notification/Notification/Application/EventHandlers/RouteBackToInitiationEmailHandler.cs
+++ b/Modules/Notification/Notification/Application/EventHandlers/RouteBackToInitiationEmailHandler.cs
@@ -1,0 +1,75 @@
+using Auth.Contracts.Users;
+using MassTransit;
+using Notification.Contracts.Email;
+using Notification.Data;
+using Notification.Infrastructure.Email.Templates;
+using Shared.Messaging.Events;
+using Shared.Messaging.Filters;
+
+namespace Notification.Application.EventHandlers;
+
+/// <summary>
+/// Consumes <see cref="RouteBackToInitiationEmailIntegrationEvent"/> and emails the RM that the
+/// appraisal has been routed back to appraisal-initiation to fix collateral data. RM email /
+/// display name and the acting user's signature name are resolved here via <see cref="IUserLookupService"/>.
+/// </summary>
+public sealed class RouteBackToInitiationEmailHandler(
+    IEmailSender emailSender,
+    IEmailTemplateRenderer templateRenderer,
+    IUserLookupService userLookupService,
+    InboxGuard<NotificationDbContext> inboxGuard,
+    ILogger<RouteBackToInitiationEmailHandler> logger)
+    : IConsumer<RouteBackToInitiationEmailIntegrationEvent>
+{
+    public async Task Consume(ConsumeContext<RouteBackToInitiationEmailIntegrationEvent> context)
+    {
+        if (await inboxGuard.TryClaimAsync(context.MessageId, GetType().Name, context.CancellationToken))
+            return;
+
+        var msg = context.Message;
+        var ct = context.CancellationToken;
+
+        try
+        {
+            var rm = string.IsNullOrWhiteSpace(msg.RmUsername)
+                ? null
+                : await userLookupService.GetRequestorAsync(msg.RmUsername, ct);
+
+            if (rm?.Email is null || string.IsNullOrWhiteSpace(rm.Email))
+            {
+                logger.LogWarning(
+                    "Skipping route-back email: no RM email for RmUsername={RmUsername} (MessageId={MessageId})",
+                    msg.RmUsername, context.MessageId);
+                await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
+                return;
+            }
+
+            // Sender (the user who made the route-back decision) — full name + phone for the footer contact.
+            var sender = string.IsNullOrWhiteSpace(msg.ActingUsername)
+                ? null
+                : await userLookupService.GetRequestorAsync(msg.ActingUsername, ct);
+            var senderName = sender?.Name ?? msg.ActingUsername ?? string.Empty;
+
+            var subject = string.IsNullOrWhiteSpace(msg.ReasonText)
+                ? "ตรวจสอบและแก้ไขข้อมูลหลักประกันลูกค้า"
+                : msg.ReasonText;
+            var model = new RouteBackNoticeModel(rm.Name, msg.Remark, senderName, sender?.ContactNo);
+            var html = templateRenderer.RouteBackNotice(subject, model);
+
+            await emailSender.SendAsync(new EmailMessage(
+                Subject: subject,
+                HtmlBody: html,
+                To: [rm.Email],
+                Source: "RouteBackToInitiation",
+                ReferenceId: msg.AppraisalId.ToString()), ct);
+
+            await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Error sending route-back email (MessageId={MessageId})", context.MessageId);
+            throw;
+        }
+    }
+}

--- a/Modules/Notification/Notification/Application/EventHandlers/ShortlistSentToRmEmailHandler.cs
+++ b/Modules/Notification/Notification/Application/EventHandlers/ShortlistSentToRmEmailHandler.cs
@@ -1,0 +1,111 @@
+using Auth.Contracts.Users;
+using MassTransit;
+using Notification.Contracts.Email;
+using Notification.Data;
+using Notification.Infrastructure.Email;
+using Notification.Infrastructure.Email.Templates;
+using Shared.Messaging.Events;
+using Shared.Messaging.Filters;
+
+namespace Notification.Application.EventHandlers;
+
+/// <summary>
+/// Consumes <see cref="ShortlistSentToRmEmailIntegrationEvent"/> and emails the RM a
+/// fee-comparison table so they can pick the winning appraisal company. The RM email /
+/// display name and the per-company display names are resolved here via
+/// <see cref="IUserLookupService"/> (the Appraisal source carries only ids + amounts).
+/// </summary>
+public sealed class ShortlistSentToRmEmailHandler(
+    IEmailSender emailSender,
+    IEmailTemplateRenderer templateRenderer,
+    IUserLookupService userLookupService,
+    InboxGuard<NotificationDbContext> inboxGuard,
+    ILogger<ShortlistSentToRmEmailHandler> logger)
+    : IConsumer<ShortlistSentToRmEmailIntegrationEvent>
+{
+    public async Task Consume(ConsumeContext<ShortlistSentToRmEmailIntegrationEvent> context)
+    {
+        if (await inboxGuard.TryClaimAsync(context.MessageId, GetType().Name, context.CancellationToken))
+            return;
+
+        var msg = context.Message;
+        var ct = context.CancellationToken;
+
+        try
+        {
+            var rm = string.IsNullOrWhiteSpace(msg.RmUsername)
+                ? null
+                : await userLookupService.GetRequestorAsync(msg.RmUsername, ct);
+
+            if (rm?.Email is null || string.IsNullOrWhiteSpace(rm.Email))
+            {
+                logger.LogWarning(
+                    "Skipping quotation fee-notice email: no RM email for RmUsername={RmUsername} (MessageId={MessageId})",
+                    msg.RmUsername, context.MessageId);
+                await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
+                return;
+            }
+
+            var adminName = await ResolveNameAsync(msg.AdminUsername, ct);
+
+            // Columns, in order, so each row's cells align positionally.
+            var columns = msg.Columns
+                .Select(c => new QuotationFeeNoticeColumn(c.ReportNumber ?? "-", c.PropertyType, c.Province))
+                .ToList();
+
+            var rows = new List<QuotationFeeNoticeRow>();
+            foreach (var row in msg.Rows)
+            {
+                var companyName = await ResolveCompanyNameAsync(row.CompanyId, ct) ?? row.CompanyId.ToString();
+                var cells = msg.Columns
+                    .Select(col => row.AmountByAppraisalId.TryGetValue(col.AppraisalId, out var amt)
+                        ? amt.ToString("#,##0")
+                        : "-")
+                    .ToList();
+                rows.Add(new QuotationFeeNoticeRow(companyName, cells, row.Total.ToString("#,##0")));
+            }
+
+            var subject = $"แจ้งค่าธรรมเนียมประเมิน ลูกค้าราย {msg.CustomerName ?? "-"}";
+            var model = new QuotationFeeNoticeModel(rm.Name, msg.CustomerName, columns, rows, adminName);
+            var html = templateRenderer.QuotationFeeNotice(subject, model);
+
+            await emailSender.SendAsync(new EmailMessage(
+                Subject: subject,
+                HtmlBody: html,
+                To: [rm.Email],
+                Source: "ShortlistSentToRm",
+                ReferenceId: msg.QuotationRequestId.ToString()), ct);
+
+            await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Error sending quotation fee-notice email (MessageId={MessageId})", context.MessageId);
+            throw;
+        }
+    }
+
+    private async Task<string> ResolveNameAsync(string? username, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(username)) return string.Empty;
+        var info = await userLookupService.GetRequestorAsync(username, ct);
+        return info?.Name ?? username;
+    }
+
+    private async Task<string?> ResolveCompanyNameAsync(Guid companyId, CancellationToken ct)
+    {
+        try
+        {
+            var usernames = await userLookupService.GetUsernamesInRoleAsync("ExtAdmin", companyId, ct);
+            if (usernames.Length == 0) return null;
+            var lookup = await userLookupService.GetByUsernamesAsync(usernames, ct);
+            return lookup.Values.FirstOrDefault(u => u.CompanyName != null)?.CompanyName;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Could not resolve company name for CompanyId={CompanyId}", companyId);
+            return null;
+        }
+    }
+}

--- a/Modules/Notification/Notification/Infrastructure/Email/Templates/EmailTemplateRenderer.cs
+++ b/Modules/Notification/Notification/Infrastructure/Email/Templates/EmailTemplateRenderer.cs
@@ -17,9 +17,132 @@ internal sealed class EmailTemplateRenderer(IDateTimeProvider clock) : IEmailTem
     public string MeetingInvitation(string subject, string? adminContent) =>
         Wrap(subject, BuildBody(adminContent));
 
+    public string QuotationFeeNotice(string subject, QuotationFeeNoticeModel model)
+    {
+        var sb = new System.Text.StringBuilder();
+
+        sb.Append("<p style=\"margin:0 0 12px;\">เรียน ").Append(Enc(model.RmName)).Append("</p>");
+
+        sb.Append("<p style=\"margin:0 0 4px;\">แจ้งค่าธรรมเนียมประเมิน ลูกค้าราย <strong>")
+            .Append(Enc(model.CustomerName ?? "-")).Append("</strong></p>");
+        sb.Append("<p style=\"margin:0 0 12px;font-weight:700;color:#c0392b;\">(รบกวนเลือกภายใน 2 วัน)</p>");
+
+        // ── Fee-comparison table ──────────────────────────────────────────────
+        sb.Append("<table role=\"presentation\" cellpadding=\"6\" cellspacing=\"0\" " +
+                  "style=\"border-collapse:collapse;width:100%;font-size:13px;border:1px solid #d0d3d7;\">");
+        sb.Append("<thead><tr style=\"background:#f2f4f6;\">");
+        sb.Append(Th("บริษัทประเมิน", "center"));
+        foreach (var col in model.Columns)
+            sb.Append(ColumnHeader(col));
+        // Last header carries an intentional line break, so it is emitted as raw markup.
+        sb.Append("<th style=\"border:1px solid #d0d3d7;text-align:center;font-weight:700;\">" +
+                  "ค่าธรรมเนียม / บาท<br/>รวม Vat</th>");
+        sb.Append("</tr></thead><tbody>");
+
+        foreach (var row in model.Rows)
+        {
+            sb.Append("<tr>");
+            sb.Append(Td(row.CompanyName, "left"));
+            foreach (var cell in row.Cells)
+                sb.Append(Td(cell, "right"));
+            sb.Append("<td style=\"border:1px solid #d0d3d7;text-align:right;font-weight:700;color:#c0392b;\">")
+                .Append(Enc(row.Total)).Append("</td>");
+            sb.Append("</tr>");
+        }
+
+        sb.Append("</tbody></table>");
+
+        // ── Note ──────────────────────────────────────────────────────────────
+        sb.Append("<p style=\"margin:14px 0 0;font-size:13px;line-height:1.6;\">")
+            .Append("<strong>หมายเหตุ</strong> ณ วันสำรวจหากพบว่ามีที่ดิน, สิ่งปลูกสร้างเพิ่มหรือไม่ตรงตามที่แจ้ง " +
+                    "ค่าธรรมเนียมอาจมีเรียกเก็บเพิ่ม<br/>")
+            .Append("- หากเลือกบริษัทประเมินราคาภายนอกแล้ว รบกวนสินเชื่อแจ้งชื่อกลับสำนักประเมินภายใน 2 วัน " +
+                    "(นับจากวันแจ้งเลือกบริษัทประเมินฯ) (ตามมติที่ประชุม ลงวันที่ 31 ม.ค. 2560)<br/>")
+            .Append("- หากเลยกำหนดตามที่แจ้ง ขอให้เป็นดุลยพินิจของทางสำนักประเมินในการตัดสินใจ เลือกบริษัทประเมิน หรือ ยกเลิก")
+            .Append("</p>");
+
+        sb.Append("<p style=\"margin:16px 0 0;\">จึงเรียนมาเพื่อโปรดทราบ</p>");
+        sb.Append("<p style=\"margin:4px 0 0;\">").Append(Enc(model.AdminName)).Append("</p>");
+
+        return Wrap(subject, sb.ToString(), showTitle: false);
+    }
+
+    public string DocumentFollowupNotice(string subject, DocumentFollowupNoticeModel model)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append("<p style=\"margin:0 0 12px;\">เรียน ").Append(Enc(model.RmName)).Append("</p>");
+        sb.Append("<p style=\"margin:0 0 12px;\">งานติดตามเอกสารของลูกค้าราย <strong>")
+            .Append(Enc(model.CustomerName ?? "-"))
+            .Append("</strong> หมายเลขเล่มประเมิน <strong>")
+            .Append(Enc(model.AppraisalNumber ?? "-")).Append("</strong></p>");
+
+        // Each requested document: numbered name as a header, remark/notes wrapping below it.
+        var itemNumber = 1;
+        foreach (var item in model.Items)
+        {
+            sb.Append("<div style=\"margin:0 0 12px;\">");
+            sb.Append("<p style=\"margin:0 0 2px;font-weight:700;\">")
+                .Append(itemNumber).Append(". ").Append(Enc(item.DocumentName)).Append("</p>");
+            if (!string.IsNullOrWhiteSpace(item.Notes))
+                sb.Append("<p style=\"margin:0 0 0 18px;white-space:pre-wrap;color:#555;\">")
+                    .Append(Enc(item.Notes).Replace("\r\n", "\n").Replace("\r", "\n").Replace("\n", "<br/>"))
+                    .Append("</p>");
+            sb.Append("</div>");
+            itemNumber++;
+        }
+
+        sb.Append("<p style=\"margin:16px 0 0;\">จึงเรียนมาเพื่อโปรดทราบ</p>");
+        sb.Append("<p style=\"margin:4px 0 0;\">").Append(Enc(model.AdminName)).Append("</p>");
+        return Wrap(subject, sb.ToString(), showTitle: false);
+    }
+
+    public string RouteBackNotice(string subject, RouteBackNoticeModel model)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append("<p style=\"margin:0 0 12px;\">เรียน ").Append(Enc(model.RmName)).Append("</p>");
+
+        // Body is just the sender's comment (no descriptive header).
+        sb.Append(RemarkBlock(model.Remark));
+
+        // Footer contact = sender's full name + phone.
+        var contact = Enc(model.SenderName);
+        if (!string.IsNullOrWhiteSpace(model.SenderPhone))
+            contact += " " + Enc(model.SenderPhone);
+        sb.Append("<p style=\"margin:16px 0 0;\">หากมีข้อสงสัยหรือต้องการสอบถามข้อมูลเพิ่มเติม กรุณาติดต่อ ")
+            .Append(contact).Append("</p>");
+        sb.Append("<p style=\"margin:12px 0 0;\">Best Regards</p>");
+        return Wrap(subject, sb.ToString(), showTitle: false);
+    }
+
     // ---------------------------------------------------------------------------
     // Private helpers
     // ---------------------------------------------------------------------------
+
+    private static string Enc(string text) => HtmlEncode(text);
+
+    private static string Th(string text, string align) =>
+        $"<th style=\"border:1px solid #d0d3d7;text-align:{align};font-weight:700;\">{Enc(text)}</th>";
+
+    // Column header = report number, then property type + province name each on its own line.
+    private static string ColumnHeader(QuotationFeeNoticeColumn col)
+    {
+        var lines = new List<string> { Enc(col.ReportNumber) };
+        if (!string.IsNullOrWhiteSpace(col.PropertyType)) lines.Add(Enc(col.PropertyType));
+        if (!string.IsNullOrWhiteSpace(col.Province)) lines.Add(Enc(col.Province));
+        return "<th style=\"border:1px solid #d0d3d7;text-align:center;font-weight:700;\">"
+               + string.Join("<br/>", lines) + "</th>";
+    }
+
+    private static string Td(string text, string align) =>
+        $"<td style=\"border:1px solid #d0d3d7;text-align:{align};\">{Enc(text)}</td>";
+
+    // Renders the free-text decision remark (line breaks preserved), or a neutral fallback.
+    private static string RemarkBlock(string? remark) =>
+        string.IsNullOrWhiteSpace(remark)
+            ? string.Empty
+            : "<p style=\"margin:0 0 12px;white-space:pre-wrap;\">"
+              + Enc(remark).Replace("\r\n", "\n").Replace("\r", "\n").Replace("\n", "<br/>")
+              + "</p>";
 
     // Newlines are converted to <br/> AFTER encoding (so our tags survive). white-space:pre-wrap
     // is kept for clients that honour it (preserves runs of spaces), but Outlook's Word engine
@@ -33,10 +156,17 @@ internal sealed class EmailTemplateRenderer(IDateTimeProvider clock) : IEmailTem
                   .Replace("\n", "<br/>")
               + "</p>";
 
-    private string Wrap(string subject, string bodyHtml)
+    private string Wrap(string subject, string bodyHtml, bool showTitle = false)
     {
         var encodedSubject = HtmlEncode(subject);
         var year = clock.ApplicationNow.Year;
+
+        // The visible subject heading is suppressed by default — the subject is still the mail's
+        // Subject line + hidden inbox-preview text, so repeating it in the body is redundant.
+        var titleRow = showTitle
+            ? "        <tr><td class=\"sarabun\" style=\"padding:24px 28px 4px;\"><div style=\"font-size:20px;font-weight:700;color:#222;line-height:1.35;\">" + encodedSubject + "</div></td></tr>\n"
+            : string.Empty;
+        var bodyPaddingTop = showTitle ? "12px" : "24px";
 
         return
             "<!DOCTYPE html>\n" +
@@ -87,10 +217,10 @@ internal sealed class EmailTemplateRenderer(IDateTimeProvider clock) : IEmailTem
             "<td width=\"12.5%\" height=\"6\" style=\"width:12.5%;height:6px;line-height:6px;font-size:0;background:#94988d;\">&nbsp;</td>" +
             "<td width=\"12.5%\" height=\"6\" style=\"width:12.5%;height:6px;line-height:6px;font-size:0;background:#f08d1d;\">&nbsp;</td>\n" +
             "        </tr></table></td></tr>\n" +
-            // ---- SUBJECT / TITLE ----
-            "        <tr><td class=\"sarabun\" style=\"padding:24px 28px 4px;\"><div style=\"font-size:20px;font-weight:700;color:#222;line-height:1.35;\">" + encodedSubject + "</div></td></tr>\n" +
+            // ---- SUBJECT / TITLE (optional) ----
+            titleRow +
             // ---- BODY (admin content) ----
-            "        <tr><td class=\"sarabun\" style=\"padding:12px 28px 24px;color:#3a3a3a;font-size:14px;line-height:1.7;\">" + bodyHtml + "</td></tr>\n" +
+            "        <tr><td class=\"sarabun\" style=\"padding:" + bodyPaddingTop + " 28px 24px;color:#3a3a3a;font-size:14px;line-height:1.7;\">" + bodyHtml + "</td></tr>\n" +
             // ---- FOOTER ----
             "        <tr><td class=\"sarabun\" style=\"background:#f4f5f7;border-top:1px solid #e3e6ea;padding:18px 28px;\">\n" +
             "          <p style=\"margin:0;font-size:12px;line-height:1.6;color:#7a7d82;\">อีเมลฉบับนี้ถูกสร้างขึ้นโดยอัตโนมัติจากระบบ <strong>Collateral Appraisal System</strong> กรุณาอย่าตอบกลับอีเมลนี้<br/>\n" +

--- a/Modules/Notification/Notification/Infrastructure/Email/Templates/IEmailTemplateRenderer.cs
+++ b/Modules/Notification/Notification/Infrastructure/Email/Templates/IEmailTemplateRenderer.cs
@@ -8,4 +8,49 @@ public interface IEmailTemplateRenderer
 
     /// <summary>Renders the meeting-invitation email.</summary>
     string MeetingInvitation(string subject, string? adminContent);
+
+    /// <summary>
+    /// Renders the "quotation fee notice" email sent to the RM to pick the winning appraisal
+    /// company. Includes a companies × appraisals fee-comparison table.
+    /// </summary>
+    string QuotationFeeNotice(string subject, QuotationFeeNoticeModel model);
+
+    /// <summary>Renders the "document follow-up" email (additional documents requested).</summary>
+    string DocumentFollowupNotice(string subject, DocumentFollowupNoticeModel model);
+
+    /// <summary>Renders the "route-back to appraisal-initiation" email (fix collateral data).</summary>
+    string RouteBackNotice(string subject, RouteBackNoticeModel model);
 }
+
+/// <summary>Render model for the quotation fee-comparison email.</summary>
+public sealed record QuotationFeeNoticeModel(
+    string RmName,
+    string? CustomerName,
+    IReadOnlyList<QuotationFeeNoticeColumn> Columns,
+    IReadOnlyList<QuotationFeeNoticeRow> Rows,
+    string AdminName);
+
+/// <summary>A table column header: report number, then property type + province name on their own lines.</summary>
+public sealed record QuotationFeeNoticeColumn(string ReportNumber, string? PropertyType, string? Province);
+
+/// <summary>A company row. <see cref="Cells"/> aligns positionally with the model's Columns.</summary>
+public sealed record QuotationFeeNoticeRow(string CompanyName, IReadOnlyList<string> Cells, string Total);
+
+/// <summary>Render model for the document-followup email.</summary>
+public sealed record DocumentFollowupNoticeModel(
+    string RmName,
+    string? CustomerName,
+    string? AppraisalNumber,
+    IReadOnlyList<DocumentFollowupNoticeItem> Items,
+    string AdminName);
+
+/// <summary>A requested document: name shown as a header, notes as the body below.</summary>
+public sealed record DocumentFollowupNoticeItem(string DocumentName, string? Notes);
+
+/// <summary>Render model for the route-back email. Body shows only the greeting + the sender's
+/// comment; the footer contact is the sender's full name + phone.</summary>
+public sealed record RouteBackNoticeModel(
+    string RmName,
+    string? Remark,
+    string SenderName,
+    string? SenderPhone);

--- a/Modules/Workflow/Workflow/DocumentFollowups/Application/Commands/RaiseDocumentFollowupCommandHandler.cs
+++ b/Modules/Workflow/Workflow/DocumentFollowups/Application/Commands/RaiseDocumentFollowupCommandHandler.cs
@@ -1,6 +1,12 @@
 using System.Text.Json;
+using Appraisal.Contracts.Appraisals;
+using Dapper;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Shared.Data;
+using Shared.Data.Outbox;
 using Shared.Identity;
+using Shared.Messaging.Events;
 using Workflow.DocumentFollowups.Domain;
 using Workflow.DocumentFollowups.Infrastructure;
 using Workflow.Workflow.Repositories;
@@ -14,6 +20,9 @@ public class RaiseDocumentFollowupCommandHandler(
     IWorkflowInstanceRepository instanceRepository,
     IWorkflowService workflowService,
     ICurrentUserService currentUser,
+    IIntegrationEventOutbox outbox,
+    ISender sender,
+    ISqlConnectionFactory connectionFactory,
     ILogger<RaiseDocumentFollowupCommandHandler> logger
 ) : ICommandHandler<RaiseDocumentFollowupCommand, RaiseDocumentFollowupResult>
 {
@@ -119,6 +128,38 @@ public class RaiseDocumentFollowupCommandHandler(
             cancellationToken: cancellationToken);
 
         followup.AttachFollowupWorkflowInstance(followupInstance.Id);
+
+        // Email the RM (parent StartedBy) that additional documents were requested. Staged on the
+        // outbox so it commits atomically with the SaveChanges below. Recipient email + acting-user
+        // display name are resolved in the Notification consumer via IUserLookupService.
+        var appraisalRef = await sender.Send(new GetAppraisalReferenceQuery(appraisalId), cancellationToken);
+
+        // Resolve document-type code (e.g. "D001") → display name (NameTh, fallback to Name).
+        var docTypeNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var docRows = await connectionFactory.GetOpenConnection().QueryAsync(
+            "SELECT Code, NameTh, Name FROM parameter.DocumentTypes WHERE IsActive = 1");
+        foreach (var d in docRows)
+        {
+            var nameTh = (string?)d.NameTh;
+            docTypeNames[(string)d.Code] = string.IsNullOrWhiteSpace(nameTh) ? (string)d.Name : nameTh;
+        }
+
+        var items = command.LineItems
+            .Select(li => new DocumentFollowupEmailItem(
+                docTypeNames.GetValueOrDefault(li.DocumentType, li.DocumentType),
+                li.Notes))
+            .ToList();
+
+        outbox.Publish(new DocumentFollowupEmailIntegrationEvent
+        {
+            FollowupId = followup.Id,
+            RmUsername = parentInstance.StartedBy,
+            ActingUsername = raisingUserId,
+            CustomerName = appraisalRef?.CustomerName,
+            AppraisalNumber = appraisalRef?.AppraisalNumber,
+            Items = items
+        }, correlationId: appraisalId.ToString());
+
         await dbContext.SaveChangesAsync(cancellationToken);
 
         logger.LogInformation(

--- a/Modules/Workflow/Workflow/Tasks/EventHandlers/TaskCompletedDomainEventHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/EventHandlers/TaskCompletedDomainEventHandler.cs
@@ -1,4 +1,7 @@
+using Appraisal.Contracts.Appraisals;
 using MassTransit;
+using Parameter.Contracts.Parameters;
+using Parameter.Contracts.Parameters.Dtos;
 using Shared.Data.Outbox;
 using Shared.Messaging.Events;
 using Workflow.Workflow.Events;
@@ -9,6 +12,9 @@ public class TaskCompletedDomainEventHandler(
     IAssignmentRepository assignmentRepository,
     IPublishEndpoint publishEndpoint,
     IIntegrationEventOutbox outbox,
+    WorkflowDbContext workflowDbContext,
+    ISender sender,
+    IParameterLookupService parameterLookup,
     ILogger<TaskCompletedDomainEventHandler> logger
 ) : INotificationHandler<TaskCompletedDomainEvent>
 {
@@ -116,6 +122,42 @@ public class TaskCompletedDomainEventHandler(
                     CancelReason = notification.Remark
                 }, notification.CorrelationId.ToString());
             }
+        }
+
+        // Route-back to appraisal-initiation ("Request More Info" by IntAdmin): email the RM to fix
+        // collateral data. Keyed on the appraisal-assignment backward "R" decision (see admin-request-info
+        // transition in appraisal-workflow.json). Analogous to the Movement=="C" cancel branch above.
+        if (notification.AppraisalId.HasValue
+            && string.Equals(notification.Movement, "B", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(notification.ActivityId, "appraisal-assignment", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(notification.ActionTaken, "R", StringComparison.OrdinalIgnoreCase)
+            && notification.TaskName?.Contains(':') != true)
+        {
+            var correlationKey = notification.CorrelationId.ToString();
+            var instance = await workflowDbContext.WorkflowInstances
+                .AsNoTracking()
+                .FirstOrDefaultAsync(w => w.CorrelationId == correlationKey, cancellationToken);
+
+            var appraisalRef = await sender.Send(
+                new GetAppraisalReferenceQuery(notification.AppraisalId.Value), cancellationToken);
+
+            // Resolve the route-back reason code (e.g. "04") → Thai description, used as the subject.
+            var reasonText = string.IsNullOrWhiteSpace(notification.ReasonCode)
+                ? null
+                : await parameterLookup.GetDescriptionAsync(
+                    new ParameterDto(null, "RoutebackReason", null, "TH", notification.ReasonCode, null, true, null),
+                    cancellationToken);
+
+            outbox.Publish(new RouteBackToInitiationEmailIntegrationEvent
+            {
+                AppraisalId = notification.AppraisalId.Value,
+                RmUsername = instance?.StartedBy,
+                ActingUsername = completedBy,
+                CustomerName = appraisalRef?.CustomerName,
+                AppraisalNumber = appraisalRef?.AppraisalNumber ?? notification.AppraisalNumber,
+                Remark = notification.Remark,
+                ReasonText = reasonText
+            }, notification.CorrelationId.ToString());
         }
     }
 }

--- a/Shared/Shared.Messaging/Events/DocumentFollowupEmailIntegrationEvent.cs
+++ b/Shared/Shared.Messaging/Events/DocumentFollowupEmailIntegrationEvent.cs
@@ -1,0 +1,28 @@
+namespace Shared.Messaging.Events;
+
+/// <summary>
+/// Published by the Workflow module (via outbox in RaiseDocumentFollowupCommandHandler) when a
+/// user requests additional documents from the customer. Consumed by the Notification module,
+/// which resolves the RM (recipient) and the acting user's display name via <c>IUserLookupService</c>,
+/// renders the email, and delivers it via SMTP.
+/// </summary>
+public record DocumentFollowupEmailIntegrationEvent : IntegrationEvent
+{
+    /// <summary>The document-followup that triggered this send — used as the send-log ReferenceId.</summary>
+    public Guid FollowupId { get; init; }
+
+    /// <summary>RM bank code (request maker / workflow StartedBy). The consumer resolves email + display name.</summary>
+    public string? RmUsername { get; init; }
+
+    /// <summary>Bank code of the user who raised the followup. The consumer resolves this to the signature name.</summary>
+    public string? ActingUsername { get; init; }
+
+    public string? CustomerName { get; init; }
+    public string? AppraisalNumber { get; init; }
+
+    /// <summary>One entry per requested document: the resolved document name + its remark/notes.</summary>
+    public IReadOnlyList<DocumentFollowupEmailItem> Items { get; init; } = [];
+}
+
+/// <summary>A requested document line: display name + the remark wording from the decision screen.</summary>
+public sealed record DocumentFollowupEmailItem(string DocumentName, string? Notes);

--- a/Shared/Shared.Messaging/Events/RouteBackToInitiationEmailIntegrationEvent.cs
+++ b/Shared/Shared.Messaging/Events/RouteBackToInitiationEmailIntegrationEvent.cs
@@ -1,0 +1,29 @@
+namespace Shared.Messaging.Events;
+
+/// <summary>
+/// Published by the Workflow module (via outbox in TaskCompletedDomainEventHandler) when IntAdmin
+/// routes an appraisal back to the appraisal-initiation activity to fix collateral data
+/// ("Request More Info": ActivityId "appraisal-assignment", Movement "B", ActionTaken "R").
+/// Consumed by the Notification module, which resolves the RM (recipient) + the acting user's
+/// display name via <c>IUserLookupService</c>, renders the email, and delivers it via SMTP.
+/// </summary>
+public record RouteBackToInitiationEmailIntegrationEvent : IntegrationEvent
+{
+    /// <summary>The appraisal being routed back — used as the send-log ReferenceId.</summary>
+    public Guid AppraisalId { get; init; }
+
+    /// <summary>RM bank code (request maker / workflow StartedBy). The consumer resolves email + display name.</summary>
+    public string? RmUsername { get; init; }
+
+    /// <summary>Bank code of the user who made the route-back decision. The consumer resolves the signature name.</summary>
+    public string? ActingUsername { get; init; }
+
+    public string? CustomerName { get; init; }
+    public string? AppraisalNumber { get; init; }
+
+    /// <summary>The decision remark ([รายละเอียดNotification]) — what to correct.</summary>
+    public string? Remark { get; init; }
+
+    /// <summary>Resolved route-back reason description (from the RoutebackReason parameter group) — used as the subject.</summary>
+    public string? ReasonText { get; init; }
+}

--- a/Shared/Shared.Messaging/Events/ShortlistSentToRmEmailIntegrationEvent.cs
+++ b/Shared/Shared.Messaging/Events/ShortlistSentToRmEmailIntegrationEvent.cs
@@ -1,0 +1,51 @@
+namespace Shared.Messaging.Events;
+
+/// <summary>
+/// Published by the Appraisal module (via outbox in SendShortlistToRmCommandHandler) when
+/// the admin sends the shortlisted quotations to the RM to pick the winning appraisal company.
+/// Consumed by the Notification module, which resolves the RM email + company names via
+/// <c>IUserLookupService</c>, renders the fee-comparison table, and delivers it via SMTP.
+/// <para>
+/// Domain data (customer name, per-appraisal report numbers, per-company fee amounts) is
+/// resolved at the source because the Appraisal aggregate owns it. Identity data (RM email,
+/// company display names) is resolved in the consumer because only the Notification module
+/// references <c>Auth.Contracts</c>.
+/// </para>
+/// </summary>
+public record ShortlistSentToRmEmailIntegrationEvent : IntegrationEvent
+{
+    /// <summary>The quotation request that triggered this send — used as the send-log ReferenceId.</summary>
+    public Guid QuotationRequestId { get; init; }
+
+    /// <summary>RM bank code (employee id, e.g. P5229). The consumer resolves this to an email + display name.</summary>
+    public string? RmUsername { get; init; }
+
+    /// <summary>Bank code of the admin who sent the shortlist. The consumer resolves this to the signature name.</summary>
+    public string? AdminUsername { get; init; }
+
+    /// <summary>Customer display name (resolved at source from request.RequestCustomers).</summary>
+    public string? CustomerName { get; init; }
+
+    /// <summary>One column per shortlisted appraisal (the fee table's columns).</summary>
+    public IReadOnlyList<QuotationEmailAppraisalColumn> Columns { get; init; } = [];
+
+    /// <summary>One row per shortlisted company (the fee table's rows).</summary>
+    public IReadOnlyList<QuotationEmailCompanyRow> Rows { get; init; } = [];
+}
+
+/// <summary>A single appraisal column in the fee-comparison table (report no. + property type + province name).</summary>
+public sealed record QuotationEmailAppraisalColumn(
+    Guid AppraisalId,
+    string? ReportNumber,
+    string? PropertyType,
+    string? Province);
+
+/// <summary>
+/// A single company row in the fee-comparison table. <see cref="CompanyId"/> is resolved to a
+/// display name in the consumer. <see cref="AmountByAppraisalId"/> maps each column's AppraisalId
+/// to that company's net fee (incl. VAT) for that appraisal; <see cref="Total"/> is the row total.
+/// </summary>
+public sealed record QuotationEmailCompanyRow(
+    Guid CompanyId,
+    IReadOnlyDictionary<Guid, decimal> AmountByAppraisalId,
+    decimal Total);

--- a/Tests/Unit/Notification.Tests/Email/NotificationEmailTemplatesTests.cs
+++ b/Tests/Unit/Notification.Tests/Email/NotificationEmailTemplatesTests.cs
@@ -1,0 +1,128 @@
+using NSubstitute;
+using Notification.Infrastructure.Email.Templates;
+using Shared.Time;
+
+namespace Notification.Tests.Email;
+
+/// <summary>
+/// Guards the three business-notification templates added for the missing RM emails:
+/// quotation fee notice (with fee table), document follow-up, and route-back. Pins the Thai
+/// subject/greeting, the table cells, and that dynamic text is HTML-encoded (no injection).
+/// </summary>
+public class NotificationEmailTemplatesTests
+{
+    private static EmailTemplateRenderer NewRenderer()
+    {
+        var clock = Substitute.For<IDateTimeProvider>();
+        clock.ApplicationNow.Returns(new DateTime(2026, 6, 12));
+        return new EmailTemplateRenderer(clock);
+    }
+
+    [Fact]
+    public void QuotationFeeNotice_RendersGreeting_Columns_AndRowTotals()
+    {
+        var model = new QuotationFeeNoticeModel(
+            RmName: "สมชาย ใจดี",
+            CustomerName: "บริษัท ทดสอบ จำกัด",
+            Columns:
+            [
+                new QuotationFeeNoticeColumn("69A00317", "LB", "จังหวัดภูเก็ต"),
+                new QuotationFeeNoticeColumn("69A00323", "LB", "จังหวัดเชียงใหม่"),
+            ],
+            Rows:
+            [
+                new QuotationFeeNoticeRow("บริษัท เอ", ["25,680", "23,540"], "139,100"),
+                new QuotationFeeNoticeRow("บริษัท บี", ["37,450", "26,750"], "169,060"),
+            ],
+            AdminName: "แอดมิน หนึ่ง");
+
+        var html = NewRenderer().QuotationFeeNotice("แจ้งค่าธรรมเนียมประเมิน ลูกค้าราย บริษัท ทดสอบ จำกัด", model);
+
+        Assert.Contains("เรียน สมชาย ใจดี", html);
+        Assert.Contains("บริษัทประเมิน", html);
+        Assert.Contains("69A00317", html);
+        Assert.Contains("69A00323", html);
+        Assert.Contains("LB", html);
+        Assert.Contains("จังหวัดภูเก็ต", html);
+        Assert.Contains("จังหวัดเชียงใหม่", html);
+        Assert.Contains("25,680", html);
+        Assert.Contains("139,100", html);
+        Assert.Contains("แอดมิน หนึ่ง", html);
+        Assert.Contains("รบกวนเลือกภายใน 2 วัน", html);
+        Assert.Contains("แจ้งค่าธรรมเนียมประเมิน ลูกค้าราย <strong>บริษัท ทดสอบ จำกัด</strong>", html);
+        // The visible subject-title heading is suppressed (subject stays as Subject line + preview).
+        Assert.DoesNotContain("font-size:20px;font-weight:700;color:#222", html);
+    }
+
+    [Fact]
+    public void QuotationFeeNotice_EncodesCompanyName_NoInjection()
+    {
+        var model = new QuotationFeeNoticeModel(
+            RmName: "RM",
+            CustomerName: "Cust",
+            Columns: [new QuotationFeeNoticeColumn("A", null, null)],
+            Rows: [new QuotationFeeNoticeRow("<script>x</script>", ["1"], "1")],
+            AdminName: "Admin");
+
+        var html = NewRenderer().QuotationFeeNotice("Subject", model);
+
+        Assert.Contains("&lt;script&gt;x&lt;/script&gt;", html);
+        Assert.DoesNotContain("<script>x</script>", html);
+    }
+
+    [Fact]
+    public void DocumentFollowupNotice_RendersRemarkAndSignature()
+    {
+        var model = new DocumentFollowupNoticeModel(
+            RmName: "สมหญิง",
+            CustomerName: "ลูกค้า ก",
+            AppraisalNumber: "69A00317",
+            Items:
+            [
+                new DocumentFollowupNoticeItem("เล่มประเมินสมบูรณ์", "รายละเอียด บรรทัดแรก\nบรรทัดสอง"),
+                new DocumentFollowupNoticeItem("เอกสารแผนที่ภาพถ่ายทางอากาศ", null),
+            ],
+            AdminName: "แอดมิน สอง");
+
+        var html = NewRenderer().DocumentFollowupNotice("งานติดตามเอกสารของลูกค้าราย ลูกค้า ก", model);
+
+        Assert.Contains("เรียน สมหญิง", html);
+        Assert.Contains("69A00317", html);
+        // Document name as a bold header, notes below (long/multiline notes wrap).
+        Assert.Contains("<strong>", html); // customer/appraisal
+        Assert.Contains("1. เล่มประเมินสมบูรณ์", html);
+        Assert.Contains("2. เอกสารแผนที่ภาพถ่ายทางอากาศ", html);
+        Assert.Contains("รายละเอียด บรรทัดแรก<br/>บรรทัดสอง", html);
+        Assert.Contains("แอดมิน สอง", html);
+    }
+
+    [Fact]
+    public void RouteBackNotice_RendersRemarkAndBestRegards()
+    {
+        var model = new RouteBackNoticeModel(
+            RmName: "สมชาย",
+            Remark: "โฉนดไม่ตรงกับเอกสาร",
+            SenderName: "แอดมิน สาม",
+            SenderPhone: "02-123-4567");
+
+        var html = NewRenderer().RouteBackNotice("ตรวจสอบและแก้ไขข้อมูลหลักประกันลูกค้า", model);
+
+        Assert.Contains("เรียน สมชาย", html);
+        Assert.Contains("โฉนดไม่ตรงกับเอกสาร", html);
+        // Footer contact = sender full name + phone; no descriptive header sentence.
+        Assert.Contains("กรุณาติดต่อ แอดมิน สาม 02-123-4567", html);
+        Assert.DoesNotContain("เนื่องจากไม่ตรงกับเอกสารที่แนบมา", html);
+        Assert.Contains("Best Regards", html);
+    }
+
+    [Fact]
+    public void RemarkBlock_EncodesHtml_NoInjection()
+    {
+        var model = new RouteBackNoticeModel("RM", "<b>bad</b>", "Admin", null);
+
+        var html = NewRenderer().RouteBackNotice("Subject", model);
+
+        Assert.Contains("&lt;b&gt;bad&lt;/b&gt;", html);
+        Assert.DoesNotContain("<b>bad</b>", html);
+    }
+}


### PR DESCRIPTION
## What
Adds three missing RM notification emails using the existing branded-email infrastructure:

1. **Quotation fee notice** — on `send-to-rm`, emails the RM a companies × appraisals fee-comparison table (report no. + property-type description + province name per column).
2. **Document follow-up** — on Request Additional Documents, emails the RM the numbered document list + remarks; subject uses the customer name.
3. **Route-back to appraisal-initiation** — on IntAdmin "Request More Info", emails the RM the decision comment; subject = the resolved route-back reason; footer = sender name + phone.

## How
- New `IntegrationEvent`s + Notification `IConsumer`s + branded HTML render methods (one per email).
- Extend `AppraisalReferenceResult` with `CustomerName` (OUTER APPLY `request.RequestCustomers`) — no migration.
- Display data resolved at the source (property-type & routeback-reason via `parameter.Parameters`, province via `TitleProvinces`, document names via `DocumentTypes`); RM email/name + company names resolved in the consumer via `IUserLookupService`.
- Suppress the duplicated subject heading in the shared branded template (affects all emails).

## Testing
- `dotnet build` green; `Notification.Tests` 25/25 (5 new renderer tests).
- Verify via `notification.EmailSendLogs` (sources `ShortlistSentToRm`, `DocumentFollowup`, `RouteBackToInitiation`). Fail-soft: skips with a warning when the RM has no email.

## Related
Frontend sibling PR: immortalgky/collateral-appraisal-system-app#276 — moves the Request Additional Documents button + banner. Merge together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrXJydSmKH1ugkBpLiXhYY