### PR TITLE
feat(integration): serve the legacy AS400 appraisal-result contract on v1

### DIFF
--- a/Modules/Auth/Auth/Domain/Identity/ApplicationUser.cs
+++ b/Modules/Auth/Auth/Domain/Identity/ApplicationUser.cs
@@ -10,6 +10,10 @@ public class ApplicationUser : IdentityUser<Guid>
     public Guid? CompanyId { get; set; }
     public string AuthSource { get; set; } = AuthSources.Local;
     public string? AoCode { get; set; }
+
+    /// <summary>Bank staff employee id. Surfaced to the legacy (AS400) result feed as InternalValuerCode.
+    /// Maintained manually or via LDAP sync (that population is a separate follow-up).</summary>
+    public string? EmployeeId { get; set; }
     public List<UserPermission> Permissions { get; set; } = default!;
 
     /// <summary>Whether the account is allowed to sign in. Defaults to true.</summary>

--- a/Modules/Auth/Auth/Infrastructure/Configurations/ApplicationUserConfiguration.cs
+++ b/Modules/Auth/Auth/Infrastructure/Configurations/ApplicationUserConfiguration.cs
@@ -30,6 +30,10 @@ public class ApplicationUserConfiguration : IEntityTypeConfiguration<Application
         builder.Property(u => u.AoCode)
             .HasMaxLength(10);
 
+        // Bank staff employee id (fed to the legacy result feed as InternalValuerCode).
+        builder.Property(u => u.EmployeeId)
+            .HasMaxLength(50);
+
         builder.Property(u => u.AuthSource)
             .HasMaxLength(20)
             .IsRequired()

--- a/Modules/Auth/Auth/Infrastructure/Migrations/20260726134432_AddEmployeeIdToApplicationUser.Designer.cs
+++ b/Modules/Auth/Auth/Infrastructure/Migrations/20260726134432_AddEmployeeIdToApplicationUser.Designer.cs
@@ -4,6 +4,7 @@ using Auth.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Auth.Infrastructure.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260726134432_AddEmployeeIdToApplicationUser")]
+    partial class AddEmployeeIdToApplicationUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modules/Auth/Auth/Infrastructure/Migrations/20260726134432_AddEmployeeIdToApplicationUser.cs
+++ b/Modules/Auth/Auth/Infrastructure/Migrations/20260726134432_AddEmployeeIdToApplicationUser.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Auth.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmployeeIdToApplicationUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "EmployeeId",
+                schema: "auth",
+                table: "AspNetUsers",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmployeeId",
+                schema: "auth",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultByCaseKeyEndpoint.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultByCaseKeyEndpoint.cs
@@ -10,7 +10,7 @@ public class GetAppraisalResultByCaseKeyEndpoint : ICarterModule
 {
     public void AddRoutes(IEndpointRouteBuilder app)
     {
-        app.MapGet("/api/v1/appraisals/result", async (
+        app.MapGet("/api/v2/appraisals/result", async (
             [Microsoft.AspNetCore.Mvc.FromQuery] string externalCaseKey,
             [Microsoft.AspNetCore.Mvc.FromQuery] string? plotNumber,
             [Microsoft.AspNetCore.Mvc.FromQuery] string? roomNumber,

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultByNumberEndpoint.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultByNumberEndpoint.cs
@@ -10,7 +10,7 @@ public class GetAppraisalResultByNumberEndpoint : ICarterModule
 {
     public void AddRoutes(IEndpointRouteBuilder app)
     {
-        app.MapGet("/api/v1/appraisals/{appraisalNumber}/result", async (
+        app.MapGet("/api/v2/appraisals/{appraisalNumber}/result", async (
             string appraisalNumber,
             [Microsoft.AspNetCore.Mvc.FromQuery] string? plotNumber,
             [Microsoft.AspNetCore.Mvc.FromQuery] string? roomNumber,

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQuery.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQuery.cs
@@ -87,3 +87,64 @@ public record AppraisalResultCollateral(
     string? MachineSerialNo);
 
 public record AppraisalResultDocument(string? DocumentType, string? DocumentPath);
+
+// ── Legacy-shaped variant (AS400 consumer): flat { ResultCode, ResultValue } envelope for ONE
+// collateral, selected via ApplicationNo (AppraisalNumber) + Filter1/Filter2. AssetTypeId is
+// currently ignored. See GetLegacyAppraisalResultQueryHandler for the selection/mapping logic.
+public record GetLegacyAppraisalResultQuery(
+    string ApplicationNo,
+    int AssetTypeId,
+    string? Filter1,
+    string? Filter2)
+    : IQuery<LegacyAppraisalResultEnvelope>;
+
+public record LegacyAppraisalResultEnvelope(int ResultCode, LegacyAppraisalResult ResultValue);
+
+// All fields default to the legacy "empty" representation ("" / 0 / 0.0) rather than null, so a
+// not-found/error result can be emitted as `new LegacyAppraisalResult()`.
+public record LegacyAppraisalResult(
+    string ErrorMessage = "",
+    string LandNo = "",
+    decimal Rai = 0m,
+    decimal Ngan = 0m,
+    decimal Wah = 0m,
+    string Rawang = "",
+    string SurveyNo = "",
+    decimal AreaUtilize = 0m,
+    string BuildingRegisterNo = "",
+    string BookNo = "",
+    string PageNo = "",
+    string InternalValuerCode = "",
+    string InternalValuerName = "",
+    decimal InternalValuation = 0m,
+    string InternalValuationDate = "",
+    string ExternalValuerCode = "",
+    string ExternalValuerName = "",
+    decimal ExternalValuation = 0m,
+    string ExternalValuationDate = "",
+    string BuildingDetails = "",
+    string TitleNo = "",
+    string BuildingNo = "",
+    int BuildingAge = 0,
+    string HouseNo = "",
+    string RoomNo = "",
+    string FloorNo = "",
+    string FloorNumber = "",
+    string Province = "",
+    string District = "",
+    string SubDistrict = "",
+    int AppraisalType = 0,
+    decimal AppraisalValue = 0m,
+    int MethodOfAppraisal = 0,
+    decimal ForceSaleValue = 0m,
+    string LandOffice = "",
+    int? Decorate = null,
+    string Developer = "",
+    decimal AppraisalValueWaOrM = 0.0m,
+    string AppraisalReportNo = "",
+    decimal AppraisalFee = 0m,
+    decimal LandValue = 0m,
+    string SequenceOfApprove = "",
+    decimal BuildingValue = 0m,
+    string AppraisalDate = "",
+    decimal MarketValue = 0m);

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQueryHandler.cs
@@ -78,6 +78,30 @@ internal static class GetAppraisalResultSql
                                             ORDER BY a.CreatedAt DESC, a.AppraisalNumber
                                             """;
 
+    // Legacy (AS400) header: adds AppraisalType, the request-level selling price (MarketValue) and the
+    // request-detail DOPA address resolved to Thai names (RequestDetails geocodes → parameter.Dopa*).
+    // COALESCE falls back to the raw code if a geocode is absent from the reference tables.
+    public const string LegacyByAppraisalNumber = """
+                                            SELECT a.Id, a.AppraisalNumber, a.AppraisalType, a.Status, a.CompletedAt, a.RequestId,
+                                                   rd.TotalSellingPrice AS MarketValue,
+                                                   COALESCE(dprov.NameTh, rd.Province)    AS Province,
+                                                   COALESCE(ddist.NameTh, rd.District)    AS District,
+                                                   COALESCE(dsub.NameTh,  rd.SubDistrict) AS SubDistrict,
+                                                   -- SequenceOfApprove = the committee meeting number the appraisal was reviewed in (latest).
+                                                   (SELECT TOP 1 m.MeetingNo
+                                                    FROM appraisal.AppraisalReviews ar
+                                                    JOIN workflow.Meetings m ON m.Id = ar.MeetingId
+                                                    WHERE ar.AppraisalId = a.Id
+                                                    ORDER BY ar.ReviewedAt DESC) AS SequenceOfApprove
+                                            FROM appraisal.Appraisals a
+                                            LEFT JOIN request.RequestDetails rd ON rd.RequestId = a.RequestId
+                                            LEFT JOIN parameter.DopaProvinces    dprov ON dprov.Code = rd.Province
+                                            LEFT JOIN parameter.DopaDistricts    ddist ON ddist.Code = rd.District
+                                            LEFT JOIN parameter.DopaSubDistricts dsub  ON dsub.Code  = rd.SubDistrict
+                                            WHERE a.AppraisalNumber = @AppraisalNumber AND a.IsDeleted = 0
+                                              AND a.Status = 'Completed'
+                                            """;
+
     public const string ActiveAssignment = """
                                            SELECT TOP 1
                                                aa.Id AS AssignmentId,
@@ -88,6 +112,7 @@ internal static class GetAppraisalResultSql
                                                c.HostCompanyCode AS CompanyCode,
                                                u.FirstName AS UserFirstName,
                                                u.LastName  AS UserLastName,
+                                               u.EmployeeId AS EmployeeId,
                                                appt.AppointmentDateTime
                                            FROM appraisal.AppraisalAssignments aa
                                            LEFT JOIN auth.Companies   c ON c.Id = TRY_CAST(aa.AssigneeCompanyId AS uniqueidentifier)
@@ -154,7 +179,18 @@ internal static class GetAppraisalResultSql
                                                    mad.MachineName         AS MachineName,
                                                    mad.Brand               AS MachineBrand,
                                                    mad.Model               AS MachineModel,
-                                                   mad.SerialNo            AS MachineSerialNo
+                                                   mad.SerialNo            AS MachineSerialNo,
+                                                   -- Legacy-only descriptors (consumed by the AS400 variant)
+                                                   bad.DecorationType      AS BuildingDecorationType,
+                                                   cad.DecorationType      AS CondoDecorationType,
+                                                   cad.CondoRegistrationNumber AS CondoRegistrationNumber,
+                                                   cad.CondoName           AS CondoName,
+                                                   cad.BuiltOnTitleNumber  AS CondoBuiltOnTitleNo,
+                                                   lad.Village             AS Village,
+                                                   bad.TotalBuildingArea   AS TotalBuildingArea,
+                                                   -- LandOffice code resolved to its Thai description (legacy variant only)
+                                                   COALESCE(pLandOffice.[description],    lad.LandOffice) AS LandOfficeName,
+                                                   COALESCE(pCadLandOffice.[description], cad.LandOffice) AS CadLandOfficeName
                                                FROM appraisal.PropertyGroups pg
                                                LEFT JOIN appraisal.PricingAnalysis pa ON pa.AnchorId = pg.Id AND pa.SubjectType = 0
                                                OUTER APPLY (
@@ -184,6 +220,12 @@ internal static class GetAppraisalResultSql
                                                LEFT JOIN appraisal.VesselAppraisalDetails vsad ON vsad.AppraisalPropertyId = ap.Id
                                                LEFT JOIN appraisal.MachineryAppraisalDetails mad ON mad.AppraisalPropertyId = ap.Id
                                                LEFT JOIN appraisal.LeaseAgreementDetails leasd ON leasd.AppraisalPropertyId = ap.Id
+                                               LEFT JOIN parameter.Parameters pLandOffice
+                                                   ON pLandOffice.[group] = 'LandOffice' AND pLandOffice.[language] = 'TH'
+                                                  AND pLandOffice.[isactive] = 1 AND pLandOffice.[code] = lad.LandOffice
+                                               LEFT JOIN parameter.Parameters pCadLandOffice
+                                                   ON pCadLandOffice.[group] = 'LandOffice' AND pCadLandOffice.[language] = 'TH'
+                                                  AND pCadLandOffice.[isactive] = 1 AND pCadLandOffice.[code] = cad.LandOffice
                                                WHERE pg.AppraisalId = @AppraisalId
                                                ORDER BY pg.GroupNumber, pgi.SequenceInGroup
                                                """;
@@ -213,8 +255,13 @@ internal static class GetAppraisalResultSql
     // A block/project appraisal has a row in appraisal.Projects (1:1 via AppraisalId).
     // ProjectType code: "U" (Condo) | "LB"/"L" (Land / Land&Building).
     public const string ProjectByAppraisalId = """
-                                               SELECT TOP 1 p.Id AS ProjectId, p.ProjectType
+                                               SELECT TOP 1 p.Id AS ProjectId, p.ProjectType,
+                                                      p.ProjectName, p.Developer, p.BuiltOnTitleDeedNumber,
+                                                      COALESCE(pLandOffice.[description], p.LandOffice) AS LandOfficeName
                                                FROM appraisal.Projects p
+                                               LEFT JOIN parameter.Parameters pLandOffice
+                                                   ON pLandOffice.[group] = 'LandOffice' AND pLandOffice.[language] = 'TH'
+                                                  AND pLandOffice.[isactive] = 1 AND pLandOffice.[code] = p.LandOffice
                                                WHERE p.AppraisalId = @AppraisalId
                                                """;
 
@@ -224,10 +271,17 @@ internal static class GetAppraisalResultSql
                                            SELECT TOP 1
                                                pu.RoomNumber, pu.Floor, pu.TowerName,
                                                pu.PlotNumber, pu.HouseNumber, pu.NumberOfFloors, pu.LandArea,
-                                               pu.UsableArea,
-                                               pp.TotalAppraisalValueRounded, pp.ForceSellingPrice
+                                               pu.UsableArea, pu.SellingPrice,
+                                               pu.CondoRegistrationNumber AS UnitRoomNo,   -- actually the room number (column to be renamed)
+                                               pt.CondoRegistrationNumber,                 -- tower-level condo registration → BuildingRegisterNo
+                                               pt.NumberOfFloors AS TowerFloors,           -- total floors of the building → FloorNumber
+                                               pt.BuildingAge    AS TowerBuildingAge,
+                                               COALESCE(pm.DecorationType, pt.DecorationType) AS DecorationType,
+                                               pp.TotalAppraisalValueRounded, pp.ForceSellingPrice, pp.CoverageAmount
                                            FROM appraisal.ProjectUnits pu
                                            LEFT JOIN appraisal.ProjectUnitPrices pp ON pp.ProjectUnitId = pu.Id
+                                           LEFT JOIN appraisal.ProjectTowers pt ON pt.Id = pu.ProjectTowerId
+                                           LEFT JOIN appraisal.ProjectModels pm ON pm.Id = pu.ProjectModelId
                                            WHERE pu.ProjectId = @ProjectId
                                            """;
 
@@ -239,7 +293,8 @@ internal static class GetAppraisalResultSql
 
     public const string BlockUnitByRoomFloor = BlockUnitSelect + """
 
-                                                  AND pu.RoomNumber = @RoomNumber AND pu.Floor = @Floor
+                                                  AND (pu.CondoRegistrationNumber = @RoomNumber OR pu.RoomNumber = @RoomNumber)
+                                                  AND pu.Floor = @Floor
                                               ORDER BY pu.SequenceNumber
                                               """;
 }
@@ -261,6 +316,7 @@ internal sealed record AssignmentRow(
     string? CompanyCode,
     string? UserFirstName,
     string? UserLastName,
+    string? EmployeeId,
     DateTime? AppointmentDateTime);
 
 internal sealed record ValuationRow(
@@ -319,14 +375,45 @@ internal sealed record CollateralRow(
     string? MachineName,
     string? MachineBrand,
     string? MachineModel,
-    string? MachineSerialNo);
+    string? MachineSerialNo,
+    // Legacy-only descriptors
+    string? BuildingDecorationType,
+    string? CondoDecorationType,
+    string? CondoRegistrationNumber,
+    string? CondoName,
+    string? CondoBuiltOnTitleNo,
+    string? Village,
+    decimal? TotalBuildingArea,
+    string? LandOfficeName,
+    string? CadLandOfficeName);
+
+// Legacy (AS400) appraisal header row: appraisal identity + type, request-level MarketValue and the
+// DOPA address already resolved to Thai names.
+internal sealed record LegacyAppraisalRow(
+    Guid Id,
+    string AppraisalNumber,
+    string? AppraisalType,
+    string? Status,
+    DateTime? CompletedAt,
+    Guid RequestId,
+    decimal? MarketValue,
+    string? Province,
+    string? District,
+    string? SubDistrict,
+    string? SequenceOfApprove);
 
 internal sealed record DocumentRow(string? DocumentType, Guid DocumentId);
 
 // Optional unit selector for block/project appraisals.
 internal sealed record UnitSelector(string? PlotNumber, string? RoomNumber, string? FloorNumber);
 
-internal sealed record ProjectRow(Guid ProjectId, string ProjectType);
+internal sealed record ProjectRow(
+    Guid ProjectId,
+    string ProjectType,
+    string? ProjectName = null,
+    string? Developer = null,
+    string? BuiltOnTitleDeedNumber = null,
+    string? LandOfficeName = null);
 
 internal sealed record BlockUnitRow(
     string? RoomNumber,
@@ -337,8 +424,15 @@ internal sealed record BlockUnitRow(
     int? NumberOfFloors,
     decimal? LandArea,
     decimal? UsableArea,
+    decimal? SellingPrice,
+    string? UnitRoomNo,
+    string? CondoRegistrationNumber,
+    int? TowerFloors,
+    int? TowerBuildingAge,
+    string? DecorationType,
     decimal? TotalAppraisalValueRounded,
-    decimal? ForceSellingPrice);
+    decimal? ForceSellingPrice,
+    decimal? CoverageAmount);
 
 internal static class AppraisalResultBuilder
 {
@@ -519,7 +613,7 @@ internal static class AppraisalResultBuilder
     // Resolves a single block/project unit by the selector. Throws ValidationException (→ 400) when
     // the selector is missing/wrong for the project type and strict is on; returns null (no match /
     // ignored selector) otherwise.
-    private static async Task<BlockUnitRow?> ResolveBlockUnitAsync(
+    internal static async Task<BlockUnitRow?> ResolveBlockUnitAsync(
         IDbConnection conn,
         ProjectRow project,
         UnitSelector selector,

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultEndpoint.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultEndpoint.cs
@@ -1,0 +1,39 @@
+using Carter;
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Integration.Application.Features.AppraisalResults.GetAppraisalResult;
+
+// Legacy (AS400) request body. AssetTypeId (RequestTitle collateral type) is accepted but ignored;
+// the collateral is located by ApplicationNo (= AppraisalNumber) + Filter1/Filter2.
+public record LegacyAppraisalResultRequest(
+    string ApplicationNo,
+    int AssetTypeId,
+    string? Filter1,
+    string? Filter2);
+
+public class GetLegacyAppraisalResultEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/v1/appraisals/result", async (
+            LegacyAppraisalResultRequest body,
+            ISender sender,
+            CancellationToken cancellationToken) =>
+        {
+            var result = await sender.Send(
+                new GetLegacyAppraisalResultQuery(
+                    body.ApplicationNo, body.AssetTypeId, body.Filter1, body.Filter2),
+                cancellationToken);
+
+            // Always 200: the { ResultCode, ResultValue } envelope carries success (1) / not-found (0).
+            return Results.Ok(result);
+        })
+        .WithName("GetLegacyAppraisalResult")
+        .WithTags("Integration - Appraisal Results")
+        .AllowAnonymous()
+        .Produces<LegacyAppraisalResultEnvelope>(StatusCodes.Status200OK);
+    }
+}

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultQueryHandler.cs
@@ -1,0 +1,395 @@
+using System.Data;
+using System.Globalization;
+using Appraisal.Domain.Appraisals;
+using Appraisal.Domain.Projects;
+using Dapper;
+using Shared.CQRS;
+using Shared.Data;
+
+namespace Integration.Application.Features.AppraisalResults.GetAppraisalResult;
+
+// Serves the legacy (AS400) flat { ResultCode, ResultValue } contract for ONE collateral, selected by
+// ApplicationNo (= AppraisalNumber) + Filter1/Filter2. Any miss (not found / no matching collateral /
+// error) returns ResultCode = 0 with an empty ResultValue rather than throwing.
+public class GetLegacyAppraisalResultQueryHandler(
+    ISqlConnectionFactory connectionFactory
+) : IQueryHandler<GetLegacyAppraisalResultQuery, LegacyAppraisalResultEnvelope>
+{
+    private const int Success = 1;
+    private const int NotFoundOrError = 0;
+
+    public async Task<LegacyAppraisalResultEnvelope> Handle(
+        GetLegacyAppraisalResultQuery query,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var conn = connectionFactory.GetOpenConnection();
+
+            var headerParams = new DynamicParameters();
+            headerParams.Add("AppraisalNumber", query.ApplicationNo);
+            var header = await conn.QuerySingleOrDefaultAsync<LegacyAppraisalRow>(
+                new CommandDefinition(GetAppraisalResultSql.LegacyByAppraisalNumber, headerParams,
+                    cancellationToken: cancellationToken));
+
+            if (header is null) return Empty();
+
+            var assignmentParams = new DynamicParameters();
+            assignmentParams.Add("AppraisalId", header.Id);
+            var assignment = await conn.QueryFirstOrDefaultAsync<AssignmentRow>(
+                new CommandDefinition(GetAppraisalResultSql.ActiveAssignment, assignmentParams,
+                    cancellationToken: cancellationToken));
+
+            decimal? fee = null;
+            if (assignment is not null)
+            {
+                var feeParams = new DynamicParameters();
+                feeParams.Add("AssignmentId", assignment.AssignmentId);
+                fee = await conn.QueryFirstOrDefaultAsync<decimal?>(
+                    new CommandDefinition(GetAppraisalResultSql.Fee, feeParams, cancellationToken: cancellationToken));
+            }
+
+            var valParams = new DynamicParameters();
+            valParams.Add("AppraisalId", header.Id);
+            var valuation = await conn.QueryFirstOrDefaultAsync<ValuationRow>(
+                new CommandDefinition(GetAppraisalResultSql.ValuationTotals, valParams,
+                    cancellationToken: cancellationToken));
+
+            // Block/project appraisal? (1:1 row in appraisal.Projects — has no AppraisalProperty rows.)
+            var projParams = new DynamicParameters();
+            projParams.Add("AppraisalId", header.Id);
+            var project = await conn.QueryFirstOrDefaultAsync<ProjectRow>(
+                new CommandDefinition(GetAppraisalResultSql.ProjectByAppraisalId, projParams,
+                    cancellationToken: cancellationToken));
+
+            LegacyAppraisalResult? result;
+            if (project is not null)
+            {
+                // Condo block selects by Room(Filter1)+Floor(Filter2); land/building block by Plot(Filter2).
+                var selector = new UnitSelector(
+                    PlotNumber: query.Filter2,
+                    RoomNumber: query.Filter1,
+                    FloorNumber: query.Filter2);
+                var unit = await AppraisalResultBuilder.ResolveBlockUnitAsync(
+                    conn, project, selector, strict: false, cancellationToken);
+                if (unit is null) return Empty();
+                result = LegacyResultMapper.MapBlock(header, assignment, fee, valuation, project, unit);
+            }
+            else
+            {
+                var groupParams = new DynamicParameters();
+                groupParams.Add("AppraisalId", header.Id);
+                var rows = (await conn.QueryAsync<CollateralRow>(
+                    new CommandDefinition(GetAppraisalResultSql.GroupsAndCollaterals, groupParams,
+                        cancellationToken: cancellationToken))).ToList();
+
+                // Condo: single-row match on Room(Filter1)+Floor(Filter2).
+                var condo = LegacyResultMapper.SelectCondo(rows, query.Filter1, query.Filter2);
+                if (condo is not null)
+                {
+                    result = LegacyResultMapper.MapCondo(header, assignment, fee, valuation, condo);
+                }
+                else
+                {
+                    // Non-condo: House(Filter1) is on the building row, Title(Filter2) on the land row —
+                    // possibly two rows in the same group — so match at group level and combine.
+                    var group = LegacyResultMapper.SelectNonCondoGroup(rows, query.Filter1, query.Filter2);
+                    if (group is null) return Empty();
+                    result = LegacyResultMapper.MapNonCondoCombined(
+                        header, assignment, fee, valuation, group.Value.Land, group.Value.Building, group.Value.GroupLandValue);
+                }
+            }
+
+            return new LegacyAppraisalResultEnvelope(Success, result);
+        }
+        catch
+        {
+            // Legacy contract: never surface a 500 — any failure is an empty ResultCode = 0 result.
+            return Empty();
+        }
+    }
+
+    private static LegacyAppraisalResultEnvelope Empty() =>
+        new(NotFoundOrError, new LegacyAppraisalResult());
+}
+
+internal static class LegacyResultMapper
+{
+    private static readonly string[] CondoCodes = ["U", "LSU"];
+    private static readonly string[] LandCodes = ["L", "LB", "LSL", "LS"];
+    private static readonly string[] BuildingCodes = ["B", "LB", "LSB", "LS"];
+
+    // Condo: single collateral row matched by Room(Filter1) + Floor(Filter2).
+    public static CollateralRow? SelectCondo(IEnumerable<CollateralRow> rows, string? filter1, string? filter2)
+    {
+        foreach (var r in rows)
+        {
+            if (IsCondo(r.PropertyType) && Eq(r.RoomNo, filter1) && Eq(r.FloorNo, filter2))
+                return r;
+        }
+
+        return null;
+    }
+
+    // Non-condo: House(Filter1) lives on the building row, Title(Filter2) on the land row. A collateral
+    // may be one combined LB row OR a separate L + B pair sharing a PropertyGroup, so match at group
+    // level and return the land-bearing and building-bearing rows (either may be null for pure L / B).
+    public static (CollateralRow? Land, CollateralRow? Building, decimal? GroupLandValue)? SelectNonCondoGroup(
+        IEnumerable<CollateralRow> rows, string? filter1, string? filter2)
+    {
+        var wantHouse = !string.IsNullOrWhiteSpace(filter1);
+        var wantTitle = !string.IsNullOrWhiteSpace(filter2);
+
+        foreach (var group in rows.Where(r => !IsCondo(r.PropertyType)).GroupBy(r => r.GroupId))
+        {
+            var landRow = group.FirstOrDefault(r => HasLand(r.PropertyType) && (!wantTitle || Eq(r.TitleNo, filter2)));
+            var buildingRow = group.FirstOrDefault(r => HasBuilding(r.PropertyType) && (!wantHouse || Eq(r.HouseNo, filter1)));
+
+            var titleOk = !wantTitle || landRow is not null;
+            var houseOk = !wantHouse || buildingRow is not null;
+            var anyMatched = (wantTitle && landRow is not null) || (wantHouse && buildingRow is not null);
+
+            if (titleOk && houseOk && anyMatched)
+                return (landRow, buildingRow, group.First().GroupLandValue);
+        }
+
+        return null;
+    }
+
+    public static LegacyAppraisalResult MapCondo(
+        LegacyAppraisalRow header, AssignmentRow? assignment, decimal? fee, ValuationRow? valuation, CollateralRow row)
+    {
+        var valuer = SplitValuer(assignment, valuation);
+
+        return BaseResult(header, fee, valuation, valuer) with
+        {
+            AppraisalValue = valuation?.AppraisedValue ?? 0m,
+            ForceSaleValue = valuation?.ForcedSaleValue ?? 0m,
+            LandOffice = Str(row.LandOfficeName ?? row.CadLandOfficeName),
+            LandValue = row.GroupLandValue ?? 0m,
+            LandNo = Str(row.LandNo),
+            TitleNo = Str(row.CondoBuiltOnTitleNo),   // condo title = the land title it is built on
+            Rawang = Str(row.Rawang),
+            SurveyNo = Str(row.SurveyNo),
+            BookNo = Str(row.BookNo),
+            PageNo = Str(row.PageNo),
+            Rai = row.Rai ?? 0m,
+            Ngan = row.Ngan ?? 0m,
+            Wah = row.Wa ?? 0m,
+            RoomNo = Str(row.RoomNo),
+            FloorNo = Str(row.FloorNo),                 // the unit's own floor
+            FloorNumber = NumStr(row.CondoTotalFloor),  // total floors of the building
+            BuildingNo = Str(row.BuildingNo),
+            BuildingAge = row.CondoBuildingAge ?? row.BuildingAge ?? 0,
+            AreaUtilize = row.AreaUtilize ?? 0m,
+            BuildingDetails = Str(row.CondoName),
+            BuildingRegisterNo = Str(row.CondoRegistrationNumber),
+            Decorate = ParseDecorate(row.CondoDecorationType),
+        };
+    }
+
+    // Combines a group's land-bearing row (title/land/area) and building-bearing row (house/building/
+    // decorate). A combined LB row is passed as both `land` and `building`.
+    public static LegacyAppraisalResult MapNonCondoCombined(
+        LegacyAppraisalRow header, AssignmentRow? assignment, decimal? fee, ValuationRow? valuation,
+        CollateralRow? land, CollateralRow? building, decimal? groupLandValue)
+    {
+        var valuer = SplitValuer(assignment, valuation);
+
+        return BaseResult(header, fee, valuation, valuer) with
+        {
+            AppraisalValue = valuation?.AppraisedValue ?? 0m,
+            ForceSaleValue = valuation?.ForcedSaleValue ?? 0m,
+            LandOffice = Str(land?.LandOfficeName ?? building?.LandOfficeName),
+            LandValue = groupLandValue ?? 0m,
+            // Land row
+            LandNo = Str(land?.LandNo),
+            TitleNo = Str(land?.TitleNo),
+            Rawang = Str(land?.Rawang),
+            SurveyNo = Str(land?.SurveyNo),
+            BookNo = Str(land?.BookNo),
+            PageNo = Str(land?.PageNo),
+            Rai = land?.Rai ?? 0m,
+            Ngan = land?.Ngan ?? 0m,
+            Wah = land?.Wa ?? 0m,
+            // Building row
+            HouseNo = Str(building?.HouseNo),
+            BuildingNo = Str(building?.BuildingNo),
+            BuildingAge = building?.BuildingAge ?? 0,
+            FloorNumber = NumStr(building?.TotalFloor),   // total floors of the building
+            AreaUtilize = building?.TotalBuildingArea ?? 0m,
+            Decorate = ParseDecorate(building?.BuildingDecorationType),
+            BuildingDetails = Str(FirstNonEmpty(land?.Village, building?.CondoName)),
+        };
+    }
+
+    public static LegacyAppraisalResult MapBlock(
+        LegacyAppraisalRow header, AssignmentRow? assignment, decimal? fee, ValuationRow? valuation,
+        ProjectRow project, BlockUnitRow unit)
+    {
+        var valuer = SplitValuer(assignment, valuation);
+        var isCondo = ProjectType.IsCondoCode(project.ProjectType);
+        var (rai, ngan, wa) = SqWaToRaiNganWa(unit.LandArea);
+
+        return BaseResult(header, fee, valuation, valuer) with
+        {
+            AppraisalValue = unit.TotalAppraisalValueRounded ?? valuation?.AppraisedValue ?? 0m,
+            ForceSaleValue = unit.ForceSellingPrice ?? valuation?.ForcedSaleValue ?? 0m,
+            // Block insurance = the unit's coverage amount (falls back to appraisal-level fire insurance).
+            BuildingValue = unit.CoverageAmount ?? valuation?.InsuranceValue ?? 0m,
+            // Block market value = the unit's own selling price (falls back to the request-level total).
+            MarketValue = unit.SellingPrice ?? header.MarketValue ?? 0m,
+            // Project-level descriptors.
+            BuildingDetails = Str(project.ProjectName),
+            Developer = Str(project.Developer),
+            TitleNo = Str(project.BuiltOnTitleDeedNumber),
+            LandOffice = Str(project.LandOfficeName),
+            // Per-unit identity.
+            LandNo = isCondo ? "" : Str(unit.PlotNumber),
+            HouseNo = isCondo ? "" : Str(unit.HouseNumber),
+            RoomNo = isCondo ? Str(unit.UnitRoomNo ?? unit.RoomNumber) : "",
+            FloorNo = isCondo ? IntStr(unit.Floor) : "",                       // the unit's own floor
+            FloorNumber = IntStr(unit.TowerFloors ?? unit.NumberOfFloors),     // total floors (from the tower)
+            BuildingAge = unit.TowerBuildingAge ?? 0,
+            BuildingNo = isCondo ? Str(unit.TowerName) : "",
+            BuildingRegisterNo = isCondo ? Str(unit.CondoRegistrationNumber) : "",
+            Decorate = ParseDecorate(unit.DecorationType),
+            AreaUtilize = unit.UsableArea ?? 0m,
+            Rai = rai,
+            Ngan = ngan,
+            Wah = wa,
+        };
+    }
+
+    // Thai land area: 1 rai = 4 ngan = 400 sq.wa; 1 ngan = 100 sq.wa. Splits a total in sq.wa.
+    private static (decimal Rai, decimal Ngan, decimal Wa) SqWaToRaiNganWa(decimal? totalSqWa)
+    {
+        if (totalSqWa is not { } total || total <= 0m) return (0m, 0m, 0m);
+
+        var rai = Math.Floor(total / 400m);
+        var afterRai = total - rai * 400m;
+        var ngan = Math.Floor(afterRai / 100m);
+        var wa = afterRai - ngan * 100m;
+        return (rai, ngan, wa);
+    }
+
+    // Appraisal-level fields shared by both paths (identity, fee, dates, address, valuer, type).
+    private static LegacyAppraisalResult BaseResult(
+        LegacyAppraisalRow header, decimal? fee, ValuationRow? valuation, ValuerSplit valuer)
+    {
+        var appraisalDate = IsoDate(valuation?.ValuationDate ?? header.CompletedAt);
+
+        return new LegacyAppraisalResult
+        {
+            AppraisalReportNo = Str(header.AppraisalNumber),
+            AppraisalFee = fee ?? 0m,
+            SequenceOfApprove = Str(header.SequenceOfApprove),
+            AppraisalType = MapAppraisalType(header.AppraisalType),
+            MethodOfAppraisal = 1, // TODO revisit: currently a fixed default per the legacy contract.
+            MarketValue = header.MarketValue ?? 0m,
+            BuildingValue = valuation?.InsuranceValue ?? 0m, // legacy BuildingValue = fire-insurance value
+            Province = Str(header.Province),
+            District = Str(header.District),
+            SubDistrict = Str(header.SubDistrict),
+            AppraisalDate = appraisalDate,
+            InternalValuerCode = valuer.InternalCode,
+            InternalValuerName = valuer.InternalName,
+            InternalValuation = valuer.InternalValue,
+            InternalValuationDate = valuer.InternalDate,
+            ExternalValuerCode = valuer.ExternalCode,
+            ExternalValuerName = valuer.ExternalName,
+            ExternalValuation = valuer.ExternalValue,
+            ExternalValuationDate = valuer.ExternalDate,
+        };
+    }
+
+    private static ValuerSplit SplitValuer(AssignmentRow? assignment, ValuationRow? valuation)
+    {
+        if (assignment is null) return new ValuerSplit();
+
+        var value = valuation?.AppraisedValue ?? 0m;
+        var date = IsoDate(valuation?.ValuationDate);
+
+        if (string.Equals(assignment.AssignmentType, AssignmentType.External.Code, StringComparison.OrdinalIgnoreCase))
+        {
+            return new ValuerSplit
+            {
+                ExternalCode = Str(assignment.CompanyCode),
+                ExternalName = Str(assignment.CompanyName),
+                ExternalValue = value,
+                ExternalDate = date,
+            };
+        }
+
+        if (string.Equals(assignment.AssignmentType, AssignmentType.Internal.Code, StringComparison.OrdinalIgnoreCase))
+        {
+            var fullName = $"{assignment.UserFirstName} {assignment.UserLastName}".Trim();
+            return new ValuerSplit
+            {
+                InternalCode = Str(assignment.EmployeeId),
+                InternalName = fullName,
+                InternalValue = value,
+                InternalDate = date,
+            };
+        }
+
+        return new ValuerSplit();
+    }
+
+    private static int MapAppraisalType(string? type) => type switch
+    {
+        AppraisalTypes.New => 1,
+        AppraisalTypes.ReAppraisal => 2,
+        AppraisalTypes.Progressive => 3,
+        AppraisalTypes.PreAppraisal => 4,
+        _ => 0,
+    };
+
+    // Legacy Decorate is our DecorationType code with the leading zero stripped ("01" → 1, "99" → 99).
+    // Returns null when there is no usable value (the legacy contract wants null, not 0, for "unknown").
+    private static int? ParseDecorate(string? code) =>
+        int.TryParse(code, NumberStyles.Integer, CultureInfo.InvariantCulture, out var v) ? v : null;
+
+    private static bool IsCondo(string? propertyType) =>
+        propertyType is not null && CondoCodes.Contains(propertyType, StringComparer.OrdinalIgnoreCase);
+
+    private static bool HasLand(string? propertyType) =>
+        propertyType is not null && LandCodes.Contains(propertyType, StringComparer.OrdinalIgnoreCase);
+
+    private static bool HasBuilding(string? propertyType) =>
+        propertyType is not null && BuildingCodes.Contains(propertyType, StringComparer.OrdinalIgnoreCase);
+
+    private static string? FirstNonEmpty(params string?[] values) =>
+        values.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
+
+    private static bool Eq(string? a, string? b) =>
+        string.Equals((a ?? string.Empty).Trim(), (b ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase);
+
+    private static string Str(string? value) => value ?? string.Empty;
+
+    private static string IntStr(int? value) =>
+        value?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
+
+    // Formats a numeric count as a string, dropping the decimal part when it is a whole number.
+    private static string NumStr(decimal? value) =>
+        value is null
+            ? string.Empty
+            : (value.Value == Math.Truncate(value.Value)
+                ? ((long)value.Value).ToString(CultureInfo.InvariantCulture)
+                : value.Value.ToString(CultureInfo.InvariantCulture));
+
+    private static string IsoDate(DateTime? value) =>
+        value?.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture) ?? string.Empty;
+
+    private sealed record ValuerSplit
+    {
+        public string InternalCode { get; init; } = "";
+        public string InternalName { get; init; } = "";
+        public decimal InternalValue { get; init; }
+        public string InternalDate { get; init; } = "";
+        public string ExternalCode { get; init; } = "";
+        public string ExternalName { get; init; } = "";
+        public decimal ExternalValue { get; init; }
+        public string ExternalDate { get; init; } = "";
+    }
+}


### PR DESCRIPTION
## What

Adds `POST /api/v1/appraisals/result`, serving the flat `{ ResultCode, ResultValue }` envelope the AS400 consumer expects for **one** collateral, selected by `ApplicationNo` (= `AppraisalNumber`) plus `Filter1`/`Filter2`. `AssetTypeId` is accepted but currently ignored.

The two existing JSON result endpoints move to `/api/v2/...` to free the v1 path for the legacy shape.

### Selection logic

Three paths, in `LegacyResultMapper`:

| Path | Selector | Notes |
|---|---|---|
| block/project | Room(`Filter1`) + Floor(`Filter2`) for condo towers; Plot(`Filter2`) for land/building | reuses `ResolveBlockUnitAsync` (widened `private` → `internal`) |
| condo | single row on Room + Floor | |
| non-condo | matched at **PropertyGroup** level | House lives on the building row and Title on the land row — possibly two rows in one group — so they are matched together and combined |

Supporting query work: a legacy header query resolving DOPA geocodes to Thai names, `LandOffice` code→description resolution, tower/model columns for block units, and the committee meeting number as `SequenceOfApprove`.

---

## ⚠️ Three things the reviewer must weigh in on

### 1. Breaking change for external consumers — no alias

`/api/v1/appraisals/result` and `/api/v1/appraisals/{appraisalNumber}/result` move to `v2` with **no backward-compatible alias**. Any LOS/AS400 caller on the old paths breaks the moment this deploys and must be cut over.

Nothing inside either repo consumes them — `git grep "v1/appraisals"` finds only the untouched `GetAppraisalStatusEndpoint.cs:13`; the frontend never calls them; there are no references in `docs/`, `docs/load-test/` k6 scripts, `.http` files, or `Tests/`. So the risk is entirely external and needs coordination, not a code change.

`docs/security-review/SECURITY-REVIEW-2026-06-08.md:111` already flagged an earlier un-aliased v1 route rename (`/appraisal/` → `/appraisals/`) as exactly this class of risk.

Side effect: the Integration module now mixes versions on one resource family — `/api/v1/appraisals/{n}/status`, `/api/v2/appraisals/{n}/result`, `/api/v1/appraisals/result`.

### 2. Known limitation — `InternalValuerCode` ships empty

Nothing in the codebase writes `ApplicationUser.EmployeeId`. There is no admin endpoint, seeder, or LDAP sync, so `SplitValuer` → `InternalCode = Str(assignment.EmployeeId)` returns `""` for **every** internal assignment until the LDAP-sync follow-up lands. Shipping this way is a deliberate call.

Worth knowing: the value is already obtainable today without waiting. The assignment SQL joins `auth.AspNetUsers u ON u.UserName = aa.AssigneeUserId`, and `UserLookupService.cs:89` / `SearchRequestorsQueryHandler.cs:98` already treat `UserName` as the bank employee code (`"P5229"`). A one-line change closes the gap whenever we want it:

```sql
COALESCE(u.EmployeeId, aa.AssigneeUserId) AS EmployeeId
```

That stays forward-compatible — an LDAP-sourced code that differs from the username still wins once populated.

### 3. Unauthenticated endpoint — accepted risk

`GetLegacyAppraisalResultEndpoint.cs:36` is `.AllowAnonymous()`. It is the **only anonymous endpoint in the entire Integration module** — every sibling, including the two just renamed to v2, uses `.RequireAuthorization("Integration")`.

It returns appraisal values, force-sale values, valuer names and full addresses to anything that can reach the host. Accepted because the AS400 caller cannot present a token.

**This must be restricted by source IP at the F5/load-balancer layer before UAT or production exposure.** Please do not merge-and-deploy without that control in place.

---

## Other notes

- The handler swallows **all** exceptions and returns `{ ResultCode: 0, ResultValue: {…empty…} }`, per the legacy contract's no-500 requirement. Consequence for debugging: a genuine bug is indistinguishable from "not found" in testing. Consider whether a log line on the catch is wanted before merge.
- `MethodOfAppraisal` is hardcoded to `1` with a `TODO revisit` — carried over from the legacy contract.

## Testing

- `dotnet build --configuration Release` — 0 errors.
- No automated coverage. There is **no unit-test project for the Integration module** at all, so `LegacyResultMapper` has no natural home today; `Tests/Unit/` has one csproj per other module.
- Suggested manual check: POST a known completed appraisal number for each of the three selection paths and diff against the AS400 field spec; confirm a bad `ApplicationNo` returns `ResultCode: 0` rather than a 500.

## Deployment

Apply the Auth migration `20260726134432_AddEmployeeIdToApplicationUser` through the normal deploy path rather than `dotnet ef database update` by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoSUNxSXysEMgWY6kQrjA2
