### PR TITLE
feat(appraisal): filter the appraisal list by purpose and property type

### DIFF
--- a/Database/Scripts/Views/Appraisal/vw_AppraisalList.sql
+++ b/Database/Scripts/Views/Appraisal/vw_AppraisalList.sql
@@ -23,6 +23,24 @@ SELECT a.Id,
        a.CreatedAt,
        va.AppraisedValue                                                                    AS AppraisalValue,
        (SELECT COUNT(*) FROM appraisal.AppraisalProperties ap WHERE ap.AppraisalId = a.Id) AS PropertyCount,
+       -- Distinct collateral type codes on this appraisal, comma-joined (e.g. 'B, L, LB').
+       -- Sourced from BOTH places the type can live, because they are mutually exclusive in
+       -- practice: normal appraisals carry N AppraisalProperties, while block appraisals have no
+       -- AppraisalProperties at all and hold their type on the 1:1 Projects row. ProjectType codes
+       -- ('U'/'LB'/'L') share the PropertyType wire format, so they union directly.
+       -- This is a display aggregate — the propertyType FILTER runs the equivalent union as a
+       -- semi-join (see AppraisalFilterBuilder), it does not read this column.
+       -- UNION (not UNION ALL) dedupes across both sources.
+       (SELECT STRING_AGG(pt.PropertyType, ', ') WITHIN GROUP (ORDER BY pt.PropertyType)
+        FROM (SELECT ap3.PropertyType
+              FROM appraisal.AppraisalProperties ap3
+              WHERE ap3.AppraisalId = a.Id
+                AND ap3.PropertyType IS NOT NULL
+              UNION
+              SELECT pr.ProjectType
+              FROM appraisal.Projects pr
+              WHERE pr.AppraisalId = a.Id
+                AND pr.ProjectType IS NOT NULL) pt)                                 AS PropertyTypes,
        -- Latest active assignment info
        la.AssigneeUserId,
        la.AssigneeCompanyId,

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/ExportAppraisals/ExportAppraisalsEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/ExportAppraisals/ExportAppraisalsEndpoint.cs
@@ -28,6 +28,8 @@ public class ExportAppraisalsEndpoint : ICarterModule
                     // Request metadata
                     [FromQuery] string? channel,
                     [FromQuery] string? bankingSegment,
+                    [FromQuery] string? purpose,
+                    [FromQuery] string? propertyType,
                     [FromQuery] bool? isPma,
                     // Geographic
                     [FromQuery] string? province,
@@ -74,7 +76,11 @@ public class ExportAppraisalsEndpoint : ICarterModule
                         AppointmentDateTo: appointmentDateTo,
                         SortBy: sortBy,
                         SortDir: sortDir
-                    );
+                    )
+                    {
+                        Purpose = purpose,
+                        PropertyType = propertyType,
+                    };
 
                     var query = new ExportAppraisalsQuery(filter, format ?? "xlsx");
                     var result = await sender.Send(query, cancellationToken);

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/AppraisalFilterBuilder.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/AppraisalFilterBuilder.cs
@@ -51,6 +51,8 @@ internal static class AppraisalFilterBuilder
             AddMultiValueFilter(conditions, parameters, filter.AppraisalType, "AppraisalType", "@AppraisalTypes");
             AddMultiValueFilter(conditions, parameters, filter.SlaStatus, "SLAStatus", "@SlaStatuses");
             AddMultiValueFilter(conditions, parameters, filter.AssignmentType, "AssignmentType", "@AssignmentTypes");
+            AddMultiValueFilter(conditions, parameters, filter.Purpose, "Purpose", "@Purposes");
+            AddPropertyTypeFilter(conditions, parameters, filter.PropertyType);
 
             // Exact match filters
             if (!string.IsNullOrWhiteSpace(filter.AssigneeUserId))
@@ -122,12 +124,6 @@ internal static class AppraisalFilterBuilder
                 parameters.Add("AppraisalNumber", filter.AppraisalNumber.Trim());
             }
 
-            if (!string.IsNullOrWhiteSpace(filter.Purpose))
-            {
-                conditions.Add("Purpose = @Purpose");
-                parameters.Add("Purpose", filter.Purpose);
-            }
-
             if (!string.IsNullOrWhiteSpace(filter.SubDistrict))
             {
                 conditions.Add("SubDistrict LIKE '%' + @SubDistrict + '%'");
@@ -182,6 +178,42 @@ internal static class AppraisalFilterBuilder
             conditions.Add($"{columnName} IN {paramName}");
             parameters.Add(paramName.TrimStart('@'), values);
         }
