### PR TITLE
feat(meetings): shared MeetingView read policy for 3-role access

### DIFF
--- a/Modules/Auth/Auth/AuthModule.cs
+++ b/Modules/Auth/Auth/AuthModule.cs
@@ -311,6 +311,10 @@ public static class AuthModule
             .AddUserPermissionPolicy("MeetingAdmin", "MEETING_ADMIN")
             .AddUserPermissionPolicy("MeetingSecretary", "MEETING_SECRETARY")
             .AddUserPermissionPolicy("CommitteeMember", "COMMITTEE_MEMBER")
+            // Shared read policy: any of the three meeting roles can view meetings/detail/documents.
+            // Write/action endpoints stay gated by the specific role policy above.
+            .AddMonitoringAnyPolicy("MeetingView",
+                new[] { "MEETING_ADMIN", "MEETING_SECRETARY", "COMMITTEE_MEMBER" })
             .AddScopePolicy("ClsReadAppraisal", "appraisal.read")
             .AddScopePolicy("ClsWriteRequest", "request.write")
             .AddScopePolicy("ClsReadDocument", "document.read")

--- a/Modules/Workflow/Workflow/Meetings/Features/Documents/ListMeetingDocumentsEndpoint.cs
+++ b/Modules/Workflow/Workflow/Meetings/Features/Documents/ListMeetingDocumentsEndpoint.cs
@@ -17,7 +17,7 @@ public class ListMeetingDocumentsEndpoint : ICarterModule
             })
             .WithName("ListMeetingDocuments")
             .WithTags("Meetings")
-            .RequireAuthorization("MeetingAdmin")
+            .RequireAuthorization("MeetingView")
             .Produces<List<MeetingDocumentDto>>();
     }
 }

--- a/Modules/Workflow/Workflow/Meetings/Features/GetMeetingDetail/GetMeetingDetailEndpoint.cs
+++ b/Modules/Workflow/Workflow/Meetings/Features/GetMeetingDetail/GetMeetingDetailEndpoint.cs
@@ -20,7 +20,7 @@ public class GetMeetingDetailEndpoint : ICarterModule
             })
             .WithName("GetMeetingDetail")
             .WithTags("Meetings")
-            .RequireAuthorization("CommitteeMember");
+            .RequireAuthorization("MeetingView");
     }
 }
 

--- a/Modules/Workflow/Workflow/Meetings/Features/GetMeetingQueue/GetMeetingQueueEndpoint.cs
+++ b/Modules/Workflow/Workflow/Meetings/Features/GetMeetingQueue/GetMeetingQueueEndpoint.cs
@@ -17,7 +17,7 @@ public class GetMeetingQueueEndpoint : ICarterModule
             })
             .WithName("GetMeetingQueue")
             .WithTags("Meetings")
-            .RequireAuthorization();
+            .RequireAuthorization("MeetingView");
     }
 }
 

--- a/Modules/Workflow/Workflow/Meetings/Features/GetMeetings/GetMeetingsEndpoint.cs
+++ b/Modules/Workflow/Workflow/Meetings/Features/GetMeetings/GetMeetingsEndpoint.cs
@@ -18,7 +18,7 @@ public class GetMeetingsEndpoint : ICarterModule
             })
             .WithName("GetMeetings")
             .WithTags("Meetings")
-            .RequireAuthorization("CommitteeMember");
+            .RequireAuthorization("MeetingView");
     }
 }
 


### PR DESCRIPTION
## Summary

The meeting listing screen serves three personas — **meeting admin**, **meeting secretary**, and **meeting committee** — but the read endpoints were each gated by a single role policy, so the other two roles got a 403 when trying to view.

- `GET /meetings` and `GET /meetings/{id}` required `CommitteeMember` only → admin/secretary blocked unless they also held `COMMITTEE_MEMBER`.
- `GET /meetings/{id}/documents` required `MeetingAdmin` only → secretary and committee could not view/download documents at all (directly conflicts with their "view/download documents" requirement).
- `GET /meetings/queue` was bare `RequireAuthorization()`.

This introduces a shared **any-of** read policy so all three meeting roles can view meetings, detail, documents, and the queue, while **write/action** endpoints stay gated by their specific role policy.

## Changes

- **`Modules/Auth/Auth/AuthModule.cs`** — register `MeetingView` policy (grants if the user holds any of `MEETING_ADMIN`, `MEETING_SECRETARY`, `COMMITTEE_MEMBER`), reusing the existing `AddMonitoringAnyPolicy` helper.
- **Repoint the four read endpoints to `MeetingView`:**
  - `Meetings/Features/GetMeetings/GetMeetingsEndpoint.cs`
  - `Meetings/Features/GetMeetingDetail/GetMeetingDetailEndpoint.cs`
  - `Meetings/Features/Documents/ListMeetingDocumentsEndpoint.cs`
  - `Meetings/Features/GetMeetingQueue/GetMeetingQueueEndpoint.cs`

## Access model after this change

| Capability | Admin | Secretary | Committee |
|---|---|---|---|
| View list / detail / documents / queue | ✅ | ✅ | ✅ |
| Generate / link / remove documents, lifecycle (create/cutoff/cancel/end) | ✅ (`MeetingAdmin`) | — | — |
| Release / route-back items | — | ✅ (`MeetingSecretary`) | — |

Write/action endpoints are **unchanged** — they remain correctly gated. Document download/view is `AllowAnonymous()`, so all three roles can download with no change needed.

## Testing

- .NET SDK is not available in the authoring environment, so the solution was not compiled here. The changes are policy-string edits plus one policy registration via the existing `AddMonitoringAnyPolicy` helper (returns `AuthorizationBuilder`, so the fluent chain is preserved).
- Recommended verification: `dotnet build`, then per-persona token checks — committee/secretary get **200** on the read + documents endpoints and **403** on `POST /meetings/{id}/documents/generate`; admin retains full access. Existing tests: `Tests/Unit/Workflow.Tests/Meetings/`.

> Note: a companion frontend change (hiding the document Generate/Upload/Remove controls from non-admins in `MeetingDocumentsDialog`) is intended for `collateral-appraisal-system-app` but is not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNAX68SP1uVCYmApNRizvw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNAX68SP1uVCYmApNRizvw)_