### PR TITLE
fix(reporting): let appraiser opinion split across pages

### DIFF
--- a/Modules/Reporting/Reporting/Templates/partials/summary-styles.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-styles.html
@@ -167,12 +167,11 @@ table.totals td.tt { text-align:right; font-style:italic; color:#333; }
    page the whole block moves to the next one rather than splitting mid-way. */
 .attrs-block { page-break-inside:avoid; break-inside:avoid; }
 
-/* The opinion section (heading + comment), the sign-off row and the committee block are three
-   SIBLING page-break units — never nested. Each stays internally intact but paginates
-   independently, so an overflowing committee table no longer drags the opinion text with it.
-   Nesting them would defeat this: Chromium honours the outermost avoid and moves the whole
-   subtree as one blob. */
-.opinion-block { page-break-inside:avoid; break-inside:avoid; }
+/* The opinion section (heading + comment) is allowed to split across a page boundary: if the
+   comment is long it flows onto the next page in place rather than jumping the whole block down
+   and leaving a large gap. The sign-off row and committee block remain independent keep-together
+   units via their own rules above, so an overflowing committee table still can't drag the
+   opinion text with it. */
 
 /* FSD-aligned: plain left-aligned bold heading, no grey fill / border. */
 .section-bar { font-weight:700; text-align:left; padding:2px 0; font-size:8.5pt; }


### PR DESCRIPTION
## What

Removes the `break-inside: avoid` keep-together rule from `.opinion-block` in the appraisal summary report styles.

## Why

Previously, when the appraiser opinion section (`สรุปความเห็นผู้ประเมิน`) didn't fit in the space left on the current page, the entire block jumped to the next page, leaving a gap at the bottom of the previous page. Users want the opinion block to flow in place and split across the page boundary instead.

## Scope

Only `.opinion-block` is affected. The committee (`.committee-block`), sign-off (`.signoff`), and attributes (`.attrs-block`) blocks keep their own independent keep-together rules and are unchanged.

The `.opinion-block` markup is shared across all four summary templates (land-building, block, condo, machine), so this single CSS change covers every appraisal-type variant consistently.

## Verification

- [ ] Render a summary PDF with a long appraiser opinion comment and confirm it splits cleanly across pages without colliding with the sign-off row below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHsViFVWT5yQgz7kgreZ3X