### PR TITLE
fix(workflow): attribute task completion to the acting user, not the assignee group

### DIFF
--- a/Modules/Workflow/Workflow/Tasks/EventHandlers/TaskCompletedDomainEventHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/EventHandlers/TaskCompletedDomainEventHandler.cs
@@ -40,6 +40,8 @@ public class TaskCompletedDomainEventHandler(
         var wasOverdue = pendingTask.SlaStatus == "Breached";
         var assignedAt = pendingTask.AssignedAt;
         var originalAssignedTo = pendingTask.AssignedTo;
+        var originalWorkingBy = pendingTask.WorkingBy;
+        var originalAssignedType = pendingTask.AssignedType;
 
         // Implicit assignment: if pool task completed without claiming, assign to the completer
         if (pendingTask.AssignedType == "2" && !string.IsNullOrEmpty(notification.CompletedBy))
@@ -50,7 +52,12 @@ public class TaskCompletedDomainEventHandler(
                 pendingTask.Id, notification.CompletedBy);
         }
 
-        var completedBy = notification.CompletedBy ?? pendingTask.AssignedTo;
+        // Resolve the acting HUMAN. Never fall back to AssignedTo for a pool task (AssignedType "2")
+        // — that is the assignee GROUP (e.g. "IntAdmin"), not a person, and it leaks into downstream
+        // notifications/emails. Mirrors the ownership rule in ValidateTaskOwnershipStep.
+        var completedBy = notification.CompletedBy
+                          ?? originalWorkingBy
+                          ?? (originalAssignedType == "1" ? originalAssignedTo : null);
 
         var completedTask = CompletedTask.CreateFromPendingTask(
             pendingTask, notification.ActionTaken, notification.CompletedAt, notification.Remark,

--- a/Modules/Workflow/Workflow/Workflow/Activities/Core/WorkflowActivityBase.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/Core/WorkflowActivityBase.cs
@@ -150,7 +150,14 @@ public abstract class WorkflowActivityBase : IWorkflowActivity
             context.WorkflowInstance.SetCurrentActivity(context.ActivityId, assigneeId);
     }
 
-    private string GetCompletedBy(Dictionary<string, object> resumeInput)
+    /// <summary>
+    /// The authenticated human who completed the activity, taken from the resume input
+    /// (<c>WorkflowEngine</c> stamps <c>completedBy</c> = <c>currentUserService.Username</c>).
+    /// Returns the "system" sentinel when absent. Prefer this over
+    /// <c>WorkflowInstance.CurrentAssignee</c>, which is a routing target and is the assignee
+    /// GROUP for pool activities.
+    /// </summary>
+    protected string GetCompletedBy(Dictionary<string, object> resumeInput)
     {
         if (resumeInput.TryGetValue("completedBy", out var completedBy)) return completedBy.ToString() ?? "system";
 

--- a/Modules/Workflow/Workflow/Workflow/Activities/TaskActivity.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/TaskActivity.cs
@@ -244,7 +244,7 @@ public class TaskActivity : WorkflowActivityBase
             }
 
             // Publish domain event to move PendingTask → CompletedTask
-            await PublishTaskCompletedEventAsync(context, outputData, cancellationToken);
+            await PublishTaskCompletedEventAsync(context, outputData, resumeInput, cancellationToken);
 
             _logger.LogInformation("TaskActivity {ActivityId} resumed with {InputCount} inputs, {OutputCount} outputs",
                 context.ActivityId, activityInputs.Count, outputData.Count);
