### PR TITLE
feat(reporting): project selling price per condo unit + committee column widths

### DIFF
--- a/Modules/Reporting/Reporting/Application/Models/AppraisalSummaryModel.cs
+++ b/Modules/Reporting/Reporting/Application/Models/AppraisalSummaryModel.cs
@@ -684,6 +684,9 @@ public sealed class BlockCondoUnitRow
     public string? RoomNumber { get; init; }
     public string? ModelType { get; init; }
     public decimal? UsableArea { get; init; }
+
+    /// <summary>ราคาขายโครงการ — the project's own advertised selling price for the unit.</summary>
+    public decimal? SellingPrice { get; init; }
     public decimal? AppraisalValue { get; init; }
     public decimal? PricePerSqm { get; init; }
     public decimal? ForcedSaleValue { get; init; }

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryBlockDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryBlockDataProvider.cs
@@ -314,6 +314,7 @@ public sealed class AppraisalSummaryBlockDataProvider(
                     RoomNumber     = u.RoomNumber,
                     ModelType      = u.ModelType,
                     UsableArea     = u.UsableArea,
+                    SellingPrice   = u.SellingPrice,
                     AppraisalValue = u.AppraisalValue,
                     PricePerSqm    = u.PricePerSqm,
                     ForcedSaleValue = u.ForcedSaleValue,

--- a/Modules/Reporting/Reporting/Templates/partials/approver-block.html
+++ b/Modules/Reporting/Reporting/Templates/partials/approver-block.html
@@ -35,8 +35,12 @@
   <tr>
     <th style="width:55px;">อนุมัติ</th>
     <th style="width:55px;">ไม่อนุมัติ</th>
-    <th>รายชื่อคณะกรรมการ (ลงนาม)</th>
-    <th style="width:230px;">ความเห็นเพิ่มเติม</th>
+    <!-- Sized to its content (130px signature line + 10px gap + the position text) rather than
+         left auto: as the auto column it swallowed all the slack and left ความเห็นเพิ่มเติม —
+         free text, the column that actually needs room — pinned at 230px. The table is not
+         table-layout:fixed, so an unusually long position still widens this column. -->
+    <th style="width:250px;">รายชื่อคณะกรรมการ (ลงนาม)</th>
+    <th>ความเห็นเพิ่มเติม</th>
   </tr>
   {{ for a in model.approvers }}
   <tr class="cm-row">

--- a/Modules/Reporting/Reporting/Templates/partials/summary-block-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-block-body.html
@@ -7,7 +7,7 @@
   /* Each unit section starts a new PORTRAIT page (the default @page) and opens its own
      table.running, so the report header bar repeats on every page the section spans. */
   .unit-page { break-before: page; }
-  /* 10–11 columns on portrait A4: 7pt + tight padding is what keeps the numeric columns on
+  /* 10–12 columns on portrait A4: 7pt + tight padding is what keeps the numeric columns on
      one line at the 15mm margin appraisal-book.html uses (the standalone form gets 5mm). */
   .unit-table { width:100%; border-collapse:collapse; font-size:7pt; margin-top:6px;
                 table-layout:fixed; }
@@ -165,17 +165,18 @@
   <table class="unit-table">
     <thead>
       <tr>
-        <th style="width:34px;">ลำดับ</th>
-        <th style="width:34px;">ชั้นที่</th>
-        <th style="width:46px;">อาคาร</th>
-        <th style="width:56px;">ห้องชุดเลขที่</th>
+        <th style="width:30px;">ลำดับ</th>
+        <th style="width:30px;">ชั้นที่</th>
+        <th style="width:40px;">อาคาร</th>
+        <th style="width:52px;">ห้องชุดเลขที่</th>
         <th>แบบห้องชุด</th>
-        <th style="width:46px;">ห้องชุด</th>
-        <th style="width:52px;">พื้นที่ใช้สอย<br/>(ตร.ม.)</th>
-        <th style="width:72px;">ราคาประเมิน<br/>(บาท)</th>
+        <th style="width:44px;">ห้องชุด</th>
+        <th style="width:48px;">พื้นที่ใช้สอย<br/>(ตร.ม.)</th>
+        <th style="width:70px;">ราคาขาย<br/>โครงการ (บาท)</th>
+        <th style="width:70px;">ราคาประเมิน<br/>(บาท)</th>
         <th style="width:60px;">ราคา/ตร.ม.<br/>(บาท)</th>
-        <th style="width:72px;">ราคาบังคับขาย<br/>(บาท)</th>
-        <th style="width:72px;">มูลค่าประกัน<br/>อัคคีภัย (บาท)</th>
+        <th style="width:70px;">ราคาบังคับขาย<br/>(บาท)</th>
+        <th style="width:70px;">มูลค่าประกัน<br/>อัคคีภัย (บาท)</th>
       </tr>
     </thead>
     <tbody>
@@ -188,6 +189,7 @@
         <td class="c">{{ u.model_type }}</td>
         <td class="c">{{ u.room_number }}</td>
         <td class="c">{{ if u.usable_area; u.usable_area | math.format "N2"; end }}</td>
+        <td class="r">{{ if u.selling_price; u.selling_price | math.format "N2"; end }}</td>
         <td class="r">{{ if u.appraisal_value; u.appraisal_value | math.format "N2"; end }}</td>
         <td class="r">{{ if u.price_per_sqm; u.price_per_sqm | math.format "N2"; end }}</td>
         <td class="r">{{ if u.forced_sale_value; u.forced_sale_value | math.format "N2"; end }}</td>


### PR DESCRIPTION
Two block/summary reporting tweaks. No migration, no entity/API change, no frontend work.

---

## 1. ราคาขายโครงการ column in the block condo unit table

Adds a **ราคาขายโครงการ (บาท)** column to the per-unit table of the block/project appraisal summary (`สรุปราคาประเมินรายยูนิต เพื่อสนับสนุนรายย่อยโครงการ`), immediately after `พื้นที่ใช้สอย (ตร.ม.)`.

| ลำดับ | ชั้นที่ | อาคาร | ห้องชุดเลขที่ | แบบห้องชุด | ห้องชุด | พื้นที่ใช้สอย | **ราคาขายโครงการ** | ราคาประเมิน | … |
|---|---|---|---|---|---|---|---|---|---|
| 1 | 5 | Tower A | CR-001 | 1BR-Standard-1 | A-501 | 35.50 | **3,500,000.00** | 4,000.00 | … |

**Why:** the table showed appraised value, price/sq.m., forced-sale price and fire-insurance value — but not the developer's own asking price for the unit, so a reviewer could not compare the two without leaving the report.

**Why it's small:** `appraisal.ProjectUnits.SellingPrice` already holds this value — it is a column in the condo unit Excel upload, it is already `SELECT`ed by the report's RS03 query and already on the provider's private `UnitPriceRow`, and the land-and-building unit table in the same report already renders it as `ราคาขาย`. Only the condo branch of the provider never mapped it.

- `Application/Models/AppraisalSummaryModel.cs` — `SellingPrice` added to `BlockCondoUnitRow`.
- `Application/Providers/AppraisalSummaryBlockDataProvider.cs` — one line, `SellingPrice = u.SellingPrice` in the `isCondo` branch.
- `Templates/partials/summary-block-body.html` — new `<th>`/`<td>` pair using the same right-aligned `N2` convention as the other money columns, plus a retune of the fixed column widths (11 → 12 columns on portrait A4; rebalanced so the four money columns still hold an 8-digit `N2` value on one line at the 15mm margin `appraisal-book.html` uses). The LB table's widths are untouched.

## 2. Committee name column sized to its content

In the committee block, `รายชื่อคณะกรรมการ (ลงนาม)` was the only column without a width, so it absorbed all the table's slack — roughly 430px for a 130px signature line plus a short position title — while `ความเห็นเพิ่มเติม`, the free-text column that actually needs the room, stayed pinned at 230px.

Swaps which column is auto: the name column gets a 250px preferred width, the comment column takes the remainder (~400px on the 5mm-margin summary forms). `table.grid` is not `table-layout:fixed`, so an unusually long position title still widens the name column rather than wrapping.

- `Templates/partials/approver-block.html`

⚠️ This partial is shared by **every** summary report (land-building, condo, construction, machine, block), so all of them get the new proportions.

## Verification

Both rendered end-to-end through the real PDF pipeline against live dev data and visually checked:

- **Unit table** — a block condo appraisal (`ProjectType = 'U'`) with populated unit selling prices, standalone `appraisal-summary-block` form (5mm margins): values right-aligned and thousands-separated, no cell overflow, `แบบห้องชุด` codes unwrapped, header repeats across pages, LB table unchanged.
- **Committee block** — an appraisal with 5 committee votes, `appraisal-summary-land-building` (5mm margins): measured 55 / 55 / 250 / ~400px against the previous 55 / 55 / ~430 / 230.

**Not verified:** the `appraisal-book` render (15mm margins — the tighter case for 12 columns). The book output for the test appraisal contained no unit-table page, so that path is unexercised. Worth a look if a block condo appraisal is ever rendered inside the book.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7aTHL144dH83KXxrRZfbK