### PR TITLE
feat(reporting): repeat summary header bar on every page

### DIFF
--- a/Modules/Reporting/Reporting/Templates/appraisal-summary-condo.html
+++ b/Modules/Reporting/Reporting/Templates/appraisal-summary-condo.html
@@ -119,6 +119,7 @@
   <!-- ════ COMMITTEE BLOCK — own page-break unit ════ -->
   {{ include 'partials/approver-block' }}
 
+  {{ include 'partials/summary-page-close' }}
 </div>
 </body>
 </html>

--- a/Modules/Reporting/Reporting/Templates/appraisal-summary-machine.html
+++ b/Modules/Reporting/Reporting/Templates/appraisal-summary-machine.html
@@ -112,6 +112,7 @@
   <!-- ════ COMMITTEE BLOCK — own page-break unit ════ -->
   {{ include 'partials/approver-block' }}
 
+  {{ include 'partials/summary-page-close' }}
 </div>
 </body>
 </html>

--- a/Modules/Reporting/Reporting/Templates/partials/summary-block-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-block-body.html
@@ -94,6 +94,10 @@
   <!-- ════ COMMITTEE BLOCK — own page-break unit ════ -->
   {{ include 'partials/approver-block' }}
 
+  <!-- Close the running-table BEFORE the landscape unit tables: a table cannot host the
+       landscape @page break, and the unit tables intentionally carry no repeating header. -->
+  {{ include 'partials/summary-page-close' }}
+
   <!-- ════ UNIT TABLE: LB / Land ════ -->
   {{ if model.building_units.size > 0 }}
   <div class="landscape-page">

--- a/Modules/Reporting/Reporting/Templates/partials/summary-construction-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-construction-body.html
@@ -88,4 +88,5 @@
   <!-- ════ COMMITTEE BLOCK — own page-break unit ════ -->
   {{ include 'partials/approver-block' }}
 
+  {{ include 'partials/summary-page-close' }}
 </div>

--- a/Modules/Reporting/Reporting/Templates/partials/summary-head-bar.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-head-bar.html
@@ -1,0 +1,16 @@
+<!--
+  Partial: the report header bar (LH Bank logo, title, report number + survey date).
+  Lives inside the <thead> of the summary running-table so Chromium repeats it on every
+  page of the summary body (see partials/summary-head + .running rules in summary-styles).
+  Shares the parent Scriban scope; expects {{ summary_title }} set and model.* fields.
+-->
+<div class="head">
+  <div class="logo">
+    <img src="logo-lh-bank.svg" class="brand-logo" alt="LH Bank"/>
+  </div>
+  <div class="title">{{ summary_title }}</div>
+  <div class="meta">
+    <div class="row"><span class="lbl">รายงานเลขที่</span><span class="val">{{ model.appraisal_book_number }}</span></div>
+    <div class="row"><span class="lbl">วันที่สำรวจและประเมินราคา</span><span class="val">{{ thai.date model.appraisal_date }}</span></div>
+  </div>
+</div>

--- a/Modules/Reporting/Reporting/Templates/partials/summary-head.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-head.html
@@ -1,21 +1,20 @@
 <!--
   Partial: shared report header + common info-block opening of the three summary bodies
   (standard / construction / block). The includer MUST:
-    1. set {{ summary_title }} before the include (the report title differs per body), and
-    2. close the still-open div.pad after appending its body-specific info rows.
+    1. set {{ summary_title }} before the include (the report title differs per body),
+    2. close the still-open div.pad after appending its body-specific info rows, and
+    3. include partials/summary-page-close at the end of its PORTRAIT content (before any
+       .landscape-page section) to close the running-table this partial opens.
   Shares the parent Scriban scope; expects: model.* (AppraisalSummaryModel snake_case fields).
+
+  The header bar sits in the <thead> of a full-width running-table: Chromium repeats a
+  table-header-group on every page the table spans AND reserves its height, so the header
+  bar prints on all summary pages without content sliding underneath it.
 -->
-<!-- ════ HEADER ════ -->
-<div class="head">
-  <div class="logo">
-    <img src="logo-lh-bank.svg" class="brand-logo" alt="LH Bank"/>
-  </div>
-  <div class="title">{{ summary_title }}</div>
-  <div class="meta">
-    <div class="row"><span class="lbl">รายงานเลขที่</span><span class="val">{{ model.appraisal_book_number }}</span></div>
-    <div class="row"><span class="lbl">วันที่สำรวจและประเมินราคา</span><span class="val">{{ thai.date model.appraisal_date }}</span></div>
-  </div>
-</div>
+<!-- ════ HEADER (repeats every page via <thead>) ════ -->
+<table class="running">
+  <thead><tr><td>{{ include 'partials/summary-head-bar' }}</td></tr></thead>
+  <tbody><tr><td>
 
 <!-- ════ INFO BLOCK (common opening — includer adds its rows and closes .pad) ════ -->
 <div class="pad">

--- a/Modules/Reporting/Reporting/Templates/partials/summary-page-close.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-page-close.html
@@ -1,0 +1,6 @@
+<!--
+  Partial: closes the summary running-table opened by partials/summary-head.
+  Each summary body MUST include this at the end of its PORTRAIT content (before any
+  .landscape-page section) so the repeating header <thead> spans the whole body.
+-->
+</td></tr></tbody></table>

--- a/Modules/Reporting/Reporting/Templates/partials/summary-standard-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-standard-body.html
@@ -162,4 +162,5 @@
   <!-- ════ COMMITTEE BLOCK (fields 42–51) — own page-break unit ════ -->
   {{ include 'partials/approver-block' }}
 
+  {{ include 'partials/summary-page-close' }}
 </div><!-- .form -->

--- a/Modules/Reporting/Reporting/Templates/partials/summary-styles.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-styles.html
@@ -30,6 +30,19 @@ body {
 .head .meta .lbl { color:#000; font-weight:600; white-space:nowrap; }
 .head .meta .val { text-align:right; flex:1; }
 
+/* Running-table: wraps the portrait flow of each summary body so the header bar in the
+   <thead> repeats on every page. Chromium repeats a table-header-group across page breaks
+   AND reserves its height, so no content slides under the bar (unlike position:fixed).
+   The wrapper is invisible — zero border/padding — and full-width so its single column
+   spans the content width; nested tables (grid / totals / prop-table / unit-table) are
+   class-scoped and unaffected. .head already draws the rule + gap under the bar.
+   NOTE: keep .landscape-page sections OUTSIDE this table — a table cannot host the
+   landscape @page break, so bodies close the running-table before their landscape units. */
+table.running { width:100%; border-collapse:collapse; }
+table.running > thead { display:table-header-group; }
+table.running > thead > tr > td,
+table.running > tbody > tr > td { border:0; padding:0; vertical-align:top; }
+
 /* ── Generic label:value rows ───────────────────────────── */
 /* No left/right padding so info/attribute rows align flush with the table edges. */
 .pad { padding:5px 0; }


### PR DESCRIPTION
## Problem

The FSD appraisal summary form (`สรุปรายงานการประเมินราคาทรัพย์สิน`) printed its header bar — LH Bank logo, report title, `รายงานเลขที่` and `วันที่สำรวจและประเมินราคา` — only once, at the top of the document. When a summary spans multiple pages (multi-group collateral tables, long `เงื่อนไข`/`หมายเหตุ`, machine detail blocks), pages 2+ arrived with no identifying header, so a loose page could not be tied back to its report number. The bank wants the header bar on every page of the summary form.

## Approach

Wrap the portrait flow of each summary body in a full-width, invisible `<table class="running">` whose `<thead>` carries the header bar. Chromium repeats a `thead` on every page a table spans **and reserves its height**, so the bar prints on all summary pages without content sliding underneath (unlike `position:fixed`).

Scoping is structural — only content inside the running-table repeats:
- **Summary bodies** (standalone `appraisal-summary-*` PDFs + the summary section of the appraisal book) get the repeating header.
- **Book detail/analysis sections** and the **block report's landscape unit tables** live outside the table and are untouched. The block body closes the running-table *before* its landscape sections, which cannot host the landscape `@page` break and intentionally carry no header.

Rejected: `position:fixed` (reserves no space → content prints under the header) and Puppeteer `DisplayHeaderFooter` (document-global; would stamp the book's detail sections and require re-inlining the font + logo as data URIs).

## Changes

- **New** `partials/summary-head-bar.html` — header-bar markup, for the `<thead>`.
- **New** `partials/summary-page-close.html` — closes the running-table.
- `partials/summary-head.html` — header bar wrapped in the running-table; extended includer contract documented.
- `partials/summary-styles.html` — added `table.running` rules with a comment on the repeat mechanism + landscape caveat.
- Five bodies (standard / construction / condo / machine / block) close the running-table at the end of their portrait flow; the block body closes it before its two landscape unit tables.

## Verification

Rendered via headless Chrome and rasterized each PDF page:
- Header bar present on **every** summary page; totals table starts cleanly below the header on page 2 (nothing hidden).
- `page-break-inside:avoid` blocks (opinion / sign-off / committee) moved to page 2 intact.
- Whole-word wrapping preserved (land descriptions wrap on word boundaries; a long unbroken token breaks at the cell edge as before) — no regression.
- Block body: page 1 portrait with header, page 2 landscape (842×595) with the unit table and **no** header bar.
- `dotnet build` clean; both new partials copied to output via the existing `Templates\**\*` wildcard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JPgBZWHX825431K1n9mpL