@@ -741,6 +741,7 @@ public class TaskActivity : WorkflowActivityBase
 
     private async Task PublishTaskCompletedEventAsync(
         ActivityContext context, Dictionary<string, object> outputData,
+        Dictionary<string, object>? resumeInput,
         CancellationToken cancellationToken)
     {
         var taskName = GetStringProperty(context.Properties, "activityName") ?? context.ActivityId;
@@ -768,8 +769,16 @@ public class TaskActivity : WorkflowActivityBase
             : null;
         if (string.IsNullOrWhiteSpace(reasonCode)) reasonCode = null;
 
-        // Pass CompletedBy for pool task implicit assignment
-        var completedBy = context.WorkflowInstance.CurrentAssignee;
+        // The acting human, taken from the resume input (WorkflowEngine stamps it from
+        // currentUserService.Username). CurrentAssignee is only a routing target — for a POOL
+        // activity it is the assignee GROUP (e.g. "IntAdmin"), never the person — so it is used
+        // solely as a fallback for system/non-human completions.
+        var resumeCompletedBy = resumeInput is not null ? GetCompletedBy(resumeInput) : null;
+        var completedBy =
+            string.IsNullOrWhiteSpace(resumeCompletedBy) ||
+            string.Equals(resumeCompletedBy, "system", StringComparison.OrdinalIgnoreCase)
+                ? context.WorkflowInstance.CurrentAssignee
+                : resumeCompletedBy;
 
         var appraisalNumber = context.WorkflowInstance.Variables.TryGetValue("appraisalNumber", out var appraisalNumObj)
             ? appraisalNumObj?.ToString()


### PR DESCRIPTION
## Problem
Found during SIT verification of #312. The route-back email footer rendered `กรุณาติดต่อ IntAdmin` with **no phone** instead of the sender's name + phone.

`IntAdmin` is the assignee **group**. The activity was completed from a **pool task**, so the acting user resolved to the group rather than the human who clicked — and a group resolves to no user, hence the missing phone.

## Root cause
The real username was already available, it just never reached the event:

1. `CompleteActivityEndpoint` captures `currentUserService.Username`.
2. `WorkflowEngine.cs:196-199` puts it in the resume input as `completedBy`.
3. `"completedBy"` is an `IsReservedKey`, so it is intentionally excluded from `outputData`.
4. `PublishTaskCompletedEventAsync` was never passed `resumeInput`, so it re-derived from `WorkflowInstance.CurrentAssignee` — a **routing target**, which `PoolAssigneeSelector` sets to the group name for pool activities.
5. `TaskCompletedDomainEventHandler` compounded it with `?? pendingTask.AssignedTo` (the group again).

## Fix
- **`TaskActivity`** — pass `resumeInput` into `PublishTaskCompletedEventAsync` and take `completedBy` from it, falling back to `CurrentAssignee` for system/non-human completions (existing behavior preserved).
- **`WorkflowActivityBase`** — `GetCompletedBy` promoted to `protected` for reuse (no duplicated key literal).
- **`TaskCompletedDomainEventHandler`** — capture `WorkingBy`/`AssignedType` before the implicit reassign (which nulls `WorkingBy`), and never fall back to `AssignedTo` when `AssignedType == "2"`. Precedence mirrors `ValidateTaskOwnershipStep`.

Deliberately **not** using `WorkflowInstance.LastCompletedBy` — right type, wrong timing (it is set *after* the event publishes).

No migration, no frontend change, no Notification-module change: once `ActingUsername` is a real username the existing `GetRequestorAsync` supplies name **and** `ContactNo`.

## ⚠️ Blast radius (please review)
`CompletedBy` feeds more than the email, so this corrects several latent bugs for **all** workflows' pool tasks:
- **Implicit pool assignment** previously reassigned the task to the *group name*; it now assigns to the actual completer (clearly the original intent).
- `TaskCompletedIntegrationEvent.CompletedBy` and `AppraisalCancelIntegrationEvent.CancelledBy` now carry a person instead of a group for pool completions.

## Testing
- `dotnet build` green; `Notification.Tests` 25/25.
- `Workflow.Tests`: 854 passed / 10 failed — **identical to the baseline with these changes stashed**, so the 10 failures are pre-existing and unrelated (AppraisalCreatedIntegrationEventConsumer, RoutingActivity, PoolTaskAccess SQL, SubmitDocumentFollowup).
- QA: complete `appraisal-assignment` with "Request More Info" **from the pool without claiming** → email footer should show your full name + phone. Repeat after claiming. Verify the pool task is reassigned to the completer, not `IntAdmin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCwSSXjaWvVQwdEfvQfibn