### PR TITLE
feat(workflow): let the secretary recall a released meeting item

### DIFF
--- a/Modules/Workflow/Workflow/Data/Configurations/ApprovalVoteConfiguration.cs
+++ b/Modules/Workflow/Workflow/Data/Configurations/ApprovalVoteConfiguration.cs
@@ -17,7 +17,8 @@ public class ApprovalVoteConfiguration : IEntityTypeConfiguration<ApprovalVote>
         builder.Property(v => v.Member).HasMaxLength(255).IsRequired();
         builder.Property(v => v.MemberRole).HasMaxLength(50);
         builder.Property(v => v.Vote).HasMaxLength(50).IsRequired();
-        builder.Property(v => v.Comments).HasMaxLength(1000);
+        // Matches the 4000-char comment/remark limit on PendingTask/CompletedTask.
+        builder.Property(v => v.Comments).HasMaxLength(4000);
 
         builder.HasIndex(v => new { v.ActivityExecutionId, v.Member }).IsUnique();
         builder.HasIndex(v => v.ActivityExecutionId);

--- a/Modules/Workflow/Workflow/Data/Configurations/WorkflowActivityExecutionConfiguration.cs
+++ b/Modules/Workflow/Workflow/Data/Configurations/WorkflowActivityExecutionConfiguration.cs
@@ -52,7 +52,7 @@ public class WorkflowActivityExecutionConfiguration : IEntityTypeConfiguration<W
             .HasMaxLength(2000);
 
         builder.Property(x => x.Comments)
-            .HasMaxLength(1000);
+            .HasMaxLength(4000);
 
         builder.Property(x => x.Movement)
             .IsRequired()

--- a/Modules/Workflow/Workflow/Data/Repository/ApprovalVoteRepository.cs
+++ b/Modules/Workflow/Workflow/Data/Repository/ApprovalVoteRepository.cs
@@ -20,6 +20,12 @@ public class ApprovalVoteRepository(WorkflowDbContext dbContext) : IApprovalVote
                 && v.Member == member, ct);
     }
 
+    public async Task<bool> HasAnyVoteAsync(Guid activityExecutionId, CancellationToken ct = default)
+    {
+        return await dbContext.ApprovalVotes
+            .AnyAsync(v => v.ActivityExecutionId == activityExecutionId, ct);
+    }
+
     public async Task AddVoteAsync(ApprovalVote vote, CancellationToken ct = default)
     {
         dbContext.ApprovalVotes.Add(vote);

--- a/Modules/Workflow/Workflow/Data/Repository/IApprovalVoteRepository.cs
+++ b/Modules/Workflow/Workflow/Data/Repository/IApprovalVoteRepository.cs
@@ -6,6 +6,7 @@ public interface IApprovalVoteRepository
 {
     Task<List<ApprovalVote>> GetVotesForExecutionAsync(Guid activityExecutionId, CancellationToken ct = default);
     Task<bool> HasMemberVotedAsync(Guid activityExecutionId, string member, CancellationToken ct = default);
+    Task<bool> HasAnyVoteAsync(Guid activityExecutionId, CancellationToken ct = default);
     Task AddVoteAsync(ApprovalVote vote, CancellationToken ct = default);
     Task<List<ApprovalVote>> GetLatestRoundVotesByAppraisalAsync(Guid appraisalId, string activityId, CancellationToken ct = default);
 }

--- a/Modules/Workflow/Workflow/Infrastructure/Migrations/20260722151742_ExtendVoteAndExecutionCommentsTo4000.Designer.cs
+++ b/Modules/Workflow/Workflow/Infrastructure/Migrations/20260722151742_ExtendVoteAndExecutionCommentsTo4000.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Workflow.Data;
 
@@ -11,9 +12,11 @@ using Workflow.Data;
 namespace Workflow.Infrastructure.Migrations
 {
     [DbContext(typeof(WorkflowDbContext))]
-    partial class WorkflowDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260722151742_ExtendVoteAndExecutionCommentsTo4000")]
+    partial class ExtendVoteAndExecutionCommentsTo4000
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modules/Workflow/Workflow/Infrastructure/Migrations/20260722151742_ExtendVoteAndExecutionCommentsTo4000.cs
+++ b/Modules/Workflow/Workflow/Infrastructure/Migrations/20260722151742_ExtendVoteAndExecutionCommentsTo4000.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Workflow.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExtendVoteAndExecutionCommentsTo4000 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Comments",
+                schema: "workflow",
+                table: "WorkflowActivityExecutions",
+                type: "nvarchar(4000)",
+                maxLength: 4000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1000)",
+                oldMaxLength: 1000,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Comments",
+                schema: "workflow",
+                table: "ApprovalVotes",
+                type: "nvarchar(4000)",
+                maxLength: 4000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1000)",
+                oldMaxLength: 1000,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Comments",
+                schema: "workflow",
+                table: "WorkflowActivityExecutions",
+                type: "nvarchar(1000)",
+                maxLength: 1000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(4000)",
+                oldMaxLength: 4000,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Comments",
+                schema: "workflow",
+                table: "ApprovalVotes",
+                type: "nvarchar(1000)",
+                maxLength: 1000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(4000)",
+                oldMaxLength: 4000,
+                oldNullable: true);
+        }
+    }
+}

--- a/Modules/Workflow/Workflow/Meetings/Activities/MeetingActivity.cs
+++ b/Modules/Workflow/Workflow/Meetings/Activities/MeetingActivity.cs
@@ -50,33 +50,59 @@ public class MeetingActivity : WorkflowActivityBase
             var appraisalValue = GetVariable<decimal>(context, "appraisalValue");
             var appraisalNo = GetVariable<string?>(context, "appraisalNumber");
 
-            // Re-entry path: if this appraisal+workflowInstance already has a RoutedBack item
-            // on a meeting, reinstate it on that same meeting instead of enqueueing a new one.
-            var routedBackItem = await _dbContext.MeetingItems
-                .FirstOrDefaultAsync(mi =>
+            // Re-entry path: if this appraisal+workflowInstance already has a non-Released Decision
+            // item on a still-live meeting — RoutedBack (rework) or Pending (a secretary recall) —
+            // re-enter that same meeting instead of enqueueing a new queue row. Excludes Cancelled
+            // meetings: Meeting.Cancel() does not remove its items, so a stale Pending/RoutedBack row
+            // left behind by a cancel-and-reschedule must not win over the live meeting's row.
+            // OrderByDescending(AddedAt) makes the pick deterministic if more than one such row
+            // somehow exists.
+            //
+            // This predicate depends on the workflow engine having already flushed the Meeting
+            // aggregate's reset (Released → Pending on recall, or the RoutedBack reinstate) to the
+            // database before this activity runs. The engine checkpoints (persists) workflow state
+            // after every activity completes and before the next one executes, so by the time
+            // MeetingActivity re-enters here that write has already landed — this predicate would
+            // otherwise see stale data.
+            var existingItem = await _dbContext.MeetingItems
+                .Where(mi =>
                     mi.AppraisalId == appraisalId &&
                     mi.WorkflowInstanceId == context.WorkflowInstanceId &&
                     mi.Kind == MeetingItemKind.Decision &&
-                    mi.ItemDecision == ItemDecision.RoutedBack, cancellationToken);
+                    mi.ItemDecision != ItemDecision.Released &&
+                    _dbContext.Meetings.Any(m => m.Id == mi.MeetingId && m.Status != MeetingStatus.Cancelled))
+                .OrderByDescending(mi => mi.AddedAt)
+                .FirstOrDefaultAsync(cancellationToken);
 
-            if (routedBackItem is not null)
+            if (existingItem is not null)
             {
                 var meeting = await _dbContext.Meetings
                     .Include(m => m.Items)
-                    .FirstOrDefaultAsync(m => m.Id == routedBackItem.MeetingId, cancellationToken)
+                    .FirstOrDefaultAsync(m => m.Id == existingItem.MeetingId, cancellationToken)
                     ?? throw new InvalidOperationException(
-                        $"Meeting {routedBackItem.MeetingId} not found for routed-back item {routedBackItem.Id}");
+                        $"Meeting {existingItem.MeetingId} not found for existing item {existingItem.Id}");
 
-                meeting.ReinstateRoutedBackItem(appraisalId, _dateTimeProvider.ApplicationNow);
+                if (existingItem.ItemDecision == ItemDecision.RoutedBack)
+                {
+                    meeting.ReinstateRoutedBackItem(appraisalId, _dateTimeProvider.ApplicationNow);
 
-                _logger.LogInformation(
-                    "MeetingActivity {ActivityId} reinstated appraisal {AppraisalId} on meeting {MeetingId} after rework",
-                    context.ActivityId, appraisalId, meeting.Id);
+                    _logger.LogInformation(
+                        "MeetingActivity {ActivityId} reinstated appraisal {AppraisalId} on meeting {MeetingId} after rework",
+                        context.ActivityId, appraisalId, meeting.Id);
+                }
+                else
+                {
+                    // Pending: the recall command already reset the item back to Pending on the
+                    // Meeting aggregate — nothing further to do here.
+                    _logger.LogInformation(
+                        "MeetingActivity {ActivityId} re-entered for appraisal {AppraisalId} on meeting {MeetingId} after a recall",
+                        context.ActivityId, appraisalId, meeting.Id);
+                }
 
                 return ActivityResult.Pending(new Dictionary<string, object>
                 {
                     [$"{NormalizeActivityId(context.ActivityId)}_awaitingMeeting"] = true,
-                    [$"{NormalizeActivityId(context.ActivityId)}_reinstatedOnMeetingId"] = meeting.Id
+                    [$"{NormalizeActivityId(context.ActivityId)}_reenteredOnMeetingId"] = meeting.Id
                 });
             }
 

--- a/Modules/Workflow/Workflow/Meetings/Domain/Meeting.cs
+++ b/Modules/Workflow/Workflow/Meetings/Domain/Meeting.cs
@@ -513,15 +513,120 @@ public class Meeting : Aggregate<Guid>
             Id, appraisalId, item.WorkflowInstanceId.Value, item.ActivityId, reason, actor));
     }
 
+    /// <summary>
+    /// Secretary undoes an accidental release, putting the item back on this meeting as
+    /// <see cref="ItemDecision.Pending"/> before any committee member has voted.
+    /// Deliberately does not use <see cref="EnsureDecisionAllowed"/>: a release commonly
+    /// auto-ends the meeting, so recall must also be allowed from <see cref="MeetingStatus.Ended"/>.
+    /// Reopens an Ended meeting to <see cref="MeetingStatus.InvitationSent"/> (or
+    /// <see cref="MeetingStatus.RoutedBack"/> if another item on it is still routed back).
+    /// </summary>
+    public void UndoRelease(Guid appraisalId, string actor, string reason, DateTime now)
+    {
+        if (Status != MeetingStatus.InvitationSent && Status != MeetingStatus.RoutedBack && Status != MeetingStatus.Ended)
+            throw new InvalidOperationException(
+                $"Cannot recall an item on a meeting in status {Status}");
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(actor);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+
+        var item = GetDecisionItemOrThrow(appraisalId);
+
+        if (item.ItemDecision != ItemDecision.Released)
+            throw new InvalidOperationException(
+                $"Cannot recall item for appraisal {appraisalId}: decision is {item.ItemDecision}, expected Released");
+
+        item.ApplyDecision(ItemDecision.Pending, actor, reason, now);
+
+        // Decision items always have WorkflowInstanceId/ActivityId set — guard defensively.
+        if (!item.WorkflowInstanceId.HasValue || item.ActivityId is null)
+            throw new InvalidOperationException(
+                $"Decision item for appraisal {appraisalId} is missing WorkflowInstanceId or ActivityId");
+
+        // Reopen the meeting if the release had auto-ended it.
+        if (Status == MeetingStatus.Ended)
+        {
+            EndedAt = null;
+            Status = _items.Any(i => i.Kind == MeetingItemKind.Decision && i.ItemDecision == ItemDecision.RoutedBack)
+                ? MeetingStatus.RoutedBack
+                : MeetingStatus.InvitationSent;
+        }
+
+        // No domain event is raised here: the RecallMeetingItem command handler flushes this
+        // reset and then resumes the workflow inline. A domain-event-driven resume would run
+        // during SaveChanges — before the reset is flushed — and the recall gate in
+        // ApprovalActivity (a persisted-state query) would not see the Pending item.
+    }
+
+    // -------------------------------------------------------------------------
+    // Approver-driven route back
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Records that a COMMITTEE APPROVER voted route_back on an already-released item, as opposed
+    /// to the secretary routing it back from the meeting screen (<see cref="RouteBackItem"/>).
+    ///
+    /// Without this, the item stays <see cref="ItemDecision.Released"/> forever: the approval
+    /// activity drives the workflow backward on its own and never tells this aggregate. That
+    /// leaves the meeting's status stale, and — because
+    /// <see cref="Meetings.Activities.MeetingActivity"/> only re-enters items whose decision is
+    /// NOT Released — the reworked appraisal gets enqueued onto a different meeting instead of
+    /// returning to this one.
+    ///
+    /// Deliberately differs from <see cref="RouteBackItem"/> in three ways:
+    /// <list type="bullet">
+    /// <item>No <see cref="EnsureDecisionAllowed"/>: releasing the last item auto-ends the
+    /// meeting, so an approver's route-back almost always arrives while Ended. Reopening mirrors
+    /// <see cref="UndoRelease"/>.</item>
+    /// <item>Expects <see cref="ItemDecision.Released"/>, not Pending.</item>
+    /// <item>Raises NO domain event. <see cref="MeetingItemRoutedBackDomainEvent"/> resumes the
+    /// workflow, which is already moving itself here — publishing it would drive it twice.</item>
+    /// </list>
+    /// </summary>
+    public void RecordApproverRouteBack(Guid appraisalId, string actor, string? reason, DateTime now)
+    {
+        if (Status == MeetingStatus.Cancelled)
+            throw new InvalidOperationException(
+                "Cannot record an approver route-back on a cancelled meeting");
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(actor);
+
+        var item = GetDecisionItemOrThrow(appraisalId);
+
+        if (item.Kind != MeetingItemKind.Decision)
+            throw new InvalidOperationException(
+                $"Appraisal {appraisalId} is not a Decision item on this meeting");
+
+        if (item.ItemDecision != ItemDecision.Released)
+            throw new InvalidOperationException(
+                $"Cannot record an approver route-back for appraisal {appraisalId}: " +
+                $"decision is {item.ItemDecision}, expected Released");
+
+        item.ApplyDecision(ItemDecision.RoutedBack, actor, reason, now);
+
+        // Reopen an auto-ended meeting — it has unfinished business again.
+        if (Status == MeetingStatus.Ended) EndedAt = null;
+        Status = MeetingStatus.RoutedBack;
+    }
+
     // -------------------------------------------------------------------------
     // Reinstate
     // -------------------------------------------------------------------------
 
     /// <summary>
     /// Re-enters a routed-back appraisal onto this same meeting by resetting its item's
-    /// decision back to <see cref="ItemDecision.Pending"/>. The meeting remains in
-    /// <see cref="MeetingStatus.RoutedBack"/> — it can only leave that status once every
-    /// Decision item is Released (the existing <see cref="ReleaseItem"/> auto-end rule).
+    /// decision back to <see cref="ItemDecision.Pending"/>.
+    ///
+    /// When this was the LAST routed-back item, the meeting returns to
+    /// <see cref="MeetingStatus.InvitationSent"/> — <see cref="MeetingStatus.RoutedBack"/> means
+    /// "something is currently routed back", so once nothing is, the status is stale. If other
+    /// items are still routed back the meeting stays in <see cref="MeetingStatus.RoutedBack"/>.
+    ///
+    /// <see cref="MeetingStatus.InvitationSent"/> is the correct target because a route-back is
+    /// only reachable from <see cref="MeetingStatus.InvitationSent"/> or
+    /// <see cref="MeetingStatus.RoutedBack"/> (see <see cref="EnsureDecisionAllowed"/>), so the
+    /// invitation has necessarily gone out. Read models re-derive the effective
+    /// <c>InProgress</c> from InvitationSent + StartAt, so a live meeting still reads as live.
     /// </summary>
     /// <remarks>
     /// This is the only valid re-entry path. The <see cref="Meetings.Activities.MeetingActivity"/>
@@ -536,6 +641,13 @@ public class Meeting : Aggregate<Guid>
 
         var item = GetDecisionItemOrThrow(appraisalId);
         item.Reinstate(now);
+
+        // Same recomputation UndoRelease performs when a recall reopens an Ended meeting.
+        if (!_items.Any(i => i.Kind == MeetingItemKind.Decision
+                             && i.ItemDecision == ItemDecision.RoutedBack))
+        {
+            Status = MeetingStatus.InvitationSent;
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/Modules/Workflow/Workflow/Meetings/Domain/MeetingOutcomes.cs
+++ b/Modules/Workflow/Workflow/Meetings/Domain/MeetingOutcomes.cs
@@ -14,4 +14,7 @@ public static class MeetingOutcomes
 
     /// <summary>Meeting was cancelled; workflow stays paused until reassigned.</summary>
     public const string Cancelled = "cancelled";
+
+    /// <summary>Secretary recalled a released item back onto the meeting before any approver voted.</summary>
+    public const string Recalled = "recall_to_meeting";
 }

--- a/Modules/Workflow/Workflow/Meetings/Features/GetMeetingDetail/GetMeetingDetailEndpoint.cs
+++ b/Modules/Workflow/Workflow/Meetings/Features/GetMeetingDetail/GetMeetingDetailEndpoint.cs
@@ -44,7 +44,11 @@ public record MeetingDto(
     string? ToText,
     string? AgendaCertifyMinutes,
     string? AgendaChairmanInformed,
-    string? AgendaOthers);
+    string? AgendaOthers,
+    DateTime? CreatedAt,
+    string? CreatedBy,
+    DateTime? UpdatedAt,
+    string? UpdatedBy);
 
 public record MeetingDetailDto(
     Guid Id,
@@ -65,6 +69,10 @@ public record MeetingDetailDto(
     string? AgendaCertifyMinutes,
     string? AgendaChairmanInformed,
     string? AgendaOthers,
+    DateTime? CreatedAt,
+    string? CreatedBy,
+    DateTime? UpdatedAt,
+    string? UpdatedBy,
     string? PreviousEndedMeetingNo,
     List<MeetingMemberDto> Members,
     MeetingItemsGroupedDto Items);
@@ -94,7 +102,35 @@ public record MeetingItemDto(
     DateTime AddedAt,
     string CustomerName,
     string AppraisalStaff,
-    decimal? AppraisedValue);
+    decimal? AppraisedValue)
+{
+    /// <summary>
+    /// Individual approver votes for this appraisal's CURRENT approval round only, oldest first.
+    ///
+    /// A recall does not delete votes — it completes the approval round and leaves its rows in
+    /// <c>workflow.ApprovalVotes</c> — and the same member may vote again in the next round (the
+    /// unique index is on <c>(ActivityExecutionId, Member)</c>). Returning votes across rounds
+    /// would therefore list the same person twice, so this is scoped to the newest
+    /// <c>pending-approval</c> execution and suppressed unless the item is currently Released.
+    ///
+    /// Empty for items that are Pending or RoutedBack, for Acknowledgement items (no workflow
+    /// gate), and for a re-released item nobody has voted on yet.
+    ///
+    /// Returned per voter rather than aggregated so the UI can name who voted and, by
+    /// subtracting from the meeting roster, who still owes a vote.
+    /// </summary>
+    public List<ItemVoteDto> Votes { get; init; } = [];
+
+    /// <summary>Timestamp of the most recent approver vote, or null when none has been cast.</summary>
+    public DateTime? LastVotedAt { get; init; }
+}
+
+/// <summary>
+/// One approver's vote. <paramref name="Member"/> is the username, matching
+/// <c>MeetingMemberDto.UserId</c> so the UI can resolve it to a display name.
+/// <paramref name="Vote"/> is workflow-config driven (<c>voteOptions</c>), not a fixed enum.
+/// </summary>
+public record ItemVoteDto(string Member, string? MemberRole, string Vote, DateTime VotedAt);
 
 /// <summary>Stable grouped shape with typed arrays — TypeScript-friendly, no dynamic dictionary keys.</summary>
 public record MeetingItemGroupDto(string Group, List<MeetingItemDto> Items);
@@ -107,11 +143,20 @@ public record MeetingItemsGroupedDto(
     List<MeetingItemGroupDto> DecisionItems,
     List<MeetingItemGroupDto> AcknowledgementItems);
 
+/// <summary>Raw vote row read from SQL before being folded into <see cref="MeetingItemDto"/>.</summary>
+internal record VoteRow(Guid AppraisalId, string Member, string? MemberRole, string Vote, DateTime VotedAt);
+
 public class GetMeetingDetailQueryHandler(
     ISqlConnectionFactory sqlConnectionFactory,
     IDateTimeProvider dateTimeProvider)
     : IQueryHandler<GetMeetingDetailQuery, MeetingDetailDto>
 {
+    /// <summary>
+    /// The workflow activity that runs a committee approval round. Same identifier the recall
+    /// guard (<c>RecallMeetingItemEndpoint</c>) and <c>GetApprovalHistoryQuery</c> use.
+    /// </summary>
+    private const string ApprovalActivityId = "pending-approval";
+
     public async Task<MeetingDetailDto> Handle(GetMeetingDetailQuery query, CancellationToken cancellationToken)
     {
         var sql = """
@@ -119,7 +164,8 @@ public class GetMeetingDetailQueryHandler(
                                Id, Title, Status, MeetingNo, StartAt, EndAt,
                                Location, Notes, CancelReason, EndedAt, CancelledAt, CutOffAt,
                                InvitationSentAt, FromText, ToText,
-                               AgendaCertifyMinutes, AgendaChairmanInformed, AgendaOthers
+                               AgendaCertifyMinutes, AgendaChairmanInformed, AgendaOthers,
+                               CreatedAt, CreatedBy, UpdatedAt, UpdatedBy
                            FROM workflow.[Meetings] m WHERE m.[Id] = @Id
 
                            SELECT
@@ -130,7 +176,8 @@ public class GetMeetingDetailQueryHandler(
                                m.Id, a.Id AS AppraisalId, a.AppraisalNumber, a.FacilityLimit, WorkflowInstanceId,
                                ActivityId, Kind, a.AppraisalType, AcknowledgementGroup,
                                ItemDecision, DecisionAt, DecisionBy, DecisionReason, AddedAt,
-                               c.Name AS CustomerName, u.FirstName + ' ' + u.LastName AS AppraisalStaff, v.AppraisedValue
+                               c.Name AS CustomerName, u.FirstName + ' ' + u.LastName AS AppraisalStaff,
+                               v.AppraisedValue
                            FROM workflow.MeetingItems m
                                INNER JOIN appraisal.Appraisals a ON a.Id = m.AppraisalId
                                CROSS APPLY (SELECT TOP 1 Name
@@ -144,10 +191,31 @@ public class GetMeetingDetailQueryHandler(
                                LEFT JOIN appraisal.ValuationAnalyses v ON v.AppraisalId = a.Id
                                WHERE MeetingId = @Id
 
-                           """ + "\n\n" + PreviousMeetingNoQuery.Sql("Id");
+                           """ + "\n\n" + PreviousMeetingNoQuery.Sql("Id") + "\n\n" + """
+
+                           -- Votes are scoped to the CURRENT approval round. A recall completes the round
+                           -- but leaves its votes behind, and the same member may vote again next round
+                           -- (unique index is on (ActivityExecutionId, Member)) — so joining on appraisal
+                           -- alone double-counts people. Ordering by StartedOn (Id only as a deterministic
+                           -- tiebreaker) rather than by latest vote is deliberate: a re-released item that
+                           -- nobody has voted on yet must report nothing, not fall back to the dead round.
+                           SELECT mi.AppraisalId, v.Member, v.MemberRole, v.Vote, v.VotedAt
+                           FROM workflow.MeetingItems mi
+                               CROSS APPLY (SELECT TOP 1 ae.Id
+                                            FROM workflow.WorkflowActivityExecutions ae
+                                            WHERE ae.WorkflowInstanceId = mi.WorkflowInstanceId
+                                              AND ae.ActivityId = @ApprovalActivityId
+                                            ORDER BY ae.StartedOn DESC, ae.Id DESC) latest
+                               INNER JOIN workflow.ApprovalVotes v
+                                   ON v.ActivityExecutionId = latest.Id
+                                   AND v.AppraisalId = mi.AppraisalId
+                           WHERE mi.MeetingId = @Id
+                             AND mi.ItemDecision = 'Released'
+                           ORDER BY v.VotedAt
+                           """;
 
         var connection = sqlConnectionFactory.GetOpenConnection();
-        await using var multi = await connection.QueryMultipleAsync(sql, new { query.Id });
+        await using var multi = await connection.QueryMultipleAsync(sql, new { query.Id, ApprovalActivityId });
 
         var meeting = await multi.ReadSingleAsync<MeetingDto>();
 
@@ -156,6 +224,36 @@ public class GetMeetingDetailQueryHandler(
         var allItems = (await multi.ReadAsync<MeetingItemDto>()).ToList();
 
         var previousEndedMeetingNo = await multi.ReadFirstOrDefaultAsync<string?>();
+
+        var voteRows = (await multi.ReadAsync<VoteRow>()).ToList();
+
+        // Attach the approver votes to each item. Items with no votes keep the empty default,
+        // so the UI can distinguish "not yet released" from "released, nobody voted".
+        if (voteRows.Count > 0)
+        {
+            var votesByAppraisal = voteRows
+                .GroupBy(v => v.AppraisalId)
+                .ToDictionary(
+                    g => g.Key,
+                    g => (
+                        Votes: g
+                            .OrderBy(v => v.VotedAt)
+                            .Select(v => new ItemVoteDto(v.Member, v.MemberRole, v.Vote, v.VotedAt))
+                            .ToList(),
+                        LastVotedAt: (DateTime?)g.Max(v => v.VotedAt)));
+
+            for (var i = 0; i < allItems.Count; i++)
+            {
+                if (!votesByAppraisal.TryGetValue(allItems[i].AppraisalId, out var voted))
+                    continue;
+
+                allItems[i] = allItems[i] with
+                {
+                    Votes = voted.Votes,
+                    LastVotedAt = voted.LastVotedAt
+                };
+            }
+        }
 
         // Decision items: one group per AppraisalType, known types first then any others.
         var decisionItemsList = allItems
@@ -205,6 +303,10 @@ public class GetMeetingDetailQueryHandler(
             meeting.AgendaCertifyMinutes,
             meeting.AgendaChairmanInformed,
             meeting.AgendaOthers,
+            meeting.CreatedAt,
+            meeting.CreatedBy,
+            meeting.UpdatedAt,
+            meeting.UpdatedBy,
             previousEndedMeetingNo,
             members,
             grouped);

--- a/Modules/Workflow/Workflow/Meetings/Features/RecallMeetingItem/RecallMeetingItemEndpoint.cs
+++ b/Modules/Workflow/Workflow/Meetings/Features/RecallMeetingItem/RecallMeetingItemEndpoint.cs
@@ -1,0 +1,164 @@
+using FluentValidation;
+using Shared.Identity;
+using Workflow.Meetings.Domain;
+using Workflow.Meetings.ReadModels;
+using Workflow.Workflow.Repositories;
+using Workflow.Workflow.Services;
+
+namespace Workflow.Meetings.Features.RecallMeetingItem;
+
+public class RecallMeetingItemEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/meetings/{id:guid}/items/{appraisalId:guid}/recall", async (
+                Guid id,
+                Guid appraisalId,
+                RecallMeetingItemRequest request,
+                ISender sender,
+                CancellationToken ct) =>
+            {
+                await sender.Send(new RecallMeetingItemCommand(id, appraisalId, request.Reason, request.Force), ct);
+                return Results.NoContent();
+            })
+            .WithName("RecallMeetingItem")
+            .WithTags("Meetings")
+            .RequireAuthorization("MeetingSecretary")
+            .Produces(StatusCodes.Status204NoContent);
+    }
+}
+
+public record RecallMeetingItemRequest(string Reason, bool Force = false);
+
+public record RecallMeetingItemCommand(Guid MeetingId, Guid AppraisalId, string Reason, bool Force)
+    : ICommand, ITransactionalCommand<IWorkflowUnitOfWork>;
+
+public class RecallMeetingItemCommandValidator : AbstractValidator<RecallMeetingItemCommand>
+{
+    public RecallMeetingItemCommandValidator()
+    {
+        RuleFor(x => x.Reason)
+            .NotEmpty().WithMessage("Reason is required.")
+            .MaximumLength(500).WithMessage("Reason must not exceed 500 characters.");
+    }
+}
+
+public class RecallMeetingItemCommandHandler(
+    IMeetingRepository meetingRepository,
+    WorkflowDbContext dbContext,
+    IWorkflowActivityExecutionRepository activityExecutionRepository,
+    IWorkflowPersistenceService workflowPersistenceService,
+    IApprovalVoteRepository voteRepository,
+    IWorkflowService workflowService,
+    ICurrentUserService currentUserService,
+    IDateTimeProvider dateTimeProvider,
+    ILogger<RecallMeetingItemCommandHandler> logger)
+    : ICommandHandler<RecallMeetingItemCommand>
+{
+    public async Task<Unit> Handle(RecallMeetingItemCommand command, CancellationToken ct)
+    {
+        var actor = currentUserService.Username
+            ?? throw new InvalidOperationException("User is not authenticated");
+
+        var meeting = await meetingRepository.GetByIdForDecisionAsync(command.MeetingId, ct)
+            ?? throw new NotFoundException($"Meeting {command.MeetingId} not found");
+
+        var item = meeting.Items.FirstOrDefault(i =>
+                i.AppraisalId == command.AppraisalId && i.Kind == MeetingItemKind.Decision)
+            ?? throw new NotFoundException($"Appraisal {command.AppraisalId} is not on meeting {command.MeetingId}");
+
+        if (item.ItemDecision != ItemDecision.Released)
+            throw new ConflictException(
+                $"Appraisal {command.AppraisalId} is not a released decision item and cannot be recalled",
+                "RECALL_NOT_RELEASED");
+
+        var workflowInstanceId = item.WorkflowInstanceId!.Value;
+
+        // Serialize against a concurrent committee vote on the same approval round BEFORE reading
+        // vote state below — otherwise a vote committing in that window would be silently discarded
+        // once we reset the round. Same lock resource WorkflowService's approval-resume path
+        // acquires ($"wf-approval:{instanceId}"); held by this command's ambient transaction, so the
+        // later acquisition inside ResumeWorkflowAsync (when the recall event resumes the workflow)
+        // is a re-entrant no-op on the same connection/transaction.
+        var lockResult = await workflowPersistenceService.AcquireApplicationLockAsync(
+            $"wf-approval:{workflowInstanceId}", "Exclusive", 30000, ct);
+        if (lockResult < 0)
+            throw new ConflictException(
+                $"Approval for appraisal {command.AppraisalId} is busy (lock code {lockResult}); please retry.",
+                "RECALL_BUSY");
+
+        // The approval round must still be sitting on pending-approval — if it already
+        // resolved (approve/reject/route_back), the workflow has moved on and the release
+        // is no longer recallable.
+        var execution = await activityExecutionRepository.GetCurrentActivityForWorkflowAsync(
+            workflowInstanceId, ct);
+        if (execution is null || execution.ActivityId != "pending-approval")
+            throw new ConflictException(
+                $"Appraisal {command.AppraisalId} is no longer awaiting committee approval and cannot be recalled",
+                "RECALL_ALREADY_RESOLVED");
+
+        // NOTE: workflow instances are pinned to the WorkflowDefinitionVersion they started on,
+        // and a version predating the recall-to-meeting transition would match no transition on
+        // resume — which the engine treats as "workflow finished" (WorkflowEngine: null next
+        // activity => CompleteWorkflowAsync). There is deliberately no guard for that here:
+        // in-flight instances are migrated to a recall-capable version out of band before this
+        // feature is enabled.
+        //
+        // Blocked once any committee member has voted; the secretary can override with force
+        // (and a reason — already required by the validator) rather than a second permission.
+        var hasVotes = await voteRepository.HasAnyVoteAsync(execution.Id, ct);
+        if (hasVotes)
+        {
+            if (!command.Force)
+                throw new ConflictException(
+                    $"At least one committee member has already voted on appraisal {command.AppraisalId}; recall requires force",
+                    "RECALL_VOTES_EXIST");
+
+            // The only audit trail for discarding real approver votes — record who, what, and why.
+            logger.LogWarning(
+                "RecallMeetingItem: {Actor} force-recalled appraisal {AppraisalId} on meeting {MeetingId} " +
+                "despite existing votes. Reason: {Reason}",
+                actor, command.AppraisalId, command.MeetingId, command.Reason);
+        }
+
+        var queueItem = await dbContext.MeetingQueueItems
+            .FirstOrDefaultAsync(q =>
+                q.AppraisalId == command.AppraisalId &&
+                q.MeetingId == command.MeetingId &&
+                q.Status == MeetingQueueItemStatus.Released, ct);
+        if (queueItem is null)
+            logger.LogWarning(
+                "RecallMeetingItem: no Released MeetingQueueItem found for appraisal {AppraisalId} on meeting " +
+                "{MeetingId}; the queue view will diverge from the meeting until reconciled",
+                command.AppraisalId, command.MeetingId);
+        else
+            queueItem.Requeue();
+
+        meeting.UndoRelease(command.AppraisalId, actor, command.Reason, dateTimeProvider.ApplicationNow);
+
+        // Flush the Requeue + the item's Released -> Pending BEFORE resuming the workflow, so the
+        // recall gate in ApprovalActivity reads persisted state. This runs inside the command's
+        // ambient transaction; it is not a commit. The resume must be inline (not via a domain
+        // event) because DispatchDomainEventInterceptor dispatches events during SaveChanges,
+        // before the flush — an event-driven resume would therefore run pre-flush and the gate
+        // would still see the committed 'Released' row.
+        await dbContext.SaveChangesAsync(ct);
+
+        // Resume the parked pending-approval activity with the recall decision. The active-
+        // transaction branch of ResumeWorkflowAsync runs in-line and re-acquires the
+        // wf-approval lock re-entrantly on this same transaction.
+        await workflowService.ResumeWorkflowAsync(
+            workflowInstanceId,
+            activityId: "pending-approval",
+            completedBy: actor,
+            input: new Dictionary<string, object>
+            {
+                ["decisionTaken"] = MeetingOutcomes.Recalled,
+                ["completedBy"] = actor,
+                ["comments"] = command.Reason
+            },
+            cancellationToken: ct);
+
+        return Unit.Value;
+    }
+}

--- a/Modules/Workflow/Workflow/Meetings/ReadModels/MeetingQueueItem.cs
+++ b/Modules/Workflow/Workflow/Meetings/ReadModels/MeetingQueueItem.cs
@@ -75,4 +75,16 @@ public class MeetingQueueItem : Entity<Guid>
                 $"Cannot release queue item in status {Status}");
         Status = MeetingQueueItemStatus.Released;
     }
+
+    /// <summary>
+    /// Undoes a <see cref="Release"/>, putting the item back on the same meeting it was
+    /// released from. The inverse of <see cref="Release"/>; used by a secretary recall.
+    /// </summary>
+    public void Requeue()
+    {
+        if (Status != MeetingQueueItemStatus.Released)
+            throw new InvalidOperationException(
+                $"Cannot requeue queue item in status {Status}");
+        Status = MeetingQueueItemStatus.Assigned;
+    }
 }

--- a/Modules/Workflow/Workflow/Workflow/Activities/ApprovalActivity.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/ApprovalActivity.cs
@@ -5,6 +5,7 @@ using Shared.Messaging.Events;
 using Workflow.Data.Repository;
 using Workflow.Domain;
 using Workflow.Domain.Committees;
+using Workflow.Meetings.Domain;
 using Workflow.Workflow.Activities.Approval;
 using Workflow.Workflow.Activities.Core;
 using Workflow.Workflow.Engine.Expression;
@@ -22,6 +23,7 @@ public class ApprovalActivity : WorkflowActivityBase
     private readonly IPublisher _publisher;
     private readonly IIntegrationEventOutbox _outbox;
     private readonly ICommitteeRepository _committeeRepository;
+    private readonly WorkflowDbContext _dbContext;
     private readonly ExpressionEvaluator _expressionEvaluator;
     private readonly IDateTimeProvider _dateTimeProvider;
     private readonly ISlaCalculator _slaCalculator;
@@ -33,6 +35,7 @@ public class ApprovalActivity : WorkflowActivityBase
         IPublisher publisher,
         IIntegrationEventOutbox outbox,
         ICommitteeRepository committeeRepository,
+        WorkflowDbContext dbContext,
         IDateTimeProvider dateTimeProvider,
         ISlaCalculator slaCalculator,
         ILogger<ApprovalActivity> logger)
@@ -42,6 +45,7 @@ public class ApprovalActivity : WorkflowActivityBase
         _publisher = publisher;
         _outbox = outbox;
         _committeeRepository = committeeRepository;
+        _dbContext = dbContext;
         _dateTimeProvider = dateTimeProvider;
         _slaCalculator = slaCalculator;
         _expressionEvaluator = new ExpressionEvaluator();
@@ -237,6 +241,63 @@ public class ApprovalActivity : WorkflowActivityBase
 
             var comments = resumeInput.TryGetValue("comments", out var c) ? c?.ToString() : null;
 
+            // Recall short-circuit: the secretary undoing a release is a system action, not a
+            // member vote. Placed before the voteOptions/member checks below because the
+            // secretary is not a committee member and "recall_to_meeting" is not among the
+            // configured voteOptions for this activity.
+            //
+            // "recall_to_meeting" alone is just a string in the resume payload — nothing stops
+            // an arbitrary caller reaching this resume path (e.g. CompleteActivityEndpoint has
+            // no authorization) from forging it and closing the round with no vote guard. Only
+            // short-circuit when the state a genuine recall actually produces is present: the
+            // RecallMeetingItem command handler resets this instance's MeetingItem to Pending and
+            // FLUSHES it (explicit SaveChanges) before resuming pending-approval inline, so a real
+            // recall has a persisted Pending decision item by the time this query runs. A forged
+            // call ran no UndoRelease, so the committed row is still Released, this query is false,
+            // and "recall_to_meeting" falls through to the vote path where voteOptions rejects it.
+            if (vote.Equals(MeetingOutcomes.Recalled, StringComparison.OrdinalIgnoreCase))
+            {
+                // Cancelled meetings are excluded for the same reason MeetingActivity excludes
+                // them: Meeting.Cancel() leaves its items behind as Decision/Pending, so an
+                // appraisal that was ever cancel-and-rescheduled carries a stale Pending row for
+                // this same workflow instance. Without this filter that stale row satisfies the
+                // gate and a forged recall succeeds — which is the exact hole this check exists
+                // to close.
+                var recalledByAggregate = await _dbContext.MeetingItems.AnyAsync(mi =>
+                    mi.WorkflowInstanceId == context.WorkflowInstanceId &&
+                    mi.Kind == MeetingItemKind.Decision &&
+                    mi.ItemDecision == ItemDecision.Pending &&
+                    _dbContext.Meetings.Any(m => m.Id == mi.MeetingId && m.Status != MeetingStatus.Cancelled),
+                    cancellationToken);
+
+                if (recalledByAggregate)
+                {
+                    execution.StampMovement("B");
+
+                    // Tear down every per-member PendingTask fanned out for this round via the
+                    // existing ApprovalRoundClosedEventHandler. No ApprovalVote is written — a
+                    // recall never counted as a vote.
+                    await _publisher.Publish(new ApprovalRoundClosedEvent(
+                        context.WorkflowInstanceId, context.ActivityId,
+                        _dateTimeProvider.ApplicationNow, "Recalled"), cancellationToken);
+
+                    _logger.LogInformation(
+                        "ApprovalActivity {ActivityId}: recalled by {Actor} - round closed, returning to pending-meeting",
+                        context.ActivityId, voter);
+
+                    return ActivityResult.Success(new Dictionary<string, object>
+                    {
+                        ["decision"] = MeetingOutcomes.Recalled
+                    });
+                }
+
+                _logger.LogWarning(
+                    "ApprovalActivity {ActivityId}: received decisionTaken='recall_to_meeting' from {Voter} but " +
+                    "no Pending MeetingItem backs it - rejecting as an ordinary vote instead of recalling",
+                    context.ActivityId, voter);
+                // Falls through to the normal vote path below, which rejects it via voteOptions.
+            }
+
             // Get stored config from workflow variables
             var members = GetVariable<List<ApprovalMemberInfo>>(context, $"{normalizedId}_members",
                 new List<ApprovalMemberInfo>());
@@ -308,6 +369,23 @@ public class ApprovalActivity : WorkflowActivityBase
                 await _publisher.Publish(new ApprovalRoundClosedEvent(
                     context.WorkflowInstanceId, context.ActivityId, _dateTimeProvider.ApplicationNow,
                     "RouteBack"), cancellationToken);
+
+                // Mirror the route-back onto the meeting that released this appraisal.
+                //
+                // Without this the MeetingItem stays Released: the meeting's status goes stale,
+                // and because MeetingActivity only re-enters items whose decision is NOT Released,
+                // the reworked appraisal gets enqueued onto a DIFFERENT meeting instead of
+                // returning to the one that sent it back.
+                //
+                // The Meeting aggregate is mutated through the same DbContext MeetingActivity
+                // uses; the engine checkpoints workflow state after each activity, which flushes
+                // this alongside it.
+                if (rbAppraisalId is not null)
+                {
+                    await RecordRouteBackOnMeetingAsync(
+                        rbAppraisalId.Value, context.WorkflowInstanceId, voter, comments,
+                        context.ActivityId, cancellationToken);
+                }
 
                 _logger.LogInformation(
                     "ApprovalActivity {ActivityId}: {Voter} voted route_back - immediate return",
@@ -607,6 +685,73 @@ public class ApprovalActivity : WorkflowActivityBase
             return Task.FromResult(Core.ValidationResult.Failure("memberSource is required for ApprovalActivity"));
 
         return Task.FromResult(Core.ValidationResult.Success());
+    }
+
+    /// <summary>
+    /// Flips this appraisal's meeting item from Released to RoutedBack after a committee approver
+    /// voted route_back, and reopens the meeting if the release had auto-ended it.
+    ///
+    /// Best-effort by design: an appraisal can reach an approval activity without ever passing
+    /// through a meeting gate, so "no released meeting item" is a normal outcome, not an error.
+    /// Failures are logged rather than thrown — the approver's vote and the workflow's backward
+    /// transition are already committed, and failing the activity here would strand the workflow
+    /// for a bookkeeping problem.
+    /// </summary>
+    private async Task RecordRouteBackOnMeetingAsync(
+        Guid appraisalId,
+        Guid workflowInstanceId,
+        string voter,
+        string? comments,
+        string activityId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var meetingItem = await _dbContext.MeetingItems
+                .Where(mi => mi.AppraisalId == appraisalId
+                             && mi.WorkflowInstanceId == workflowInstanceId
+                             && mi.Kind == MeetingItemKind.Decision
+                             && mi.ItemDecision == ItemDecision.Released)
+                .OrderByDescending(mi => mi.AddedAt)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (meetingItem is null)
+            {
+                _logger.LogDebug(
+                    "ApprovalActivity {ActivityId}: no released meeting item for appraisal {AppraisalId}; " +
+                    "nothing to route back on the meeting side",
+                    activityId, appraisalId);
+                return;
+            }
+
+            var meeting = await _dbContext.Meetings
+                .Include(m => m.Items)
+                .FirstOrDefaultAsync(m => m.Id == meetingItem.MeetingId, cancellationToken);
+
+            if (meeting is null || meeting.Status == MeetingStatus.Cancelled)
+            {
+                _logger.LogWarning(
+                    "ApprovalActivity {ActivityId}: meeting {MeetingId} for appraisal {AppraisalId} is " +
+                    "missing or cancelled; skipping meeting-side route back",
+                    activityId, meetingItem.MeetingId, appraisalId);
+                return;
+            }
+
+            meeting.RecordApproverRouteBack(appraisalId, voter, comments, _dateTimeProvider.ApplicationNow);
+
+            _logger.LogInformation(
+                "ApprovalActivity {ActivityId}: approver {Voter} routed back appraisal {AppraisalId}; " +
+                "meeting {MeetingId} item set to RoutedBack and meeting status is now {Status}",
+                activityId, voter, appraisalId, meeting.Id, meeting.Status);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "ApprovalActivity {ActivityId}: failed to mirror approver route back onto the meeting " +
+                "for appraisal {AppraisalId}. The appraisal will re-queue onto a new meeting instead of " +
+                "returning to its original one.",
+                activityId, appraisalId);
+        }
     }
 
     protected override WorkflowActivityExecution CreateActivityExecution(ActivityContext context)

--- a/Modules/Workflow/Workflow/Workflow/Config/appraisal-workflow.json
+++ b/Modules/Workflow/Workflow/Workflow/Config/appraisal-workflow.json
@@ -1240,6 +1240,14 @@
         "condition": "decision == 'route_back' && assignmentType == 'Internal'",
         "properties": {},
         "type": "Conditional"
+      },
+      {
+        "id": "approval-recall-to-meeting",
+        "from": "pending-approval",
+        "to": "pending-meeting",
+        "condition": "decision == 'recall_to_meeting'",
+        "properties": {},
+        "type": "Conditional"
       }
     ],
     "variables": {

--- a/Shared/Shared/Exceptions/ConflictException.cs
+++ b/Shared/Shared/Exceptions/ConflictException.cs
@@ -2,6 +2,13 @@ namespace Shared.Exceptions;
 
 public class ConflictException : Exception
 {
+    /// <summary>
+    /// Optional machine-readable discriminator for callers that need to distinguish between
+    /// multiple 409 cases without matching on <see cref="Exception.Message"/>. Null for the
+    /// existing constructors so current call sites are unaffected.
+    /// </summary>
+    public string? Code { get; }
+
     public ConflictException(string message) : base(message)
     {
     }
@@ -9,5 +16,10 @@ public class ConflictException : Exception
     public ConflictException(string name, object key)
         : base($"{name} ({key}) already exists.")
     {
+    }
+
+    public ConflictException(string message, string code) : base(message)
+    {
+        Code = code;
     }
 }

--- a/Shared/Shared/Exceptions/Handler/CustomExceptionHandler.cs
+++ b/Shared/Shared/Exceptions/Handler/CustomExceptionHandler.cs
@@ -107,6 +107,9 @@ public class CustomExceptionHandler(ILogger<CustomExceptionHandler> logger) : IE
         if (exception is BulkUploadParseException bulkEx)
             problemDetails.Extensions.Add("rowErrors", bulkEx.RowErrors);
 
+        if (exception is ConflictException { Code: not null } conflictEx)
+            problemDetails.Extensions.Add("errorCode", conflictEx.Code);
+
         await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
         return true;
     }

--- a/Tests/Unit/Workflow.Tests/Meetings/MeetingTests.cs
+++ b/Tests/Unit/Workflow.Tests/Meetings/MeetingTests.cs
@@ -429,6 +429,97 @@ public class MeetingTests
     }
 
     [Fact]
+    public void RecordApproverRouteBack_OnAutoEndedMeeting_ReopensAsRoutedBack()
+    {
+        var meeting = BuildNewMeeting();
+        var id1 = Guid.NewGuid();
+        meeting.AddItem(id1, "APR-001", 500_000m, 500_000m, Guid.NewGuid(), "act-1", DateTime.UtcNow);
+        meeting.SendInvitation(DateTime.UtcNow.AddDays(-1));
+
+        // Releasing the only decision item auto-ends the meeting.
+        meeting.ReleaseItem(id1, "secretary", DateTime.UtcNow);
+        meeting.Status.Should().Be(MeetingStatus.Ended);
+
+        meeting.RecordApproverRouteBack(id1, "jane.smith", "needs rework", DateTime.UtcNow);
+
+        meeting.Status.Should().Be(MeetingStatus.RoutedBack);
+        meeting.EndedAt.Should().BeNull("the meeting has unfinished business again");
+
+        var item = meeting.Items.Single(i => i.AppraisalId == id1);
+        item.ItemDecision.Should().Be(ItemDecision.RoutedBack,
+            "MeetingActivity only re-enters items whose decision is NOT Released");
+        item.DecisionBy.Should().Be("jane.smith");
+    }
+
+    [Fact]
+    public void RecordApproverRouteBack_RaisesNoDomainEvent()
+    {
+        var meeting = BuildNewMeeting();
+        var id1 = Guid.NewGuid();
+        meeting.AddItem(id1, "APR-001", 500_000m, 500_000m, Guid.NewGuid(), "act-1", DateTime.UtcNow);
+        meeting.SendInvitation(DateTime.UtcNow.AddDays(-1));
+        meeting.ReleaseItem(id1, "secretary", DateTime.UtcNow);
+        meeting.ClearDomainEvents();
+
+        meeting.RecordApproverRouteBack(id1, "jane.smith", "needs rework", DateTime.UtcNow);
+
+        meeting.DomainEvents.Should().BeEmpty(
+            "the approval activity already drives the workflow backward; raising " +
+            "MeetingItemRoutedBackDomainEvent would resume it a second time");
+    }
+
+    [Fact]
+    public void RecordApproverRouteBack_WhenItemNotReleased_Throws()
+    {
+        var meeting = BuildNewMeeting();
+        var id1 = Guid.NewGuid();
+        meeting.AddItem(id1, "APR-001", 500_000m, 500_000m, Guid.NewGuid(), "act-1", DateTime.UtcNow);
+        meeting.SendInvitation(DateTime.UtcNow.AddDays(-1));
+
+        var act = () => meeting.RecordApproverRouteBack(id1, "jane.smith", "reason", DateTime.UtcNow);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*expected Released*");
+    }
+
+    [Fact]
+    public void ReinstateRoutedBackItem_WhenLastRoutedBackItem_ReturnsMeetingToInvitationSent()
+    {
+        var meeting = BuildNewMeeting();
+        var id1 = Guid.NewGuid();
+        meeting.AddItem(id1, "APR-001", 500_000m, 500_000m, Guid.NewGuid(), "act-1", DateTime.UtcNow);
+        meeting.SendInvitation(DateTime.UtcNow.AddDays(-1));
+
+        meeting.RouteBackItem(id1, "secretary", "reason1", DateTime.UtcNow);
+        meeting.Status.Should().Be(MeetingStatus.RoutedBack);
+
+        meeting.ReinstateRoutedBackItem(id1, DateTime.UtcNow);
+
+        meeting.Status.Should().Be(MeetingStatus.InvitationSent,
+            "RoutedBack means something is currently routed back; once nothing is, it is stale");
+        meeting.Items.Single(i => i.AppraisalId == id1).ItemDecision
+            .Should().Be(ItemDecision.Pending);
+    }
+
+    [Fact]
+    public void ReinstateRoutedBackItem_WhileAnotherItemStillRoutedBack_StaysRoutedBack()
+    {
+        var meeting = BuildNewMeeting();
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        meeting.AddItem(id1, "APR-001", 500_000m, 500_000m, Guid.NewGuid(), "act-1", DateTime.UtcNow);
+        meeting.AddItem(id2, "APR-002", 600_000m, 600_000m, Guid.NewGuid(), "act-2", DateTime.UtcNow);
+        meeting.SendInvitation(DateTime.UtcNow.AddDays(-1));
+
+        meeting.RouteBackItem(id1, "secretary", "reason1", DateTime.UtcNow);
+        meeting.RouteBackItem(id2, "secretary", "reason2", DateTime.UtcNow);
+
+        meeting.ReinstateRoutedBackItem(id1, DateTime.UtcNow);
+
+        meeting.Status.Should().Be(MeetingStatus.RoutedBack,
+            "id2 is still routed back");
+    }
+
+    [Fact]
     public void RouteBackItem_OnAcknowledgementItem_Throws()
     {
         var ackMeeting = BuildInvitationSentMeetingWithAckItem();

--- a/Tests/Unit/Workflow.Tests/Workflow/Activities/ApprovalActivityPublishTests.cs
+++ b/Tests/Unit/Workflow.Tests/Workflow/Activities/ApprovalActivityPublishTests.cs
@@ -1,10 +1,12 @@
 using FluentAssertions;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Shared.Data.Outbox;
 using Shared.Messaging.Events;
 using Shared.Time;
+using Workflow.Data;
 using Workflow.Data.Repository;
 using Workflow.Domain;
 using Workflow.Domain.Committees;
@@ -28,11 +30,15 @@ public class ApprovalActivityPublishTests
     private readonly IPublisher _publisher = Substitute.For<IPublisher>();
     private readonly IIntegrationEventOutbox _outbox = Substitute.For<IIntegrationEventOutbox>();
     private readonly ICommitteeRepository _committeeRepository = Substitute.For<ICommitteeRepository>();
+    private readonly WorkflowDbContext _dbContext = new(
+        new DbContextOptionsBuilder<WorkflowDbContext>()
+            .UseInMemoryDatabase($"approval-activity-publish-{Guid.NewGuid()}")
+            .Options);
     private readonly IDateTimeProvider _clock = Substitute.For<IDateTimeProvider>();
 
     private ApprovalActivity BuildActivity() =>
         new(_memberResolver, _voteRepository, _publisher, _outbox, _committeeRepository,
-            _clock, Substitute.For<global::Workflow.Sla.Services.ISlaCalculator>(),
+            _dbContext, _clock, Substitute.For<global::Workflow.Sla.Services.ISlaCalculator>(),
             Substitute.For<ILogger<ApprovalActivity>>());
 
     [Fact]

--- a/Tests/Unit/Workflow.Tests/Workflow/Activities/ApprovalActivityVotingModeTests.cs
+++ b/Tests/Unit/Workflow.Tests/Workflow/Activities/ApprovalActivityVotingModeTests.cs
@@ -1,10 +1,12 @@
 using FluentAssertions;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Shared.Data.Outbox;
 using Shared.Messaging.Events;
 using Shared.Time;
+using Workflow.Data;
 using Workflow.Data.Repository;
 using Workflow.Domain;
 using Workflow.Domain.Committees;
@@ -31,6 +33,10 @@ public class ApprovalActivityVotingModeTests
     private readonly IPublisher _publisher = Substitute.For<IPublisher>();
     private readonly IIntegrationEventOutbox _outbox = Substitute.For<IIntegrationEventOutbox>();
     private readonly ICommitteeRepository _committeeRepository = Substitute.For<ICommitteeRepository>();
+    private readonly WorkflowDbContext _dbContext = new(
+        new DbContextOptionsBuilder<WorkflowDbContext>()
+            .UseInMemoryDatabase($"approval-activity-voting-mode-{Guid.NewGuid()}")
+            .Options);
     private readonly IDateTimeProvider _clock = Substitute.For<IDateTimeProvider>();
 
     private const string ActivityId = "approval-1";
@@ -38,7 +44,7 @@ public class ApprovalActivityVotingModeTests
 
     private ApprovalActivity BuildActivity() =>
         new(_memberResolver, _voteRepository, _publisher, _outbox, _committeeRepository,
-            _clock, Substitute.For<global::Workflow.Sla.Services.ISlaCalculator>(),
+            _dbContext, _clock, Substitute.For<global::Workflow.Sla.Services.ISlaCalculator>(),
             Substitute.For<ILogger<ApprovalActivity>>());
 
     private static string Normalize(string id) =>

--- a/httpRequests/Workflow/PublishAppraisalWorkflowNewVersion.http
+++ b/httpRequests/Workflow/PublishAppraisalWorkflowNewVersion.http
@@ -30,7 +30,7 @@ Content-Type: application/json
 { "createdBy": "{{actor}}" }
 
 ### versionId captured from the create-draft response
-@versionId = 019f3b77-b5f5-7d68-ae45-ed8f1c80094d
+@versionId = 019f8d12-5d98-7e0f-aa65-a75a72f185bb
 
 ### 2. Push the edited appraisal-workflow.json into the draft.
 ###    The file's top-level "workflowSchema" binds; name/description/category/createdBy are ignored.


### PR DESCRIPTION
## What

Adds `POST /meetings/{id}/items/{appraisalId}/recall` so a secretary who released an appraisal to committee approval by accident can pull it back to `Pending` on the same meeting — previously the appraisal was stuck in `pending-approval` until someone voted.

Two related meeting/approval bookkeeping gaps are fixed alongside it, because the recall path exposed them.

## Recall flow — `RecallMeetingItemEndpoint.cs`

`MeetingSecretary`-only, `ITransactionalCommand<IWorkflowUnitOfWork>`. Guard order matters:

1. Item must currently be `Released` → else 409 `RECALL_NOT_RELEASED`.
2. Acquire the `wf-approval:{instanceId}` application lock **before** reading vote state — otherwise a vote committing in that window is silently discarded when the round is reset. It's the same resource `WorkflowService`'s approval-resume path takes, held by this command's ambient transaction, so the later acquisition inside `ResumeWorkflowAsync` is a re-entrant no-op. Lock failure → 409 `RECALL_BUSY`.
3. The instance must still sit on `pending-approval` → else 409 `RECALL_ALREADY_RESOLVED`.
4. If any committee member has voted → 409 `RECALL_VOTES_EXIST` unless `force: true`. Forcing needs no extra permission (a reason is already mandatory) but logs a warning — that log is the only audit trail for discarding real approver votes.

Then: `MeetingQueueItem.Requeue()` (Released → Assigned), `Meeting.UndoRelease()`, an explicit `SaveChangesAsync` (not a commit), and an inline `ResumeWorkflowAsync` with `decisionTaken = recall_to_meeting`.

**The flush is load-bearing.** The recall gate in `ApprovalActivity` is a persisted-state query, and `DispatchDomainEventInterceptor` dispatches during `SaveChanges` — so an event-driven resume would run *before* the flush and the gate would still read `Released`. That's why `UndoRelease` raises no domain event and the resume is inline.

`Meeting.UndoRelease` also reopens an `Ended` meeting (releasing the last item auto-ends it, which is exactly when an accidental release is noticed) to `InvitationSent`, or `RoutedBack` if another item on it is still routed back.

## Approver route-back mirroring

When a committee approver voted `route_back`, the `MeetingItem` stayed `Released`. The meeting's status went stale and — because `MeetingActivity` only re-enters items whose decision is **not** `Released` — the reworked appraisal was enqueued onto a *different* meeting instead of returning to the one that sent it back.

`Meeting.RecordApproverRouteBack` flips it to `RoutedBack` and reopens the meeting. It deliberately raises **no** domain event: `MeetingItemRoutedBackDomainEvent` resumes the workflow, which is already moving itself here, so publishing would drive it twice.

`ApprovalActivity` calls it best-effort — an appraisal can reach an approval activity without ever passing through a meeting gate, so "no released meeting item" is a normal outcome, and failing the activity over bookkeeping would strand a workflow whose backward transition is already committed.

## Supporting changes

- **`MeetingActivity`** — re-entry predicate widened from `RoutedBack`-only to any non-`Released` decision item on a non-`Cancelled` meeting. `Meeting.Cancel()` leaves its items behind, so cancelled meetings must be excluded or a stale row from a cancel-and-reschedule outranks the live one.
- **`ApprovalActivity` recall short-circuit** — placed ahead of the `voteOptions`/member checks (the secretary is not a committee member and `recall_to_meeting` is not a configured vote option), and gated on that same persisted `Pending` item. A forged `recall_to_meeting` payload has no such row, so it falls through to the vote path and `voteOptions` rejects it. Constructor gains `WorkflowDbContext`; the three affected test files are updated.
- **`GetMeetingDetail`** — returns per-approver `Votes` / `LastVotedAt`, scoped to the newest `pending-approval` execution. A recall completes the round but leaves its votes behind and the same member may vote again next round (the unique index is `(ActivityExecutionId, Member)`), so joining on appraisal alone would list people twice. Ordering by `StartedOn` rather than latest vote is deliberate: a re-released item nobody has voted on yet must report nothing, not fall back to the dead round. Meeting audit fields added too.
- **`ConflictException.Code`** → ProblemDetails `errorCode`, so the UI maps the four recall conflicts to distinct messages instead of matching on message text. Existing constructors leave it null, so current call sites are unaffected.
- **Migration** — `ApprovalVotes.Comments` and `WorkflowActivityExecutions.Comments` 1000 → 4000, matching the limit already on `PendingTask`.

## ⚠️ Deploy note — workflow version

`appraisal-workflow.json` gains an `approval-recall-to-meeting` transition (`pending-approval` → `pending-meeting`).

Workflow instances are pinned to the `WorkflowDefinitionVersion` they started on. An instance on a version predating this transition that resumes with `recall_to_meeting` matches **no** transition, which the engine treats as *workflow finished* (`WorkflowEngine` → null next activity → `CompleteWorkflowAsync`) — a silent completion.

**Publish a new definition version and migrate in-flight instances before enabling recall.** `httpRequests/Workflow/PublishAppraisalWorkflowNewVersion.http` is updated for this. There is deliberately no in-code guard; the reasoning is recorded in `RecallMeetingItemEndpoint.cs`.

## Tests

`dotnet build` clean. New unit tests in `MeetingTests` cover `RecordApproverRouteBack` (reopens an auto-ended meeting as `RoutedBack`, raises no event, rejects a non-`Released` item) and `ReinstateRoutedBackItem` status recomputation. The two `ApprovalActivity` test files gain the new `WorkflowDbContext` dependency.

Frontend counterpart follows in a separate PR and depends on this endpoint and the `votes` payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012q7oUfjvb6tKASTH16ToKK