+    }
+
+    /// <summary>
+    /// Matches appraisals that carry at least one collateral of the given type(s).
+    ///
+    /// The type lives in two different places depending on how the appraisal was created, and both
+    /// must be searched or block appraisals silently disappear from the results:
+    ///   • Normal appraisals → appraisal.AppraisalProperties.PropertyType (N rows per appraisal).
+    ///   • Block appraisals  → appraisal.Projects.ProjectType (1:1 with the appraisal). Blocks have
+    ///     NO AppraisalProperties rows at all, so the property-side subquery alone misses them.
+    /// ProjectType codes ("U"/"LB"/"L") are a subset of the PropertyType codes and share the same
+    /// wire format (see Domain/Projects/ProjectType.cs), so no translation is needed.
+    /// </summary>
+    private static void AddPropertyTypeFilter(
+        List<string> conditions, DynamicParameters parameters, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return;
+
+        var values = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (values.Length == 0) return;
+
+        // Written as `Id IN (subquery)` rather than a correlated EXISTS on purpose:
+        // AppraisalProperties also has an `Id` column, so inside an EXISTS body an unqualified `Id`
+        // would bind to the inner table, and the outer query (SELECT * FROM appraisal.vw_AppraisalList)
+        // has no alias to qualify with. On the left of IN, `Id` is unambiguously the outer view's column.
+        // The two sources are unioned into one derived table so @PropertyTypes appears exactly
+        // once — a repeated list parameter would depend on Dapper expanding every occurrence.
+        conditions.Add(
+            """
+            Id IN (SELECT t.AppraisalId
+                   FROM (SELECT ap.AppraisalId, ap.PropertyType AS Code FROM appraisal.AppraisalProperties ap
+                         UNION ALL
+                         SELECT pr.AppraisalId, pr.ProjectType FROM appraisal.Projects pr) t
+                   WHERE t.Code IN @PropertyTypes)
+            """);
+        parameters.Add("PropertyTypes", values);
     }
 
     private static void AddDateRangeFilter(

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsEndpoint.cs
@@ -29,6 +29,8 @@ public class GetAppraisalsEndpoint : ICarterModule
                     // Request metadata
                     [FromQuery] string? channel,
                     [FromQuery] string? bankingSegment,
+                    [FromQuery] string? purpose,
+                    [FromQuery] string? propertyType,
                     [FromQuery] bool? isPma,
                     // Geographic
                     [FromQuery] string? province,
@@ -73,7 +75,11 @@ public class GetAppraisalsEndpoint : ICarterModule
                         AppointmentDateTo: appointmentDateTo,
                         SortBy: sortBy,
                         SortDir: sortDir
-                    );
+                    )
+                    {
+                        Purpose = purpose,
+                        PropertyType = propertyType,
+                    };
 
                     var query = new GetAppraisalsQuery(pagination, filter);
 
@@ -88,9 +94,10 @@ public class GetAppraisalsEndpoint : ICarterModule
             .WithSummary("Get all appraisals")
             .WithDescription(
                 "Retrieves all appraisals with pagination, filtering, sorting, and facet counts. " +
-                "Supports text search (search), multi-value filters (comma-separated status, priority, appraisalType, slaStatus, assignmentType), " +
+                "Supports text search (search), multi-value filters (comma-separated status, priority, appraisalType, slaStatus, assignmentType, purpose, propertyType), " +
                 "date ranges (createdFrom/To, slaDueDateFrom/To, assignedDateFrom/To, appointmentDateFrom/To), " +
-                "geographic filters (province, district), and sorting (sortBy, sortDir).")
+                "geographic filters (province, district), and sorting (sortBy, sortDir). " +
+                "propertyType matches appraisals having at least one property of the given type(s).")
             .WithTags("Appraisal");
     }
 }

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsFilterRequest.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsFilterRequest.cs
@@ -43,10 +43,14 @@ public record GetAppraisalsFilterRequest(
     string? SortDir = null
 )
 {
-    // Picker-only additive fields (not bound by GetAppraisalsEndpoint; opt-in via init setters)
+    // Additive fields set via init setters. Purpose and PropertyType are bound by the list and
+    // export endpoints; the rest remain picker-only.
     public string? CustomerName { get; init; }
     public string? AppraisalNumber { get; init; }
     public string? Purpose { get; init; }
+
+    // Matches appraisals having at least one property of the given type(s); comma-separated for IN.
+    public string? PropertyType { get; init; }
     public string? SubDistrict { get; init; }
     public DateTime? RequestedAtFrom { get; init; }
     public DateTime? RequestedAtTo { get; init; }

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsResult.cs
@@ -31,6 +31,9 @@ public record AppraisalDto
     public DateTime? SLADueDate { get; init; }
     public string? SLAStatus { get; init; }
     public int PropertyCount { get; init; }
+
+    /// <summary>Distinct property type codes on this appraisal, comma-joined (e.g. "B, L, LB").</summary>
+    public string? PropertyTypes { get; init; }
     public DateTime? CreatedAt { get; init; }
     public decimal? AppraisalValue { get; init; }
 


### PR DESCRIPTION
## What

Adds `purpose` and `propertyType` filters to the appraisal list and export endpoints, plus a `PropertyTypes` display column on the list.

- **`purpose`** — promoted from exact-match (`=`) to multi-value `IN` via the existing `AddMultiValueFilter` helper, matching how `status` / `priority` / `appraisalType` / `slaStatus` already behave.
- **`propertyType`** — new `AddPropertyTypeFilter`, matching appraisals that carry at least one collateral of the given type(s).
- **`PropertyTypes`** — new display aggregate on `vw_AppraisalList` (e.g. `"B, L, LB"`).

## Why the two-source union

The collateral type lives in two different places depending on how the appraisal was created, and both must be searched:

- Normal appraisals → `appraisal.AppraisalProperties.PropertyType` (N rows per appraisal).
- Block appraisals → `appraisal.Projects.ProjectType` (1:1). Blocks have **no** `AppraisalProperties` rows at all, so a property-side-only subquery would make every block appraisal silently vanish from a filtered result.

`ProjectType` codes (`U`/`LB`/`L`) are a subset of the `PropertyType` codes and share the same wire format, so they union directly with no translation.

Two implementation notes worth a reviewer's eye:

- The filter is written as `Id IN (subquery)` rather than a correlated `EXISTS`. `AppraisalProperties` also has an `Id` column, so inside an `EXISTS` body an unqualified `Id` would bind to the inner table — and the outer `SELECT * FROM appraisal.vw_AppraisalList` has no alias to qualify with.
- The two sources are unioned into one derived table so `@PropertyTypes` appears exactly once, rather than relying on Dapper expanding a repeated list parameter.

## Notes for the reviewer

- **Export columns lag the filters.** `ExportAppraisalsQueryHandler` now *filters* by the new fields, but its column list (`:66-71` for XLSX, `:112` for CSV) still emits the same fixed 15 columns with no `BankingSegment` / `Purpose` / `PropertyTypes`. A user who filters by property type and hits Export gets a file without that column. Happy to fold the column additions into this PR if you'd prefer that over a follow-up.
- **Filter-style inconsistency.** `bankingSegment` remains exact-match `=` while `purpose`/`propertyType` are comma-separated `IN`. Harmless today because the UI dropdowns are single-select, but `bankingSegment=A,B` would match nothing.
- `BankingSegment` needed no backend work — it was already bound end-to-end. Both `BankingSegment` and `Purpose` are already in `AllowedSortFields`, so the frontend can sort on them.

## Deployment

`vw_AppraisalList.sql` is a view script (DbUp path), not an EF migration — it must be applied to the target database before `PropertyTypes` exists.

## Testing

- `dotnet build --configuration Release` — 0 errors.
- No automated coverage: there are no existing tests referencing `AppraisalFilterBuilder` or `GetAppraisals`. `AppraisalFilterBuilder` is `internal static` and `Appraisal.csproj` grants `InternalsVisibleTo` only to `Integration`, so adding a unit test needs an extra `InternalsVisibleTo` entry first.
- Suggested manual check: `GET /appraisals?propertyType=U` should return block appraisals (the whole point of the union), and `GET /appraisals?purpose=<a>,<b>` should return the union of both.

## Paired frontend PR

Depends on nothing, but the frontend appraisal-search-filters PR depends on **this** — its property-type column and filters are no-ops until this is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoSUNxSXysEMgWY6kQrjA2
