### PR TITLE
Remove empty approach when last method removed

### DIFF
--- a/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/RemoveMethod/RemoveMethodCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/RemoveMethod/RemoveMethodCommandHandler.cs
@@ -46,6 +46,9 @@ public class RemoveMethodCommandHandler(
 
         approach.RemoveMethod(command.MethodId);
 
+        if (approach.Methods.Count == 0)
+            pricingAnalysis.RemoveApproach(approach.Id);
+
         await repository.UpdateAsync(pricingAnalysis, cancellationToken);
 
         return new RemoveMethodResult(command.MethodId, true);

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysis.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysis.cs
@@ -408,4 +408,13 @@ public class PricingAnalysis : Aggregate<Guid>
     {
         Remark = remark;
     }
+
+    public void RemoveApproach(Guid approachId)
+    {
+        var approach = _approaches.FirstOrDefault(m => m.Id == approachId);
+        if (approach is null)
+            throw new InvalidOperationException($"Approach with ID {approachId} not found in pricing analysis.");
+
+        _approaches.Remove(approach);
+    }
 }


### PR DESCRIPTION
When a method is removed from an approach, also remove the approach from PricingAnalysis if it has no remaining methods to avoid leaving empty approaches. Added PricingAnalysis.RemoveApproach(Guid) which validates presence and removes the approach. Updated RemoveMethodCommandHandler to call RemoveApproach when an approach's Methods.Count reaches zero and persist the change.

Files changed: Modules/Appraisal/Appraisal/Application/Features/PricingAnalysis/RemoveMethod/RemoveMethodCommandHandler.cs, Modules/Appraisal/Appraisal/Domain/Appraisals/PricingAnalysis.cs