### PR TITLE
Add SameAssigneeAsActivity assignee selection strategy

### DIFF
--- a/Modules/Workflow/Workflow/AssigneeSelection/Core/AssigneeSelectionStrategy.cs
+++ b/Modules/Workflow/Workflow/AssigneeSelection/Core/AssigneeSelectionStrategy.cs
@@ -50,7 +50,13 @@ public enum AssigneeSelectionStrategy
     /// <summary>
     /// Assign to a user specified in a named workflow variable
     /// </summary>
-    VariableAssignee
+    VariableAssignee,
+
+    /// <summary>
+    /// Assign to the same user who was assigned a different, named prior activity in this
+    /// workflow instance (positive counterpart of the excludeAssigneesFrom rule)
+    /// </summary>
+    SameAssigneeAsActivity
 }
 
 /// <summary>
@@ -75,6 +81,7 @@ public static class AssignmentStrategyExtensions
             AssigneeSelectionStrategy.StartedBy => "started_by",
             AssigneeSelectionStrategy.Pool => "pool",
             AssigneeSelectionStrategy.VariableAssignee => "variable_assignee",
+            AssigneeSelectionStrategy.SameAssigneeAsActivity => "same_assignee_as_activity",
             _ => throw new ArgumentOutOfRangeException(nameof(strategy), strategy, "Unknown assignment strategy")
         };
     }
@@ -96,6 +103,7 @@ public static class AssignmentStrategyExtensions
             "started_by" => AssigneeSelectionStrategy.StartedBy,
             "pool" => AssigneeSelectionStrategy.Pool,
             "variable_assignee" => AssigneeSelectionStrategy.VariableAssignee,
+            "same_assignee_as_activity" => AssigneeSelectionStrategy.SameAssigneeAsActivity,
             _ => throw new ArgumentException($"Unknown assignment strategy: {strategyString}", nameof(strategyString))
         };
     }

--- a/Modules/Workflow/Workflow/AssigneeSelection/Factories/AssigneeSelectorFactory.cs
+++ b/Modules/Workflow/Workflow/AssigneeSelection/Factories/AssigneeSelectorFactory.cs
@@ -35,6 +35,8 @@ public class AssigneeSelectorFactory : IAssigneeSelectorFactory
                 .GetRequiredService<PoolAssigneeSelector>(),
             AssigneeSelectionStrategy.VariableAssignee => _serviceProvider
                 .GetRequiredService<VariableAssigneeSelector>(),
+            AssigneeSelectionStrategy.SameAssigneeAsActivity => _serviceProvider
+                .GetRequiredService<SameAssigneeAsActivitySelector>(),
             _ => throw new ArgumentException($"Unknown assignee selection strategy: {strategy}")
         };
     }

--- a/Modules/Workflow/Workflow/AssigneeSelection/Strategies/SameAssigneeAsActivitySelector.cs
+++ b/Modules/Workflow/Workflow/AssigneeSelection/Strategies/SameAssigneeAsActivitySelector.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Workflow.AssigneeSelection.Core;
+using Workflow.Data;
+using Workflow.Workflow.Models;
+
+namespace Workflow.AssigneeSelection.Strategies;
+
+/// <summary>
+/// Assigns the task to the same user who was assigned a different, named prior activity in the
+/// same workflow instance. This is the positive counterpart of the <c>excludeAssigneesFrom</c>
+/// rule: instead of excluding that activity's assignee, it selects them. The source activity id is
+/// read from <c>Properties["sameAssigneeAsActivity"]</c> and resolved against
+/// <see cref="WorkflowActivityExecution.AssignedTo"/> — the same identifier
+/// <c>excludeAssigneesFrom</c> compares against — so the two rules are exact inverses.
+/// Fails softly (so the cascade falls through) when the property is missing or the source activity
+/// has no completed execution in this instance (e.g. non-PMA flows where it never ran).
+/// </summary>
+public class SameAssigneeAsActivitySelector : IAssigneeSelector
+{
+    private readonly WorkflowDbContext _dbContext;
+    private readonly ILogger<SameAssigneeAsActivitySelector> _logger;
+
+    public SameAssigneeAsActivitySelector(
+        WorkflowDbContext dbContext,
+        ILogger<SameAssigneeAsActivitySelector> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<AssigneeSelectionResult> SelectAssigneeAsync(
+        AssignmentContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var sourceActivityId = GetStringValue(context.Properties, "sameAssigneeAsActivity");
+
+        if (string.IsNullOrWhiteSpace(sourceActivityId))
+        {
+            _logger.LogInformation(
+                "SameAssigneeAsActivity selector skipped for activity {ActivityName}: no 'sameAssigneeAsActivity' configured",
+                context.ActivityName);
+            return AssigneeSelectionResult.Failure(
+                "SameAssigneeAsActivity strategy requires 'sameAssigneeAsActivity' in properties");
+        }
+
+        if (context.WorkflowInstanceId == Guid.Empty)
+        {
+            return AssigneeSelectionResult.Failure(
+                "SameAssigneeAsActivity strategy requires a valid WorkflowInstanceId");
+        }
+
+        var assignee = await _dbContext.WorkflowActivityExecutions
+            .Where(ae => ae.WorkflowInstanceId == context.WorkflowInstanceId
+                         && ae.ActivityId == sourceActivityId
+                         && ae.Status == ActivityExecutionStatus.Completed
+                         && ae.AssignedTo != null
+                         && ae.AssignedTo != ""
+                         && ae.AssignedTo != "system")
+            .OrderByDescending(ae => ae.CompletedOn)
+            .Select(ae => ae.AssignedTo)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (string.IsNullOrEmpty(assignee))
+        {
+            _logger.LogInformation(
+                "SameAssigneeAsActivity selector: no completed assignee for source activity {SourceActivity} in workflow {WorkflowInstanceId}",
+                sourceActivityId, context.WorkflowInstanceId);
+            return AssigneeSelectionResult.Failure(
+                $"No completed assignee found for source activity '{sourceActivityId}'");
+        }
+
+        _logger.LogInformation(
+            "SameAssigneeAsActivity selector assigned {UserId} for activity {ActivityName} from source activity {SourceActivity} in workflow {WorkflowInstanceId}",
+            assignee, context.ActivityName, sourceActivityId, context.WorkflowInstanceId);
+
+        return AssigneeSelectionResult.Success(assignee, new Dictionary<string, object>
+        {
+            ["SelectionStrategy"] = "SameAssigneeAsActivity",
+            ["SourceActivity"] = sourceActivityId,
+            ["ResolvedAssignee"] = assignee
+        });
+    }
+
+    private static string? GetStringValue(Dictionary<string, object>? dict, string key)
+    {
+        if (dict is null || !dict.TryGetValue(key, out var val))
+            return null;
+
+        if (val is string s) return s;
+        if (val is JsonElement { ValueKind: JsonValueKind.String } je) return je.GetString();
+        return val?.ToString();
+    }
+}

--- a/Modules/Workflow/Workflow/Workflow/Config/appraisal-workflow.json
+++ b/Modules/Workflow/Workflow/Workflow/Config/appraisal-workflow.json
@@ -510,12 +510,14 @@
           "assigneeGroup": "IntAppraisalStaff",
           "assignmentStrategies": "variable_assignee",
           "initialAssignmentStrategies": [
+            "same_assignee_as_activity",
             "variable_assignee",
             "round_robin"
           ],
           "revisitAssignmentStrategies": [
             "previous_owner"
           ],
+          "sameAssigneeAsActivity": "int-pma-input",
           "assigneeVariable": "internalFollowupStaffId",
           "timeoutDuration": "PT72H",
           "decisionConditions": {

--- a/Modules/Workflow/Workflow/WorkflowModule.cs
+++ b/Modules/Workflow/Workflow/WorkflowModule.cs
@@ -65,6 +65,7 @@ public static class WorkflowModule
         services.AddScoped<IAssigneeSelectorFactory, AssigneeSelectorFactory>();
         services.AddScoped<TeamConstrainedAssigneeSelector>();
         services.AddScoped<VariableAssigneeSelector>();
+        services.AddScoped<SameAssigneeAsActivitySelector>();
         services.AddScoped<ICascadingAssignmentEngine, CascadingAssignmentEngine>();
 
         // Team service — queries auth schema (Company = Team, Group = assignment group)

--- a/Tests/Unit/Workflow.Tests/AssigneeSelection/SameAssigneeAsActivitySelectorTests.cs
+++ b/Tests/Unit/Workflow.Tests/AssigneeSelection/SameAssigneeAsActivitySelectorTests.cs
@@ -1,0 +1,105 @@
+using Workflow.AssigneeSelection.Core;
+using Workflow.AssigneeSelection.Strategies;
+using Workflow.Data;
+using Workflow.Workflow.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Workflow.Tests.AssigneeSelection;
+
+public class SameAssigneeAsActivitySelectorTests
+{
+    private static SameAssigneeAsActivitySelector CreateSelector(out WorkflowDbContext dbContext)
+    {
+        var options = new DbContextOptionsBuilder<WorkflowDbContext>()
+            .UseInMemoryDatabase($"SameAssigneeTests_{Guid.NewGuid()}")
+            .Options;
+        dbContext = new WorkflowDbContext(options);
+        var logger = Substitute.For<ILogger<SameAssigneeAsActivitySelector>>();
+        return new SameAssigneeAsActivitySelector(dbContext, logger);
+    }
+
+    [Fact]
+    public async Task SelectAssigneeAsync_MissingProperty_ReturnsFailure()
+    {
+        var selector = CreateSelector(out _);
+        var context = new AssignmentContext
+        {
+            WorkflowInstanceId = Guid.NewGuid(),
+            ActivityName = "appraisal-book-verification"
+        };
+
+        var result = await selector.SelectAssigneeAsync(context);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("sameAssigneeAsActivity");
+    }
+
+    [Fact]
+    public async Task SelectAssigneeAsync_EmptyWorkflowInstanceId_ReturnsFailure()
+    {
+        var selector = CreateSelector(out _);
+        var context = new AssignmentContext
+        {
+            WorkflowInstanceId = Guid.Empty,
+            ActivityName = "appraisal-book-verification",
+            Properties = new Dictionary<string, object> { ["sameAssigneeAsActivity"] = "int-pma-input" }
+        };
+
+        var result = await selector.SelectAssigneeAsync(context);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("WorkflowInstanceId");
+    }
+
+    [Fact]
+    public async Task SelectAssigneeAsync_NoCompletedSourceExecution_ReturnsFailure()
+    {
+        var selector = CreateSelector(out _);
+        var context = new AssignmentContext
+        {
+            WorkflowInstanceId = Guid.NewGuid(),
+            ActivityName = "appraisal-book-verification",
+            Properties = new Dictionary<string, object> { ["sameAssigneeAsActivity"] = "int-pma-input" }
+        };
+
+        var result = await selector.SelectAssigneeAsync(context);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("No completed assignee");
+    }
+
+    [Fact]
+    public async Task SelectAssigneeAsync_SourceActivityCompleted_ReturnsSameAssignee()
+    {
+        // Arrange — seed a completed PMA input execution assigned to th.pma1
+        var selector = CreateSelector(out var dbContext);
+        var workflowInstanceId = Guid.NewGuid();
+
+        var pmaInput = WorkflowActivityExecution.Create(
+            workflowInstanceId, "int-pma-input", "PMA Property Input", "TaskActivity", "th.pma1",
+            new Dictionary<string, object>());
+        pmaInput.Complete("th.pma1", new Dictionary<string, object>(), "Done");
+
+        dbContext.WorkflowActivityExecutions.Add(pmaInput);
+        await dbContext.SaveChangesAsync();
+
+        var context = new AssignmentContext
+        {
+            WorkflowInstanceId = workflowInstanceId,
+            ActivityName = "appraisal-book-verification",
+            Properties = new Dictionary<string, object> { ["sameAssigneeAsActivity"] = "int-pma-input" }
+        };
+
+        // Act
+        var result = await selector.SelectAssigneeAsync(context);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.AssigneeId.Should().Be("th.pma1");
+        result.Metadata.Should().ContainKey("SourceActivity");
+    }
+}


### PR DESCRIPTION
## Summary
Implements a new assignee selection strategy that assigns tasks to the same user who was assigned a different, named prior activity within the same workflow instance. This serves as the positive counterpart to the existing `excludeAssigneesFrom` rule.

## Key Changes
- **New Strategy Implementation**: Added `SameAssigneeAsActivitySelector` class that queries completed workflow activity executions to find and assign the same user from a source activity
- **Strategy Registration**: 
  - Added `SameAssigneeAsActivity` enum value to `AssigneeSelectionStrategy`
  - Registered string mappings (`same_assignee_as_activity`) for serialization/deserialization
  - Registered selector in `AssigneeSelectorFactory` and `WorkflowModule` dependency injection
- **Configuration**: Updated appraisal workflow configuration to include the new strategy in initial assignment strategies
- **Comprehensive Tests**: Added full test suite covering:
  - Missing property validation
  - Invalid workflow instance ID handling
  - No completed source activity scenarios
  - Successful assignee resolution from prior activity

## Implementation Details
- The selector reads the source activity ID from `Properties["sameAssigneeAsActivity"]`
- Queries `WorkflowActivityExecutions` for completed executions matching the source activity in the same workflow instance
- Filters out system assignments and empty assignees
- Returns the most recent assignee if multiple completions exist
- Fails gracefully (soft failure) when property is missing or source activity has no completed execution, allowing the cascade to fall through to other strategies
- Includes comprehensive logging for debugging and audit trails
- Handles JSON element property values in addition to string values

https://claude.ai/code/session_01VP5LN8YVPoWJc46dGdji6u