### PR TITLE
fix(reporting): repeat headers on block summary unit tables, split condo room fields

### DIFF
--- a/Modules/Reporting/Reporting/Application/Models/AppraisalSummaryModel.cs
+++ b/Modules/Reporting/Reporting/Application/Models/AppraisalSummaryModel.cs
@@ -676,6 +676,11 @@ public sealed class BlockCondoUnitRow
     public int Sequence { get; init; }
     public int? Floor { get; init; }
     public string? TowerName { get; init; }
+
+    /// <summary>ห้องชุดเลขที่ (field 54) — the condo registration number on the unit title.</summary>
+    public string? CondoRegistrationNumber { get; init; }
+
+    /// <summary>ห้องชุด (field 56) — the room number as marketed/labelled.</summary>
     public string? RoomNumber { get; init; }
     public string? ModelType { get; init; }
     public decimal? UsableArea { get; init; }

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryBlockDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryBlockDataProvider.cs
@@ -161,6 +161,7 @@ public sealed class AppraisalSummaryBlockDataProvider(
                 u.SellingPrice,
                 u.Floor,
                 u.TowerName,
+                u.CondoRegistrationNumber,
                 u.RoomNumber,
                 up.TotalAppraisalValueRounded  AS AppraisalValue,
                 up.StandardPrice               AS PricePerSqm,
@@ -309,6 +310,7 @@ public sealed class AppraisalSummaryBlockDataProvider(
                     Sequence       = u.SequenceNumber,
                     Floor          = u.Floor,
                     TowerName      = u.TowerName,
+                    CondoRegistrationNumber = u.CondoRegistrationNumber,
                     RoomNumber     = u.RoomNumber,
                     ModelType      = u.ModelType,
                     UsableArea     = u.UsableArea,
@@ -659,6 +661,7 @@ public sealed class AppraisalSummaryBlockDataProvider(
         // Condo-side
         public int?     Floor           { get; init; }
         public string?  TowerName       { get; init; }
+        public string?  CondoRegistrationNumber { get; init; }
         public string?  RoomNumber      { get; init; }
         // Prices (from LEFT JOIN ProjectUnitPrices)
         public decimal? AppraisalValue  { get; init; }

--- a/Modules/Reporting/Reporting/Templates/partials/summary-block-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-block-body.html
@@ -4,12 +4,21 @@
   Shares the parent Scriban scope; expects: model.* (AppraisalSummaryModel snake_case fields).
 -->
 <style>
-  .unit-table { width:100%; border-collapse:collapse; font-size:9.5pt; margin-top:6px; }
+  /* Each unit section starts a new PORTRAIT page (the default @page) and opens its own
+     table.running, so the report header bar repeats on every page the section spans. */
+  .unit-page { break-before: page; }
+  /* 10–11 columns on portrait A4: 7pt + tight padding is what keeps the numeric columns on
+     one line at the 15mm margin appraisal-book.html uses (the standalone form gets 5mm). */
+  .unit-table { width:100%; border-collapse:collapse; font-size:7pt; margin-top:6px;
+                table-layout:fixed; }
   .unit-table th,
-  .unit-table td { border:1px solid #888; padding:3px 5px; }
+  .unit-table td { border:1px solid #888; padding:2px 3px; overflow-wrap:anywhere; }
   .unit-table th { background:#f0f0f0; text-align:center; font-weight:bold; }
+  /* Repeat the column headers on each page the unit table spans — a long unit list runs to
+     several pages and the trailing ones are unreadable without them. */
+  .unit-table thead { display:table-header-group; }
   .unit-table td.c { text-align:center; }
-  .unit-table td.r { text-align:right; }
+  .unit-table td.r { text-align:right; white-space:nowrap; }
 
   /* รายการทรัพย์สิน (FSD §2.1.5 fields 10–21): one bordered box — full-width header cell,
      fixed label column, value column. "Open rows": no horizontal rules between rows 10–20,
@@ -94,29 +103,32 @@
   <!-- ════ COMMITTEE BLOCK — own page-break unit ════ -->
   {{ include 'partials/approver-block' }}
 
-  <!-- Close the running-table BEFORE the landscape unit tables: a table cannot host the
-       landscape @page break, and the unit tables intentionally carry no repeating header. -->
+  <!-- Close the running-table BEFORE the unit tables: each unit section opens its own
+       running-table so the header bar repeats across the pages that section spans. -->
   {{ include 'partials/summary-page-close' }}
 
   <!-- ════ UNIT TABLE: LB / Land ════ -->
   {{ if model.building_units.size > 0 }}
-  <div class="landscape-page">
-  <div class="section-bar">
+  <div class="unit-page">
+  <table class="running">
+    <thead><tr><td>{{ include 'partials/summary-head-bar' }}</td></tr></thead>
+    <tbody><tr><td>
+  <div class="section-bar center">
     สรุปราคาประเมินรายแปลง เพื่อสนับสนุนรายย่อยโครงการ
   </div>
   <table class="unit-table">
     <thead>
       <tr>
-        <th style="width:38px;">ลำดับ</th>
-        <th>แปลงเลขที่</th>
-        <th>บ้านเลขที่</th>
+        <th style="width:34px;">ลำดับ</th>
+        <th style="width:58px;">แปลงเลขที่</th>
+        <th style="width:58px;">บ้านเลขที่</th>
         <th>แบบบ้าน</th>
-        <th style="width:70px;">เนื้อที่ดิน<br/>(ตร.วา)</th>
-        <th style="width:70px;">พื้นที่ใช้สอย<br/>(ตร.ม.)</th>
-        <th style="width:90px;">ราคาขาย<br/>(บาท)</th>
-        <th style="width:90px;">ราคาประเมิน<br/>(บาท)</th>
-        <th style="width:90px;">ราคาบังคับขาย<br/>(บาท)</th>
-        <th style="width:90px;">มูลค่าประกัน<br/>อัคคีภัย (บาท)</th>
+        <th style="width:52px;">เนื้อที่ดิน<br/>(ตร.วา)</th>
+        <th style="width:52px;">พื้นที่ใช้สอย<br/>(ตร.ม.)</th>
+        <th style="width:72px;">ราคาขาย<br/>(บาท)</th>
+        <th style="width:72px;">ราคาประเมิน<br/>(บาท)</th>
+        <th style="width:72px;">ราคาบังคับขาย<br/>(บาท)</th>
+        <th style="width:72px;">มูลค่าประกัน<br/>อัคคีภัย (บาท)</th>
       </tr>
     </thead>
     <tbody>
@@ -125,9 +137,9 @@
         <td class="c">{{ u.sequence }}</td>
         <td class="c">{{ u.plot_number }}</td>
         <td class="c">{{ u.house_number }}</td>
-        <td>{{ u.model_type }}</td>
-        <td class="r">{{ if u.land_area; u.land_area | math.format "N2"; end }}</td>
-        <td class="r">{{ if u.usable_area; u.usable_area | math.format "N2"; end }}</td>
+        <td class="c">{{ u.model_type }}</td>
+        <td class="c">{{ if u.land_area; u.land_area | math.format "N2"; end }}</td>
+        <td class="c">{{ if u.usable_area; u.usable_area | math.format "N2"; end }}</td>
         <td class="r">{{ if u.selling_price; u.selling_price | math.format "N2"; end }}</td>
         <td class="r">{{ if u.appraisal_value; u.appraisal_value | math.format "N2"; end }}</td>
         <td class="r">{{ if u.forced_sale_value; u.forced_sale_value | math.format "N2"; end }}</td>
@@ -136,28 +148,34 @@
       {{ end }}
     </tbody>
   </table>
-  </div><!-- .landscape-page -->
+    </td></tr></tbody>
+  </table>
+  </div><!-- .unit-page -->
   {{ end }}
 
   <!-- ════ UNIT TABLE: Condo ════ -->
   {{ if model.condo_units.size > 0 }}
-  <div class="landscape-page">
-  <div class="section-bar">
+  <div class="unit-page">
+  <table class="running">
+    <thead><tr><td>{{ include 'partials/summary-head-bar' }}</td></tr></thead>
+    <tbody><tr><td>
+  <div class="section-bar center">
     สรุปราคาประเมินรายยูนิต เพื่อสนับสนุนรายย่อยโครงการ
   </div>
   <table class="unit-table">
     <thead>
       <tr>
-        <th style="width:38px;">ลำดับ</th>
-        <th style="width:40px;">ชั้นที่</th>
-        <th>อาคาร</th>
-        <th>ห้องชุดเลขที่</th>
+        <th style="width:34px;">ลำดับ</th>
+        <th style="width:34px;">ชั้นที่</th>
+        <th style="width:46px;">อาคาร</th>
+        <th style="width:56px;">ห้องชุดเลขที่</th>
         <th>แบบห้องชุด</th>
-        <th style="width:70px;">พื้นที่ใช้สอย<br/>(ตร.ม.)</th>
-        <th style="width:90px;">ราคาประเมิน<br/>(บาท)</th>
-        <th style="width:80px;">ราคา/ตร.ม.<br/>(บาท)</th>
-        <th style="width:90px;">ราคาบังคับขาย<br/>(บาท)</th>
-        <th style="width:90px;">มูลค่าประกัน<br/>อัคคีภัย (บาท)</th>
+        <th style="width:46px;">ห้องชุด</th>
+        <th style="width:52px;">พื้นที่ใช้สอย<br/>(ตร.ม.)</th>
+        <th style="width:72px;">ราคาประเมิน<br/>(บาท)</th>
+        <th style="width:60px;">ราคา/ตร.ม.<br/>(บาท)</th>
+        <th style="width:72px;">ราคาบังคับขาย<br/>(บาท)</th>
+        <th style="width:72px;">มูลค่าประกัน<br/>อัคคีภัย (บาท)</th>
       </tr>
     </thead>
     <tbody>
@@ -166,9 +184,10 @@
         <td class="c">{{ u.sequence }}</td>
         <td class="c">{{ u.floor }}</td>
         <td class="c">{{ u.tower_name }}</td>
+        <td class="c">{{ u.condo_registration_number }}</td>
+        <td class="c">{{ u.model_type }}</td>
         <td class="c">{{ u.room_number }}</td>
-        <td>{{ u.model_type }}</td>
-        <td class="r">{{ if u.usable_area; u.usable_area | math.format "N2"; end }}</td>
+        <td class="c">{{ if u.usable_area; u.usable_area | math.format "N2"; end }}</td>
         <td class="r">{{ if u.appraisal_value; u.appraisal_value | math.format "N2"; end }}</td>
         <td class="r">{{ if u.price_per_sqm; u.price_per_sqm | math.format "N2"; end }}</td>
         <td class="r">{{ if u.forced_sale_value; u.forced_sale_value | math.format "N2"; end }}</td>
@@ -177,7 +196,9 @@
       {{ end }}
     </tbody>
   </table>
-  </div><!-- .landscape-page -->
+    </td></tr></tbody>
+  </table>
+  </div><!-- .unit-page -->
   {{ end }}
 
 </div>


### PR DESCRIPTION
## The problem

The per-unit tables in the block summary rendered as `.landscape-page` sections with no repeating header. A long unit list spills across several pages, and every page after the first arrived with **neither** the report header bar **nor** the column headers — leaving the trailing pages unreadable on their own.

Separately, the condo unit table conflated two distinct FSD fields: ห้องชุดเลขที่ (field 54, the condo registration number on the unit title) and ห้องชุด (field 56, the room number as marketed). Only one column existed.

## The fix

**Layout.** Each unit section now starts a portrait page (`.unit-page`) and opens its own `table.running`, so the header bar repeats on every page that section spans. The unit table's `thead` becomes a `table-header-group` so the column headers repeat too.

Fitting 10–11 columns on portrait A4 at the 15mm margin `appraisal-book.html` uses required:
- font 9.5pt → 7pt, padding `3px 5px` → `2px 3px`
- `table-layout: fixed` with retuned per-column widths
- `overflow-wrap: anywhere` on cells, `white-space: nowrap` on the numeric (`.r`) columns

**Fields.** `BlockCondoUnitRow` gains `CondoRegistrationNumber`, plumbed through `AppraisalSummaryBlockDataProvider` (SQL projection, row type, and mapping), and the condo unit table gains a ห้องชุด column so both values show.

## Verified safe

- `partials/summary-head-bar.html` exists; `.section-bar.center` is defined at `summary-styles.html:108`.
- `.landscape-page` is still used by `partials/section-costmachine.html:39`, so removing it from this template breaks nothing else.
- `CondoRegistrationNumber` exists on `ProjectUnit` (`ProjectUnitConfiguration.cs:32`), so the new SQL projection is valid.

## Testing

`dotnet build --configuration Release` — 0 errors.

**This PR needs a rendered PDF before merge — a CSS change of this kind is not reviewable from the diff.** I have not rendered it (needs the infra stack and an appraisal with a long block unit list). What to check:

1. Header bar **and** column headers both repeat on page 2+ of a long unit list.
2. No numeric column wraps or clips at 7pt — the ราคาประเมิน / ราคาบังคับขาย / มูลค่าประกันอัคคีภัย columns are the tight ones.
3. ห้องชุดเลขที่ and ห้องชุด show different values on a condo block.
4. The LB/Land table still fits — it has one fewer column than the condo table, so it should be the safer of the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoSUNxSXysEMgWY6kQrjA2
