### PR TITLE
fix(workflow): stop losing appraisal-created signals to WorkflowInstance concurrency races

### DIFF
--- a/Bootstrapper/Api/Program.cs
+++ b/Bootstrapper/Api/Program.cs
@@ -110,7 +110,6 @@ builder.Services.AddMassTransit(config =>
         });
 
         configurator.PrefetchCount = 16;
-        configurator.ConfigureEndpoints(context);
         configurator.UseMessageRetry(r =>
         {
             r.Exponential(5,
@@ -201,27 +200,36 @@ builder.Services.AddMassTransit(config =>
             e.UsePartitioner<AssignmentSlaRecalculatedIntegrationEvent>(partitioner, m => m.Message.AppraisalId);
         });
 
-        // #6 Appointment date changed — two concurrent reschedule events for the same appraisal
-        // must not publish the stale SLA recalculation last. Partitioned by AppraisalId so
-        // per-appraisal ordering holds. Consumer is [ExcludeFromConfigureEndpoints] to prevent
-        // ConfigureEndpoints from also creating an unordered auto-queue.
-        configurator.ReceiveEndpoint("workflow-appointment-changed", e =>
+        // #6 WorkflowInstance variable feeders. All three consumers read-modify-write the SAME
+        // WorkflowInstance row — the first two write Variables, AppraisalCreated additionally runs
+        // an entire workflow resume inside the optimistic window — guarded only by RowVersion.
+        // AppraisalCreated and AppraisalValueChanged are staged into the SAME outbox transaction on
+        // the CI carry-forward path (PricingAnalysis.CloneForGroup raises AppraisalFinalValuesChanged
+        // during appraisal creation), so on separate queues they ran concurrently and the slow resume
+        // lost the race — DbUpdateConcurrencyException on every CI submit.
+        //
+        // One endpoint + ONE SHARED partitioner makes them mutually exclusive per workflow instance.
+        // The partitioner must be a single instance across all three UsePartitioner calls; separate
+        // CreatePartitioner calls give no cross-type serialization at all.
+        //
+        // Partition key is the WORKFLOW key (CorrelationId = Appraisal.RequestId = Request.Id), not
+        // AppraisalId: the contended resource is the WorkflowInstance row, which is keyed by
+        // correlation id. This key is equal-or-coarser than the AppraisalId used previously, so the
+        // per-appraisal ordering these endpoints used to guarantee is preserved as a subset.
+        //
+        // All three consumers are [ExcludeFromConfigureEndpoints] so ConfigureEndpoints does not
+        // also create unordered auto-queues for them.
+        configurator.ReceiveEndpoint("workflow-instance-variables", e =>
         {
             var partitioner = e.CreatePartitioner(16);
-            e.ConfigureConsumer<AppointmentDateChangedIntegrationEventConsumer>(context);
-            e.UsePartitioner<AppointmentDateChangedIntegrationEvent>(partitioner, m => m.Message.AppraisalId);
-        });
 
-        // Appraisal value changed — drives the approval-tier switch (meeting vs direct committee) by
-        // writing appraisalValue into WorkflowInstance.Variables. Partitioned by AppraisalId so multiple
-        // pricing recomputes for the same appraisal serialize (no out-of-order stale appraisalValue write).
-        // Consumer is [ExcludeFromConfigureEndpoints] to prevent ConfigureEndpoints from also creating an
-        // unordered auto-queue.
-        configurator.ReceiveEndpoint("workflow-appraisal-value-changed", e =>
-        {
-            var partitioner = e.CreatePartitioner(16);
+            e.ConfigureConsumer<AppraisalCreatedIntegrationEventConsumer>(context);
             e.ConfigureConsumer<AppraisalValueChangedIntegrationEventConsumer>(context);
-            e.UsePartitioner<AppraisalValueChangedIntegrationEvent>(partitioner, m => m.Message.AppraisalId);
+            e.ConfigureConsumer<AppointmentDateChangedIntegrationEventConsumer>(context);
+
+            e.UsePartitioner<AppraisalCreatedIntegrationEvent>(partitioner, m => m.Message.RequestId);
+            e.UsePartitioner<AppraisalValueChangedIntegrationEvent>(partitioner, m => m.Message.CorrelationId);
+            e.UsePartitioner<AppointmentDateChangedIntegrationEvent>(partitioner, m => m.Message.CorrelationId);
         });
 
         // #7 PMA external-sync status round-trip — the Integration module's WebhookDispatchConsumer
@@ -241,6 +249,13 @@ builder.Services.AddMassTransit(config =>
         });
 
         // In-memory outbox removed — using per-module persistent outbox via IntegrationEventDeliveryService
+
+        // MUST be last: MassTransit applies bus-level filters (UseMessageRetry above) only to
+        // endpoints configured after they are declared. Called earlier, the auto-configured
+        // consumer endpoints were built without the retry filter, so a transient/concurrency
+        // failure dead-lettered on the first attempt. Explicit ReceiveEndpoint blocks above are
+        // unaffected — their consumers are [ExcludeFromConfigureEndpoints].
+        configurator.ConfigureEndpoints(context);
     });
 });
 

--- a/Modules/Workflow/Workflow/EventHandlers/AppointmentDateChangedIntegrationEventConsumer.cs
+++ b/Modules/Workflow/Workflow/EventHandlers/AppointmentDateChangedIntegrationEventConsumer.cs
@@ -234,6 +234,15 @@ public class AppointmentDateChangedIntegrationEventConsumer(
         {
             await dbContext.SaveChangesAsync(ct);
         }
+        catch (DbUpdateConcurrencyException)
+        {
+            // MUST precede the DbUpdateException catch — it derives from it. A lost RowVersion race
+            // is NOT an idempotent duplicate: the appointmentDate write and the recomputed task
+            // deadlines did not land, and swallowing it here then calling MarkAsProcessedAsync
+            // discarded them silently. Surface it so MassTransit redelivers — the staged
+            // InboxMessage rolled back with the work, so no "Processing" row blocks the retry.
+            throw;
+        }
         catch (DbUpdateException)
         {
             // PK violation on InboxMessage INSERT: another consumer committed the same message

--- a/Modules/Workflow/Workflow/EventHandlers/AppraisalCreatedIntegrationEventConsumer.cs
+++ b/Modules/Workflow/Workflow/EventHandlers/AppraisalCreatedIntegrationEventConsumer.cs
@@ -1,5 +1,8 @@
+using Microsoft.EntityFrameworkCore;
+using Shared.Data.Outbox;
 using Shared.Messaging.Events;
 using Shared.Messaging.Filters;
+using Shared.Time;
 using Workflow.Data;
 using Workflow.Workflow.Repositories;
 using Workflow.Workflow.Services;
@@ -7,19 +10,54 @@ using static Workflow.Workflow.Services.WorkflowSignals;
 
 namespace Workflow.EventHandlers;
 
+/// <summary>
+/// Links the newly created Appraisal to its workflow instance and dispatches the
+/// "AppraisalCreated" signal that resumes the await-appraisal-created AwaitSignalActivity.
+///
+/// Idempotency: the InboxMessage INSERT is staged into the SAME SaveChangesAsync/transaction as
+/// the work (M4 fix, mirroring AppointmentDateChangedIntegrationEventConsumer). Using
+/// InboxGuard.TryClaimAsync here was unsafe: it commits the "Processing" claim in its own
+/// transaction, so when the work rolled back every MassTransit retry landed inside the guard's
+/// 5-minute stale window, returned "skip", and the message was acked and silently lost — leaving
+/// the workflow parked at await-appraisal-created forever.
+///
+/// Concurrency: WorkflowInstance carries a RowVersion token. The instance is loaded INSIDE the
+/// transaction (and inside the execution-strategy delegate) so a retry always re-reads a fresh
+/// token, and a lost optimistic-concurrency race is retried a bounded number of times rather than
+/// failing the message.
+///
+/// Ordering: hosted on the shared "workflow-instance-variables" endpoint, partitioned by RequestId
+/// alongside the other WorkflowInstance variable feeders, so this resume can no longer run
+/// concurrently with AppraisalValueChanged/AppointmentDateChanged for the same workflow instance.
+/// [ExcludeFromConfigureEndpoints] keeps ConfigureEndpoints from also creating an unordered
+/// auto-queue that would reintroduce the race.
+/// </summary>
+[ExcludeFromConfigureEndpoints]
 public class AppraisalCreatedIntegrationEventConsumer(
     ILogger<AppraisalCreatedIntegrationEventConsumer> logger,
+    WorkflowDbContext dbContext,
     IWorkflowInstanceRepository workflowInstanceRepository,
     IWorkflowSignalDispatcher signalDispatcher,
     IWorkflowUnitOfWork unitOfWork,
+    IDateTimeProvider dateTimeProvider,
     InboxGuard<WorkflowDbContext> inboxGuard) : IConsumer<AppraisalCreatedIntegrationEvent>
 {
+    // Matches InboxGuard.StaleThresholdMinutes so the two share the same reclaim window.
+    private const int StaleThresholdMinutes = 5;
+
+    private const int MaxConcurrencyAttempts = 3;
+
     public async Task Consume(ConsumeContext<AppraisalCreatedIntegrationEvent> context)
     {
-        if (await inboxGuard.TryClaimAsync(context.MessageId, GetType().Name, context.CancellationToken))
-            return;
-
+        var ct = context.CancellationToken;
+        var messageId = context.MessageId;
+        var consumerName = GetType().Name;
         var message = context.Message;
+
+        // Idempotency check — read-only, no commit yet. The claim itself is staged later so it
+        // shares the fate of the work.
+        if (await AlreadyHandledAsync(messageId, consumerName, ct))
+            return;
 
         logger.LogInformation(
             "Integration Event received: {IntegrationEvent} for AppraisalId: {AppraisalId}, RequestId: {RequestId}",
@@ -27,72 +65,43 @@ public class AppraisalCreatedIntegrationEventConsumer(
             message.AppraisalId,
             message.RequestId);
 
+        var correlationValue = message.RequestId.ToString();
+
+        var appraisalPayload = new Dictionary<string, object>
+        {
+            ["appraisalId"] = message.AppraisalId,
+            ["appraisalNumber"] = message.AppraisalNumber ?? string.Empty,
+            ["appraisalType"] = message.AppraisalType ?? "New"
+        };
+
+        // When the creation request included an appointment date, thread it into the
+        // same payload so Variables["appointmentDate"] is written atomically with the
+        // appraisal-created signal — no second consumer, no RowVersion race.
+        if (message.AppointmentDateTime.HasValue)
+            appraisalPayload["appointmentDate"] = message.AppointmentDateTime.Value;
+
         try
         {
-            var instance = await workflowInstanceRepository.GetByCorrelationId(
-                message.RequestId.ToString(), context.CancellationToken);
-
-            if (instance is null)
+            for (var attempt = 1;; attempt++)
             {
-                logger.LogWarning(
-                    "No workflow found for RequestId: {RequestId}. AppraisalId {AppraisalId} will not be linked.",
-                    message.RequestId, message.AppraisalId);
-                await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, context.CancellationToken);
-                return;
-            }
-
-            var appraisalPayload = new Dictionary<string, object>
-            {
-                ["appraisalId"] = message.AppraisalId,
-                ["appraisalNumber"] = message.AppraisalNumber ?? string.Empty,
-                ["appraisalType"] = message.AppraisalType ?? "New"
-            };
-
-            // When the creation request included an appointment date, thread it into the
-            // same payload so Variables["appointmentDate"] is written atomically with the
-            // appraisal-created signal — no second consumer, no RowVersion race.
-            if (message.AppointmentDateTime.HasValue)
-                appraisalPayload["appointmentDate"] = message.AppointmentDateTime.Value;
-
-            // Wrap in execution strategy + transaction so that
-            // SqlServerRetryingExecutionStrategy allows DB operations inside
-            // the user-initiated transaction, and ResumeWorkflowAsync takes
-            // the HasActiveTransaction branch to defer commit.
-            var strategy = unitOfWork.CreateExecutionStrategy();
-            await strategy.ExecuteAsync(async () =>
-            {
-                await unitOfWork.BeginTransactionAsync(context.CancellationToken);
                 try
                 {
-                    instance.UpdateVariables(appraisalPayload);
-
-                    await signalDispatcher.DispatchAsync(
-                        signalName: AppraisalCreated,
-                        correlationValue: message.RequestId.ToString(),
-                        payload: appraisalPayload,
-                        context.CancellationToken);
-
-                    await unitOfWork.SaveChangesAsync(context.CancellationToken);
-                    await unitOfWork.CommitTransactionAsync(context.CancellationToken);
+                    await LinkAndDispatchAsync(messageId, consumerName, correlationValue, appraisalPayload,
+                        message.RequestId, message.AppraisalId, ct);
+                    break;
                 }
-                catch
+                catch (Exception ex) when (attempt < MaxConcurrencyAttempts && IsConcurrencyConflict(ex))
                 {
-                    try { await unitOfWork.RollbackTransactionAsync(context.CancellationToken); }
-                    catch (Exception rollbackEx)
-                    {
-                        logger.LogError(rollbackEx, "Failed to rollback transaction for RequestId: {RequestId}",
-                            message.RequestId);
-                    }
+                    logger.LogWarning(ex,
+                        "Concurrency conflict linking AppraisalId {AppraisalId} for RequestId {RequestId}; " +
+                        "attempt {Attempt}/{MaxAttempts}, reloading",
+                        message.AppraisalId, message.RequestId, attempt, MaxConcurrencyAttempts);
 
-                    throw;
+                    await Task.Delay(TimeSpan.FromMilliseconds(50 * attempt), ct);
                 }
-            });
+            }
 
-            logger.LogInformation(
-                "Linked AppraisalId {AppraisalId} to workflow {WorkflowInstanceId} and dispatched signal for RequestId: {RequestId}",
-                message.AppraisalId, instance.Id, message.RequestId);
-
-            await inboxGuard.MarkAsProcessedAsync(context.MessageId, GetType().Name, context.CancellationToken);
+            await inboxGuard.MarkAsProcessedAsync(messageId, consumerName, ct);
         }
         catch (Exception ex)
         {
@@ -101,5 +110,137 @@ public class AppraisalCreatedIntegrationEventConsumer(
                 message.AppraisalId, message.RequestId);
             throw;
         }
+    }
+
+    /// <summary>
+    /// True when the failure is a lost optimistic-concurrency race. Walks the inner-exception chain:
+    /// WorkflowEngine/WorkflowService rethrow DbUpdateConcurrencyException untouched today, but the
+    /// resume path is deep enough that an intermediate layer wrapping it must not silently disable
+    /// the retry.
+    /// </summary>
+    private static bool IsConcurrencyConflict(Exception exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+            if (current is DbUpdateConcurrencyException)
+                return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// One retryable unit: load the instance, write the appraisal variables, dispatch the signal
+    /// (which resumes the workflow) and stage the inbox claim — all inside a single transaction.
+    /// </summary>
+    private async Task LinkAndDispatchAsync(
+        Guid? messageId,
+        string consumerName,
+        string correlationValue,
+        Dictionary<string, object> appraisalPayload,
+        Guid requestId,
+        Guid appraisalId,
+        CancellationToken ct)
+    {
+        // Wrap in execution strategy + transaction so that
+        // SqlServerRetryingExecutionStrategy allows DB operations inside
+        // the user-initiated transaction, and ResumeWorkflowAsync takes
+        // the HasActiveTransaction branch to defer commit.
+        var strategy = unitOfWork.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            // A previous attempt may have left a half-applied graph (and a stale RowVersion) in
+            // the tracker; the strategy can also re-enter this delegate after a transient fault.
+            dbContext.ChangeTracker.Clear();
+
+            await unitOfWork.BeginTransactionAsync(ct);
+            try
+            {
+                // Loaded INSIDE the transaction so the RowVersion we write against is fresh.
+                var instance = await workflowInstanceRepository.GetByCorrelationId(correlationValue, ct);
+
+                if (instance is null)
+                {
+                    logger.LogWarning(
+                        "No workflow found for RequestId: {RequestId}. AppraisalId {AppraisalId} will not be linked.",
+                        requestId, appraisalId);
+                }
+                else
+                {
+                    instance.UpdateVariables(appraisalPayload);
+
+                    await signalDispatcher.DispatchAsync(
+                        signalName: AppraisalCreated,
+                        correlationValue: correlationValue,
+                        payload: appraisalPayload,
+                        ct);
+                }
+
+                // Stage the claim so it commits with the work — or rolls back with it, leaving no
+                // "Processing" row to block MassTransit's redelivery.
+                StageInboxMessage(messageId, consumerName);
+
+                await unitOfWork.SaveChangesAsync(ct);
+                await unitOfWork.CommitTransactionAsync(ct);
+
+                if (instance is not null)
+                    logger.LogInformation(
+                        "Linked AppraisalId {AppraisalId} to workflow {WorkflowInstanceId} and dispatched signal for RequestId: {RequestId}",
+                        appraisalId, instance.Id, requestId);
+            }
+            catch
+            {
+                try { await unitOfWork.RollbackTransactionAsync(ct); }
+                catch (Exception rollbackEx)
+                {
+                    logger.LogError(rollbackEx, "Failed to rollback transaction for RequestId: {RequestId}",
+                        requestId);
+                }
+
+                throw;
+            }
+        });
+    }
+
+    /// <summary>
+    /// Read-only inbox pre-check. Returns true when the message must be skipped. A stale
+    /// "Processing" row is deleted so the staged INSERT later in this consume does not collide.
+    /// </summary>
+    private async Task<bool> AlreadyHandledAsync(Guid? messageId, string consumerName, CancellationToken ct)
+    {
+        if (!messageId.HasValue) return false;
+
+        var existing = await dbContext.Set<InboxMessage>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(m => m.MessageId == messageId.Value
+                                      && m.ConsumerType == consumerName, ct);
+
+        if (existing is null) return false;
+
+        if (existing.Status == InboxMessageStatus.Processed)
+            return true;
+
+        // Processing but still within the live window — another consumer is handling it.
+        if (existing.Status == InboxMessageStatus.Processing
+            && existing.StartedAt >= dateTimeProvider.ApplicationNow.AddMinutes(-StaleThresholdMinutes))
+            return true;
+
+        // Stale Processing row: remove it so our coming INSERT doesn't hit a PK collision.
+        if (existing.Status == InboxMessageStatus.Processing)
+        {
+            var schema = dbContext.Model.GetDefaultSchema() ?? "dbo";
+            await dbContext.Database.ExecuteSqlRawAsync(
+                "DELETE FROM [" + schema + "].[InboxMessage] " +
+                "WHERE MessageId = {0} AND ConsumerType = {1} AND Status = 'Processing'",
+                new object[] { messageId.Value, consumerName }, ct);
+        }
+
+        return false;
+    }
+
+    private void StageInboxMessage(Guid? messageId, string consumerName)
+    {
+        if (!messageId.HasValue) return;
+
+        dbContext.Set<InboxMessage>().Add(
+            InboxMessage.Create(messageId.Value, consumerName, dateTimeProvider.ApplicationNow));
     }
 }

--- a/Modules/Workflow/Workflow/EventHandlers/AppraisalValueChangedIntegrationEventConsumer.cs
+++ b/Modules/Workflow/Workflow/EventHandlers/AppraisalValueChangedIntegrationEventConsumer.cs
@@ -119,8 +119,20 @@ public class AppraisalValueChangedIntegrationEventConsumer(
         {
             await dbContext.SaveChangesAsync(ct);
         }
+        catch (DbUpdateConcurrencyException)
+        {
+            // MUST precede the DbUpdateException catch — it derives from it. A lost RowVersion race
+            // is NOT an idempotent duplicate: the appraisalValue write did not land, and swallowing
+            // it here then calling MarkAsProcessedAsync discarded the update silently (which can
+            // leave the approval-tier switch routing on a stale/absent value). Surface it so
+            // MassTransit redelivers — the staged InboxMessage rolled back with the work, so there
+            // is no "Processing" row to block the retry.
+            throw;
+        }
         catch (DbUpdateException)
         {
+            // PK violation on the InboxMessage INSERT: another consumer committed the same message
+            // between our read and our save — idempotent skip.
             dbContext.ChangeTracker.Clear();
         }
     }

--- a/Modules/Workflow/Workflow/Workflow/Engine/WorkflowEngine.cs
+++ b/Modules/Workflow/Workflow/Workflow/Engine/WorkflowEngine.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using Workflow.Workflow.Activities;
 using Workflow.Workflow.Activities.Core;
 using Workflow.Workflow.Activities.Factories;
@@ -212,6 +213,16 @@ public class WorkflowEngine : IWorkflowEngine
         {
             _logger.LogInformation(
                 "ORCHESTRATION: Resume request canceled for workflow instance {WorkflowInstanceId} at activity {ActivityId}",
+                workflowInstanceId, activityId);
+            throw;
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            // A lost optimistic-concurrency race is retryable and must NOT drive the workflow to
+            // Failed — that would permanently kill a healthy instance over a transient collision.
+            // (The failure-checkpoint below would throw on the same stale token anyway.)
+            _logger.LogWarning(
+                "ORCHESTRATION: Concurrency conflict resuming workflow instance {WorkflowInstanceId} at activity {ActivityId}; propagating for caller retry",
                 workflowInstanceId, activityId);
             throw;
         }
@@ -489,6 +500,14 @@ public class WorkflowEngine : IWorkflowEngine
                 activityDefinition.Id, duration.TotalMilliseconds);
 
             return activityResult;
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            // Infrastructure-level, not a business failure: the caller lost an optimistic-concurrency
+            // race and must reload and retry the whole unit. Converting it to ActivityResult.Failed
+            // would hide it from the caller's retry filter AND mark a perfectly healthy activity as
+            // failed. Let it propagate untouched — do NOT track a failed execution step.
+            throw;
         }
         catch (Exception ex)
         {

--- a/Modules/Workflow/Workflow/Workflow/Repositories/WorkflowInstanceRepository.cs
+++ b/Modules/Workflow/Workflow/Workflow/Repositories/WorkflowInstanceRepository.cs
@@ -1,11 +1,16 @@
 using Workflow.Data;
 using Workflow.Workflow.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.Extensions.Logging;
 using Shared.Data;
 
 namespace Workflow.Workflow.Repositories;
 
-public class WorkflowInstanceRepository(WorkflowDbContext dbContext, IDateTimeProvider dateTimeProvider) : IWorkflowInstanceRepository
+public class WorkflowInstanceRepository(
+    WorkflowDbContext dbContext,
+    IDateTimeProvider dateTimeProvider,
+    ILogger<WorkflowInstanceRepository> logger) : IWorkflowInstanceRepository
 {
     public async Task<WorkflowInstance?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
@@ -103,7 +108,174 @@ public class WorkflowInstanceRepository(WorkflowDbContext dbContext, IDateTimePr
     {
         await LoggerAsync(cancellationToken);
 
-        await dbContext.SaveChangesAsync(cancellationToken);
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            // SaveChanges flushes EVERY tracked entity, so the losing command is not necessarily
+            // the WorkflowInstance — WorkflowBookmark carries a rowversion too. Name the entity and
+            // both token values so the racing writer can be identified from the log alone.
+            await LogConcurrencyConflictAsync(ex, cancellationToken);
+            throw;
+        }
+    }
+
+    private async Task LogConcurrencyConflictAsync(
+        DbUpdateConcurrencyException ex,
+        CancellationToken cancellationToken)
+    {
+        foreach (var entry in ex.Entries)
+        {
+            try
+            {
+                var key = entry.Metadata.FindPrimaryKey()?.Properties
+                    .Select(p => entry.Property(p.Name).CurrentValue)
+                    .FirstOrDefault();
+
+                var databaseValues = await entry.GetDatabaseValuesAsync(cancellationToken);
+
+                logger.LogError(
+                    "CONCURRENCY: {Entity} key={Key} state={State} rowExistsInDb={RowExists} " +
+                    "originalToken={OriginalToken} databaseToken={DatabaseToken} " +
+                    "dbUpdatedBy={DbUpdatedBy} dbUpdatedOn={DbUpdatedOn} " +
+                    "mineActivity={MineActivity}/{MineStatus} dbActivity={DbActivity}/{DbStatus}",
+                    entry.Metadata.ClrType.Name,
+                    key,
+                    entry.State,
+                    databaseValues is not null,
+                    DescribeConcurrencyToken(entry, entry.OriginalValues),
+                    databaseValues is null ? "<row-missing>" : DescribeConcurrencyToken(entry, databaseValues),
+                    // Audit columns identify the winning writer; activity/status reveal whether the
+                    // winner was a duplicate resume that already advanced the workflow past us.
+                    Peek(databaseValues, "UpdatedBy"),
+                    Peek(databaseValues, "UpdatedAt"),
+                    Peek(entry.CurrentValues, "CurrentActivityId"),
+                    Peek(entry.CurrentValues, "Status"),
+                    Peek(databaseValues, "CurrentActivityId"),
+                    Peek(databaseValues, "Status"));
+
+                // The columns the winning writer actually changed — compare what WE loaded against
+                // what is in the row now. This names the racer far more precisely than the audit
+                // columns can (every consumer and background job stamps UpdatedBy='anonymous').
+                if (databaseValues is not null)
+                    logger.LogError("CONCURRENCY: {Entity} key={Key} columns changed by the winning writer: {Changes}",
+                        entry.Metadata.ClrType.Name, key, DescribeDrift(entry.OriginalValues, databaseValues));
+            }
+            catch (Exception logEx)
+            {
+                // Diagnostics must never mask the original concurrency failure.
+                logger.LogWarning(logEx, "CONCURRENCY: failed to describe conflicting entry {Entity}",
+                    entry.Metadata.ClrType.Name);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Lists properties whose value in the database differs from the value we originally loaded,
+    /// i.e. exactly what the writer that beat us touched. The concurrency token itself is skipped
+    /// (it always differs, that is the whole point).
+    /// </summary>
+    private static string DescribeDrift(PropertyValues mine, PropertyValues theirs)
+    {
+        var changes = new List<string>();
+
+        foreach (var property in theirs.Properties)
+        {
+            if (property.IsConcurrencyToken) continue;
+            if (mine.Properties.All(p => p.Name != property.Name)) continue;
+
+            var mineValue = Stringify(mine[property.Name]);
+            var theirValue = Stringify(theirs[property.Name]);
+
+            if (mineValue == theirValue) continue;
+
+            // Dictionary-valued columns (notably Variables) share a long identical prefix, so a raw
+            // truncated string diff hides the one key that actually moved. Diff by key instead.
+            if (mine[property.Name] is IDictionary<string, object> mineMap
+                && theirs[property.Name] is IDictionary<string, object> theirMap)
+            {
+                changes.Add($"{property.Name}: {DescribeMapDrift(mineMap, theirMap)}");
+                continue;
+            }
+
+            changes.Add($"{property.Name}: '{Truncate(mineValue)}' -> '{Truncate(theirValue)}'");
+        }
+
+        return changes.Count == 0 ? "<none — token bumped with no column change>" : string.Join(" | ", changes);
+    }
+
+    /// <summary>Per-key diff of two variable maps: added, removed and changed keys only.</summary>
+    private static string DescribeMapDrift(
+        IDictionary<string, object> mine,
+        IDictionary<string, object> theirs)
+    {
+        var parts = new List<string>();
+
+        foreach (var (key, theirValue) in theirs)
+        {
+            if (!mine.TryGetValue(key, out var mineValue))
+            {
+                parts.Add($"+{key}='{Truncate(Stringify(theirValue))}'");
+                continue;
+            }
+
+            var mineText = Stringify(mineValue);
+            var theirText = Stringify(theirValue);
+            if (mineText != theirText)
+                parts.Add($"~{key}: '{Truncate(mineText)}' -> '{Truncate(theirText)}'");
+        }
+
+        foreach (var key in mine.Keys.Where(k => !theirs.ContainsKey(k)))
+            parts.Add($"-{key}");
+
+        return parts.Count == 0 ? "<no key-level difference>" : string.Join(", ", parts);
+    }
+
+    private static string Stringify(object? value)
+    {
+        if (value is null) return "<null>";
+        if (value is string s) return s;
+        if (value is byte[] bytes) return "0x" + Convert.ToHexString(bytes);
+        if (value.GetType().IsPrimitive || value is DateTime or DateTimeOffset or Guid or decimal)
+            return value.ToString() ?? "<null>";
+
+        // Value-converted properties (Variables, RuntimeOverrides, ActiveBranchActivities) surface as
+        // mutable CLR objects; reference comparison would report every one of them as changed.
+        try
+        {
+            return JsonSerializer.Serialize(value);
+        }
+        catch
+        {
+            return value.ToString() ?? "<null>";
+        }
+    }
+
+    private static string Truncate(string value) =>
+        value.Length <= 300 ? value : value[..300] + "…";
+
+    /// <summary>Reads a property by name if the entity actually has it; never throws.</summary>
+    private static string Peek(PropertyValues? values, string propertyName)
+    {
+        if (values is null) return "<n/a>";
+        if (values.Properties.All(p => p.Name != propertyName)) return "<n/a>";
+
+        return values[propertyName]?.ToString() ?? "<null>";
+    }
+
+    private static string DescribeConcurrencyToken(EntityEntry entry, PropertyValues values)
+    {
+        var token = entry.Metadata.GetProperties().FirstOrDefault(p => p.IsConcurrencyToken);
+        if (token is null) return "<none>";
+
+        return values[token.Name] switch
+        {
+            byte[] bytes => "0x" + Convert.ToHexString(bytes),
+            null => "<null>",
+            var other => other.ToString() ?? "<null>"
+        };
     }
 
     public async Task LoggerAsync(CancellationToken cancellationToken = default)

--- a/Tests/Unit/Workflow.Tests/EventHandlers/AppraisalCreatedIntegrationEventConsumerTests.cs
+++ b/Tests/Unit/Workflow.Tests/EventHandlers/AppraisalCreatedIntegrationEventConsumerTests.cs
@@ -26,10 +26,11 @@ public class AppraisalCreatedIntegrationEventConsumerTests
         await using var db = NewDb();
         var instanceRepository = Substitute.For<IWorkflowInstanceRepository>();
         var unitOfWork = Substitute.For<IWorkflowUnitOfWork>();
+        var dateTimeProvider = Substitute.For<Shared.Time.IDateTimeProvider>();
         var inboxGuard = new InboxGuard<WorkflowDbContext>(
             db,
             Substitute.For<ILogger<InboxGuard<WorkflowDbContext>>>(),
-            Substitute.For<Shared.Time.IDateTimeProvider>());
+            dateTimeProvider);
 
         var requestId = Guid.NewGuid();
         var appraisalId = Guid.NewGuid();
@@ -43,7 +44,7 @@ public class AppraisalCreatedIntegrationEventConsumerTests
 
         var consumer = new AppraisalCreatedIntegrationEventConsumer(
             Substitute.For<ILogger<AppraisalCreatedIntegrationEventConsumer>>(),
-            instanceRepository, signalDispatcher, unitOfWork, inboxGuard);
+            db, instanceRepository, signalDispatcher, unitOfWork, dateTimeProvider, inboxGuard);
 
         var ctx = BuildContext(new AppraisalCreatedIntegrationEvent
         {
@@ -71,15 +72,16 @@ public class AppraisalCreatedIntegrationEventConsumerTests
     }
 
     [Fact]
-    public async Task Consume_NoWorkflowFound_MarksProcessedAndDoesNotSave()
+    public async Task Consume_NoWorkflowFound_StagesInboxRowAndDoesNotDispatch()
     {
         await using var db = NewDb();
         var instanceRepository = Substitute.For<IWorkflowInstanceRepository>();
         var unitOfWork = Substitute.For<IWorkflowUnitOfWork>();
+        var dateTimeProvider = Substitute.For<Shared.Time.IDateTimeProvider>();
         var inboxGuard = new InboxGuard<WorkflowDbContext>(
             db,
             Substitute.For<ILogger<InboxGuard<WorkflowDbContext>>>(),
-            Substitute.For<Shared.Time.IDateTimeProvider>());
+            dateTimeProvider);
 
         var requestId = Guid.NewGuid();
 
@@ -90,7 +92,7 @@ public class AppraisalCreatedIntegrationEventConsumerTests
 
         var consumer = new AppraisalCreatedIntegrationEventConsumer(
             Substitute.For<ILogger<AppraisalCreatedIntegrationEventConsumer>>(),
-            instanceRepository, signalDispatcher, unitOfWork, inboxGuard);
+            db, instanceRepository, signalDispatcher, unitOfWork, dateTimeProvider, inboxGuard);
 
         var ctx = BuildContext(new AppraisalCreatedIntegrationEvent
         {
@@ -102,7 +104,10 @@ public class AppraisalCreatedIntegrationEventConsumerTests
 
         await consumer.Consume(ctx);
 
-        await unitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+        // The inbox claim is now staged transactionally even when there is no workflow to link,
+        // so the "acknowledge and move on" path still commits exactly once.
+        await unitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+        await unitOfWork.Received(1).CommitTransactionAsync(Arg.Any<CancellationToken>());
         await signalDispatcher.DidNotReceive().DispatchAsync(
             Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<Dictionary<string, object>>(), Arg.Any<CancellationToken>());
@@ -114,10 +119,11 @@ public class AppraisalCreatedIntegrationEventConsumerTests
         await using var db = NewDb();
         var instanceRepository = Substitute.For<IWorkflowInstanceRepository>();
         var unitOfWork = Substitute.For<IWorkflowUnitOfWork>();
+        var dateTimeProvider = Substitute.For<Shared.Time.IDateTimeProvider>();
         var inboxGuard = new InboxGuard<WorkflowDbContext>(
             db,
             Substitute.For<ILogger<InboxGuard<WorkflowDbContext>>>(),
-            Substitute.For<Shared.Time.IDateTimeProvider>());
+            dateTimeProvider);
 
         var requestId = Guid.NewGuid();
         var appraisalId = Guid.NewGuid();
@@ -132,7 +138,7 @@ public class AppraisalCreatedIntegrationEventConsumerTests
 
         var consumer = new AppraisalCreatedIntegrationEventConsumer(
             Substitute.For<ILogger<AppraisalCreatedIntegrationEventConsumer>>(),
-            instanceRepository, signalDispatcher, unitOfWork, inboxGuard);
+            db, instanceRepository, signalDispatcher, unitOfWork, dateTimeProvider, inboxGuard);
 
         var ctx = BuildContext(new AppraisalCreatedIntegrationEvent
         {
@@ -157,10 +163,11 @@ public class AppraisalCreatedIntegrationEventConsumerTests
         await using var db = NewDb();
         var instanceRepository = Substitute.For<IWorkflowInstanceRepository>();
         var unitOfWork = Substitute.For<IWorkflowUnitOfWork>();
+        var dateTimeProvider = Substitute.For<Shared.Time.IDateTimeProvider>();
         var inboxGuard = new InboxGuard<WorkflowDbContext>(
             db,
             Substitute.For<ILogger<InboxGuard<WorkflowDbContext>>>(),
-            Substitute.For<Shared.Time.IDateTimeProvider>());
+            dateTimeProvider);
 
         var requestId = Guid.NewGuid();
         var instance = WorkflowInstance.Create(
@@ -173,7 +180,7 @@ public class AppraisalCreatedIntegrationEventConsumerTests
 
         var consumer = new AppraisalCreatedIntegrationEventConsumer(
             Substitute.For<ILogger<AppraisalCreatedIntegrationEventConsumer>>(),
-            instanceRepository, signalDispatcher, unitOfWork, inboxGuard);
+            db, instanceRepository, signalDispatcher, unitOfWork, dateTimeProvider, inboxGuard);
 
         var ctx = BuildContext(new AppraisalCreatedIntegrationEvent
         {


### PR DESCRIPTION
## Problem

Resuming `await-appraisal-created` reliably failed with `DbUpdateConcurrencyException` ("expected 1 row, affected 0"), and the message was then **silently dropped** — the workflow stayed parked at that activity forever with no error surfaced anywhere. Reproduced 3/3 on CI submits.

## Root cause

On the CI carry-forward path, `AppraisalCreatedIntegrationEvent` and `AppraisalValueChangedIntegrationEvent` are staged into the **same outbox transaction** (`PricingAnalysis.CloneForGroup` raises `AppraisalFinalValuesChangedEvent` during creation), then dispatched to **two different queues** and consumed **concurrently**. Both read-modify-write the same `WorkflowInstance` row, guarded only by `RowVersion`:

| Consumer | Behaviour |
|---|---|
| `AppraisalValueChangedIntegrationEventConsumer` | writes one variable, commits in ms — **wins** |
| `AppraisalCreatedIntegrationEventConsumer` | holds the optimistic window open across the **whole workflow resume** — **loses** |

The existing partitioners serialized each queue internally by `AppraisalId` but gave no ordering *between* queues.

Diagnostics added here pinned it exactly:

```
CONCURRENCY: WorkflowInstance … originalToken=0x…15D5BD databaseToken=0x…15D5BE
             mineActivity=await-appraisal-created/Running dbActivity=await-appraisal-created/Suspended
CONCURRENCY: … columns changed by the winning writer:
             UpdatedBy: 'P5229' -> 'anonymous' | Variables: +appraisalValue='0'
```

## Changes

**Serialize the writers**
- One `workflow-instance-variables` endpoint hosting all three `WorkflowInstance` variable feeders behind **one shared partitioner**, keyed on the **workflow correlation id** (`= Appraisal.RequestId = Request.Id`) rather than `AppraisalId` — the contended resource is the `WorkflowInstance` row. That key is equal-or-coarser than `AppraisalId`, so existing per-appraisal ordering guarantees are preserved as a subset.
- `ConfigureEndpoints(context)` moved **last**. Declared before `UseMessageRetry`, the auto-configured endpoints were built with no retry filter at all.

**Stop the silent message loss**
- `AppraisalCreatedIntegrationEventConsumer`: `InboxGuard.TryClaimAsync` replaced with a read-only pre-check, with the `InboxMessage` INSERT staged into the same transaction as the work. The claim was previously committed separately, so on rollback every retry landed inside the guard's 5-minute stale window, returned "skip", and the message was acked and lost. Instance is now loaded inside the transaction/strategy delegate, with up to 3 reload-and-retry attempts on a lost race.
- `AppraisalValueChanged` / `AppointmentDateChanged` consumers: catch `DbUpdateConcurrencyException` **before** `DbUpdateException` (it derives from it). A lost race was being treated as an idempotent duplicate and marked Processed — silently discarding the variable write.

**Stop killing healthy workflows**
- `WorkflowEngine` rethrows `DbUpdateConcurrencyException` untouched instead of converting it to `ActivityResult.Failed` and driving the instance to `WorkflowStatus.Failed`. A transient collision was permanently failing healthy workflows, and the wrapping also hid it from the caller's retry filter.

**Diagnostics**
- `WorkflowInstanceRepository` logs entity, key, both concurrency tokens, audit columns and a per-key `Variables` drift diff on conflict. This is what identified the racer and is worth keeping — it is error-level and only fires on an actual conflict.

## Deployment

⚠️ **Queue topology changes.** `workflow-appointment-changed`, `workflow-appraisal-value-changed` and the auto-generated appraisal-created queue become orphaned; anything in them at cutover is stranded. Each app node runs its own broker (no clustering), so this is a **per-node** check: confirm empty in each node's management UI before deploying, then delete.

## Testing

- `dotnet build` green across the solution.
- Not run: `dotnet test`. Note the 4 tests in `AppraisalCreatedIntegrationEventConsumerTests` fail on `main` already for an unrelated reason (`InboxGuard.MarkAsProcessedAsync` uses `ExecuteSqlRawAsync`, unsupported by the InMemory provider) — verified by stashing. Their constructor/assertions are updated here to match the new signature and the now-transactional inbox staging.
- **Runtime verification still outstanding** — reviewer should confirm: `workflow-instance-variables` bound to all three message types with no auto-generated appraisal-created queue; `webhook-dispatch` still receiving `AppraisalCreatedIntegrationEvent`; and a CI carry-forward submit producing no `CONCURRENCY:` lines.

## Not covered

Serializing these three does not make `WorkflowInstance` writes globally safe. HTTP-driven resumes (`CompleteActivityEndpoint`), other queue-based resumers, and `SlaMonitorService` remain unserialized — the retry loop is the backstop there.

## Known issue left open

`SwitchActivity` coerces a missing/null expression value to `0m`. With `approval-tier-switch` cases `["<= 30000000", "> 30000000"]`, an absent `appraisalValue` silently matches `<= 30000000` and **routes past the meeting**. This PR makes a lost write loud rather than silent, but does not remove the fail-open default. Flagged for separate triage.

Separately, CI carry-forward currently writes `ValuationAnalyses` as 0 (the pre-save domain event can't see `Added` clones) — diagnosed but **not** fixed here; scheduled as follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8PPD8bWU1JmisXp1tMZSZ
