### PR TITLE
fix(reporting): keep long unbroken text inside report template cells

### DIFF
--- a/Modules/Reporting/Reporting/Templates/appraisal-summary-condo.html
+++ b/Modules/Reporting/Reporting/Templates/appraisal-summary-condo.html
@@ -111,10 +111,13 @@
     <div class="comment-box">-</div>
     {{ end }}
   </div>
-
-  <!-- ════ SIGN-OFF + COMMITTEE (shared partial) ════ -->
-  {{ include 'partials/summary-signoff' }}
   </div><!-- .opinion-block -->
+
+  <!-- ════ SIGN-OFF — own page-break unit ════ -->
+  {{ include 'partials/summary-signoff' }}
+
+  <!-- ════ COMMITTEE BLOCK — own page-break unit ════ -->
+  {{ include 'partials/approver-block' }}
 
 </div>
 </body>

--- a/Modules/Reporting/Reporting/Templates/appraisal-summary-machine.html
+++ b/Modules/Reporting/Reporting/Templates/appraisal-summary-machine.html
@@ -44,6 +44,11 @@
       {{ if model.groups.size == 0 }}
       <tr><td colspan="5" style="height:34px;">&nbsp;</td></tr>
       {{ end }}
+      <tr class="grp-total">
+        <td></td>
+        <td colspan="3"><strong>รวมมูลค่าเครื่องจักร</strong></td>
+        <td class="num"><strong>{{ if model.total_appraisal_value; model.total_appraisal_value | math.format "N2"; end }}</strong></td>
+      </tr>
       {{ if model.condition }}<tr><td><strong>เงื่อนไข</strong></td><td colspan="4" class="brk">{{ model.condition }}</td></tr>{{ end }}
       {{ if model.remark }}<tr><td><strong>หมายเหตุ</strong></td><td colspan="4" class="brk">{{ model.remark }}</td></tr>{{ end }}
     </tbody>
@@ -99,10 +104,13 @@
     <div class="comment-box">-</div>
     {{ end }}
   </div>
-
-  <!-- ════ SIGN-OFF + COMMITTEE (shared partial) ════ -->
-  {{ include 'partials/summary-signoff' }}
   </div><!-- .opinion-block -->
+
+  <!-- ════ SIGN-OFF — own page-break unit ════ -->
+  {{ include 'partials/summary-signoff' }}
+
+  <!-- ════ COMMITTEE BLOCK — own page-break unit ════ -->
+  {{ include 'partials/approver-block' }}
 
 </div>
 </body>

--- a/Modules/Reporting/Reporting/Templates/partials/summary-block-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-block-body.html
@@ -81,10 +81,13 @@
     <div class="comment-box">-</div>
     {{ end }}
   </div>
-
-  <!-- ════ SIGN-OFF + COMMITTEE BLOCK — shared partial ════ -->
-  {{ include 'partials/summary-signoff' }}
   </div><!-- .opinion-block -->
+
+  <!-- ════ SIGN-OFF — own page-break unit ════ -->
+  {{ include 'partials/summary-signoff' }}
+
+  <!-- ════ COMMITTEE BLOCK — own page-break unit ════ -->
+  {{ include 'partials/approver-block' }}
 
   <!-- ════ UNIT TABLE: LB / Land ════ -->
   {{ if model.building_units.size > 0 }}

--- a/Modules/Reporting/Reporting/Templates/partials/summary-construction-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-construction-body.html
@@ -82,7 +82,10 @@
     </tbody>
   </table>
 
-  <!-- ════ SIGN-OFF + COMMITTEE BLOCK — shared partial ════ -->
+  <!-- ════ SIGN-OFF — own page-break unit ════ -->
   {{ include 'partials/summary-signoff' }}
+
+  <!-- ════ COMMITTEE BLOCK — own page-break unit ════ -->
+  {{ include 'partials/approver-block' }}
 
 </div>

--- a/Modules/Reporting/Reporting/Templates/partials/summary-signoff.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-signoff.html
@@ -1,6 +1,9 @@
 <!--
-  Partial: shared 3-column sign-off (ผู้นำเสนอ / ผู้จัดการส่วน / ผู้ช่วยผู้อำนวยการ) + committee block,
-  identical across all summary bodies. Shares the parent Scriban scope; expects model.* fields.
+  Partial: shared 3-column sign-off (ผู้นำเสนอ / ผู้จัดการส่วน / ผู้ช่วยผู้อำนวยการ), identical across
+  all summary bodies. Shares the parent Scriban scope; expects model.* fields.
+
+  The committee block is NOT included here — each body includes partials/approver-block as a sibling
+  so the two paginate independently. See .signoff / .committee-block in partials/summary-styles.
 -->
 <div class="signoff">
   <div class="cell">
@@ -19,6 +22,3 @@
     <div>ผู้ช่วยผู้อำนวยการ</div>
   </div>
 </div>
-
-<!-- ════ COMMITTEE BLOCK (shared partial) ════ -->
-{{ include 'partials/approver-block' }}

--- a/Modules/Reporting/Reporting/Templates/partials/summary-standard-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-standard-body.html
@@ -154,9 +154,12 @@
     <div class="comment-box">-</div>
     {{ end }}
   </div>
-
-  <!-- ════ SIGN-OFF (fields 36–41) + COMMITTEE BLOCK (fields 42–51) — shared partial ════ -->
-  {{ include 'partials/summary-signoff' }}
   </div><!-- .opinion-block -->
+
+  <!-- ════ SIGN-OFF (fields 36–41) — own page-break unit ════ -->
+  {{ include 'partials/summary-signoff' }}
+
+  <!-- ════ COMMITTEE BLOCK (fields 42–51) — own page-break unit ════ -->
+  {{ include 'partials/approver-block' }}
 
 </div><!-- .form -->

--- a/Modules/Reporting/Reporting/Templates/partials/summary-styles.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-styles.html
@@ -33,10 +33,14 @@ body {
 /* ── Generic label:value rows ───────────────────────────── */
 /* No left/right padding so info/attribute rows align flush with the table edges. */
 .pad { padding:5px 0; }
-.kv { display:flex; align-items:baseline; gap:0; margin-bottom:2.5px; }
+/* min-width:0 on both levels defeats the automatic minimum size: .kv is a grid item inside
+   .cols2/.cols3 (a 1fr track is minmax(auto,1fr)) and .v is a flex item, so both would
+   otherwise floor at their min-content width and let an unbroken token push past the page —
+   the wrap rule on .v alone cannot override that. See the overflow-wrap note further down. */
+.kv { display:flex; align-items:baseline; gap:0; margin-bottom:2.5px; min-width:0; }
 /* Fixed-width label = longest label (~102px) + 8px, so the value sits 8px past it and aligns. */
 .kv .k { font-weight:500; white-space:nowrap; width:110px; flex-shrink:0; }
-.kv .v { flex:1; min-height:14px; }
+.kv .v { flex:1; min-width:0; min-height:14px; overflow-wrap:anywhere; }
 /* Empty field → show a dash placeholder. */
 .kv .v:empty::before { content:"-"; }
 /* Machine attributes have a longer label (สภาพความต้องการของตลาด) — widen so values align. */
@@ -47,6 +51,9 @@ body {
                 border-bottom:1px solid #000; padding-bottom:2px; margin-bottom:3px; }
 .machine-head .machine-seq { white-space:nowrap; }
 .machine-head .machine-qty { white-space:nowrap; font-weight:500; }
+/* The machine name is free text the appraiser types, and it is the flexible item in this
+   flex row — min-width:0 stops its min-content size from pushing the head past the page. */
+.machine-head .machine-title { min-width:0; overflow-wrap:anywhere; }
 .machine-attrs { padding-left:18px; }
 /* Narrative attributes (components / remarks / opinion) flow full width below the label. */
 .machine-attrs .kv-block { display:block; }
@@ -82,7 +89,7 @@ body {
    the appraiser's textarea line breaks — e.g. the (1)/(2) breakdown in §1.4 — from
    collapsing onto a single line. Inside a numbered block the gutter already provides the
    indent, so no extra padding there. */
-.narrative { padding-left:18px; margin-bottom:4px; white-space:pre-line; }
+.narrative { padding-left:18px; margin-bottom:4px; white-space:pre-line; overflow-wrap:anywhere; }
 .numbered .narrative { padding-left:0; }
 /* Centered section heading — used by the book-intro page (FSD §2.1.2.7 section 1). */
 .section-bar.center { text-align:center; }
@@ -91,7 +98,10 @@ body {
 /* Construction value block: long labels — fixed label width so values line up per column;
    values never wrap; slightly smaller font so the long labels fit on one line. */
 .construction-values { font-size:7.5pt; }
-.construction-values .kv { align-items:baseline; }
+/* These values are nowrap, so they have no wrap rule to fall back on: keep the default
+   min-content floor (overriding the global .kv min-width:0) so an over-long value widens
+   its grid track as it always has, rather than silently overlapping the next column. */
+.construction-values .kv { align-items:baseline; min-width:auto; }
 .construction-values .kv .k { width:165px; white-space:normal; }
 .construction-values .kv .v { white-space:nowrap; }
 /* Right column (even cells): label stays on one line; value pushed to the right edge. */
@@ -103,7 +113,18 @@ body {
 
 /* ── Tables ─────────────────────────────────────────────── */
 table.grid { width:100%; border-collapse:collapse; font-size:8pt; }
-table.grid th, table.grid td { border:1px solid #000; padding:3px 5px; vertical-align:top; }
+/* overflow-wrap:anywhere for the same reason as .brk below — several columns hold text the
+   appraiser typed (floor type, ประเภทพื้น, รายการสิ่งปลูกสร้าง, machine names, comparison
+   rows). Without it one unbroken token sets the cell's min-content width, and auto table
+   layout hands that column the space at every other column's expense. .num cells opt out
+   via white-space:nowrap, so figures still never break. */
+table.grid th, table.grid td { border:1px solid #000; padding:3px 5px; vertical-align:top;
+                               overflow-wrap:anywhere; }
+/* The income / leasehold / profit-rent parameter tables carry no other styling. Their values
+   are all math.format-ed figures today, so this is defensive rather than a fix for an
+   observed defect — it costs nothing on numeric content and keeps the table inside the page
+   if free text is ever bound to a .pv cell. */
+table.params td { overflow-wrap:anywhere; }
 table.grid th { background:#ececec; text-align:center; font-weight:700; }
 .num { text-align:right; white-space:nowrap; }
 /* Land titles: one title per line, numbered — single global style used by every land
@@ -111,7 +132,7 @@ table.grid th { background:#ececec; text-align:center; font-weight:700; }
    list-style-position:inside + zero padding keeps the number inline with the first line and
    lets wrapped lines run flush to the cell's left edge (no hanging indent under the text). */
 .land-titles { margin:0; padding-left:0; list-style:decimal inside; }
-.land-titles li { margin-top:1px; }
+.land-titles li { margin-top:1px; overflow-wrap:anywhere; }
 /* A lone title has nothing to enumerate — drop the "1." but keep the list markup/spacing. */
 .land-titles.no-num { list-style:none; }
 /* Per-group cost breakdown: suppress internal horizontal borders so a group's
@@ -146,10 +167,11 @@ table.totals td.tt { text-align:right; font-style:italic; color:#333; }
    page the whole block moves to the next one rather than splitting mid-way. */
 .attrs-block { page-break-inside:avoid; break-inside:avoid; }
 
-/* Appraiser-opinion section (heading + comment + the 3-column signature row) travels as one
-   unit. The committee table is nested inside via the sign-off partial and keeps its own
-   .committee-block rule; when the combined height exceeds a page Chromium ignores the outer
-   avoid and falls back to normal pagination, so this can never strand content. */
+/* The opinion section (heading + comment), the sign-off row and the committee block are three
+   SIBLING page-break units — never nested. Each stays internally intact but paginates
+   independently, so an overflowing committee table no longer drags the opinion text with it.
+   Nesting them would defeat this: Chromium honours the outermost avoid and moves the whole
+   subtree as one blob. */
 .opinion-block { page-break-inside:avoid; break-inside:avoid; }
 
 /* FSD-aligned: plain left-aligned bold heading, no grey fill / border. */
@@ -164,9 +186,19 @@ table.grid.comparison th:first-child, table.grid.comparison td:first-child { wid
 .methods .m { display:flex; align-items:center; gap:4px; }
 
 /* white-space:pre-line keeps the appraiser's line breaks (newlines render as breaks). */
-.comment-box { min-height:42px; padding:4px 0; margin-top:3px; white-space:pre-line; }
-/* Preserve line breaks in free-text fields (เงื่อนไข / หมายเหตุ). */
-.brk { white-space:pre-line; }
+.comment-box { min-height:42px; padding:4px 0; margin-top:3px; white-space:pre-line;
+               overflow-wrap:anywhere; }
+/* Free-text fields the appraiser types (เงื่อนไข / หมายเหตุ / construction remark /
+   building description). pre-line preserves their line breaks.
+
+   overflow-wrap:anywhere, not break-word: a line only breaks at a soft-wrap opportunity
+   (space, hyphen, ICU dictionary break for Thai), and a long unbroken run — e.g. a pasted
+   string of digits — offers none, so it used to run straight past the cell's right border.
+   Both values break such a run, but only `anywhere` also lowers the element's min-content
+   width, which is what stops that same string from inflating the auto-layout table wider
+   than the page. It never pre-empts a real break opportunity: a word that fits still moves
+   to the next line whole, and Thai still breaks on ICU word boundaries. */
+.brk { white-space:pre-line; overflow-wrap:anywhere; }
 /* Sections wrapped in .landscape-page start on a new A4 landscape page. */
 @page landscape { size: A4 landscape; margin: 10mm; }
 .landscape-page { page: landscape; break-before: page; }
@@ -183,7 +215,8 @@ table.grid.comparison th:first-child, table.grid.comparison td:first-child { wid
 /* Cost-machine grid: 17 columns — shrink font + padding so it fits A4 landscape. */
 .cm-cost-table { font-size:6.5pt; }
 .cm-cost-table th, .cm-cost-table td { padding:2px 3px; }
-.cm-notes { margin-top:8px; font-size:7.5pt; line-height:1.6; }
+/* Static literal notes today — overflow-wrap is defensive, same reasoning as table.params. */
+.cm-notes { margin-top:8px; font-size:7.5pt; line-height:1.6; overflow-wrap:anywhere; }
 .cm-notes .lbl { font-weight:600; }
 /* Appraiser-opinion property type, underlined. */
 .opinion-type { display:inline-block; border-bottom:1px solid #000; font-weight:600; margin-bottom:3px; }


### PR DESCRIPTION
## Problem

A user reported that long unbroken text runs past its cell border instead of wrapping — first on the **Appraisal Summary** (`เงื่อนไข` / `หมายเหตุ` filled with a pasted run of digits), then on the **Appraisal Book** building-detail fields (`โครงหลังคา`, `ฝ้าเพดาน`, `หมายเหตุ` filled with `OtherOtherOther...`).

**Root cause.** CSS only breaks a line at a *soft-wrap opportunity* — a space, a hyphen, or an ICU dictionary break for Thai. A 200-character run of digits offers none, so the browser has nothing to break on. Normal Thai/English prose wraps fine, which is why only these fields misbehaved.

There is a second, less obvious effect: that same run also sets the cell's **min-content width**, and `table-layout:auto` then stretches the table until the trailing columns fall off the page entirely.

## Fix

One stylesheet, `partials/summary-styles.html`, which is shared by every summary variant (condo / land & building / machine / block / construction) **and** by `appraisal-book.html` — so a single edit covers all of them.

`overflow-wrap:anywhere` on every container that holds text the appraiser types, plus `min-width:0` where that container is a flex or grid item (a flex/grid item's automatic minimum size is its min-content size, which a wrap rule alone cannot override):

| Selector | Fields |
|---|---|
| `.kv` / `.kv .v` | label:value rows — address, building details, remarks |
| `.brk` | `เงื่อนไข` / `หมายเหตุ` / construction remark |
| `.comment-box` | `สรุปความเห็นผู้ประเมิน` |
| `.narrative` | machine and book write-ups |
| `.land-titles li` | title-deed lists |
| `table.grid td` / `th` | `ประเภทพื้น`, `รายการสิ่งปลูกสร้าง`, comparison rows |
| `.machine-head .machine-title` | machine name |
| `table.params td`, `.cm-notes` | defensive — these hold figures / static text today |

### Why `anywhere` and not `break-word`

Both break an over-long word, but only `anywhere` **also lowers min-content width**, which is what stops the table being stretched past the page. `break-word` alone would wrap the text and leave the table broken.

It never pre-empts a real break opportunity: a word that fits still moves to the next line whole, and Thai still breaks on ICU word boundaries. Only a token wider than the line itself is cut — where the alternative is overflowing the border.

### One deliberate opt-out

`.construction-values .kv` sets `min-width:auto` to override the global rule. Its values are `white-space:nowrap`, so they have no wrap rule to fall back on and must keep the default min-content floor — otherwise an over-long value would silently overlap the next column instead of widening its track.

## Verification

Rendered before/after in headless Chromium against the real stylesheet, with the "before" built by stripping only the added properties.

- **Defect fixed** — the digit run wraps inside the cell, the table stays at 100% width, all columns visible.
- **Whole-word wrapping unchanged** — Thai breaks at ICU word boundaries, `ACTEEI33343SEWWD1212` moves to the next line whole, manual line breaks in `เงื่อนไข`/`หมายเหตุ` still preserved.
- **No column redistribution** — `comparison`, the 17-column `cm-cost-table`, the floor/cost tables, `construction-values`, `machine-summary` and `machine-attrs` all render **pixel-identical** to before with normal content.
- `dotnet build Modules/Reporting/Reporting` → 0 errors, 0 warnings.

No data, model or endpoint changes. No input-length cap was added — the report should stay robust to whatever is already stored.

## Note on scope

This branch also carries a **second, pre-existing template change** that was already sitting uncommitted in the working tree and is bundled here at the repo owner's request (first commit):

- The committee block was included from inside `summary-signoff`, itself nested in the `.opinion-block` page-break unit. Chromium honours the outermost `break-inside:avoid`, so an overflowing committee table dragged the opinion text with it. The three blocks are now siblings that paginate independently.
- Adds the `รวมมูลค่าเครื่องจักร` total row to the machine summary table.

One `.opinion-block` comment hunk documents that pagination change but lives in `summary-styles.html`, so it landed in the wrapping commit rather than the pagination one — separating it would have needed interactive hunk staging. It is a comment only, with no behavioural effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UzmdGEjVWZuq2sBG8trf4