### PR TITLE
fix(integration): PascalCase legacy result response + align valuation to AppraisalValue

### DIFF
--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultEndpoint.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultEndpoint.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Carter;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
@@ -16,6 +18,14 @@ public record LegacyAppraisalResultRequest(
 
 public class GetLegacyAppraisalResultEndpoint : ICarterModule
 {
+    // The legacy (AS400) contract uses PascalCase property names and keeps nulls, unlike the API's
+    // global camelCase / omit-null policy. Serialize this endpoint's response with these options only.
+    private static readonly JsonSerializerOptions LegacyJsonOptions = new()
+    {
+        PropertyNamingPolicy = null, // PascalCase — use the DTO property names as-is
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never, // keep nulls (e.g. Decorate: null)
+    };
+
     public void AddRoutes(IEndpointRouteBuilder app)
     {
         app.MapPost("/api/v1/appraisals/result", async (
@@ -29,7 +39,8 @@ public class GetLegacyAppraisalResultEndpoint : ICarterModule
                 cancellationToken);
 
             // Always 200: the { ResultCode, ResultValue } envelope carries success (1) / not-found (0).
-            return Results.Ok(result);
+            // PascalCase, nulls kept — per the legacy contract (overrides the global camelCase policy).
+            return Results.Json(result, LegacyJsonOptions, statusCode: StatusCodes.Status200OK);
         })
         .WithName("GetLegacyAppraisalResult")
         .WithTags("Integration - Appraisal Results")

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultQueryHandler.cs
@@ -159,11 +159,12 @@ internal static class LegacyResultMapper
     public static LegacyAppraisalResult MapCondo(
         LegacyAppraisalRow header, AssignmentRow? assignment, decimal? fee, ValuationRow? valuation, CollateralRow row)
     {
-        var valuer = SplitValuer(assignment, valuation);
+        var appraisalValue = valuation?.AppraisedValue ?? 0m;
+        var valuer = SplitValuer(assignment, appraisalValue, valuation?.ValuationDate);
 
         return BaseResult(header, fee, valuation, valuer) with
         {
-            AppraisalValue = valuation?.AppraisedValue ?? 0m,
+            AppraisalValue = appraisalValue,
             ForceSaleValue = valuation?.ForcedSaleValue ?? 0m,
             LandOffice = Str(row.LandOfficeName ?? row.CadLandOfficeName),
             LandValue = row.GroupLandValue ?? 0m,
@@ -194,11 +195,12 @@ internal static class LegacyResultMapper
         LegacyAppraisalRow header, AssignmentRow? assignment, decimal? fee, ValuationRow? valuation,
         CollateralRow? land, CollateralRow? building, decimal? groupLandValue)
     {
-        var valuer = SplitValuer(assignment, valuation);
+        var appraisalValue = valuation?.AppraisedValue ?? 0m;
+        var valuer = SplitValuer(assignment, appraisalValue, valuation?.ValuationDate);
 
         return BaseResult(header, fee, valuation, valuer) with
         {
-            AppraisalValue = valuation?.AppraisedValue ?? 0m,
+            AppraisalValue = appraisalValue,
             ForceSaleValue = valuation?.ForcedSaleValue ?? 0m,
             LandOffice = Str(land?.LandOfficeName ?? building?.LandOfficeName),
             LandValue = groupLandValue ?? 0m,
@@ -227,13 +229,14 @@ internal static class LegacyResultMapper
         LegacyAppraisalRow header, AssignmentRow? assignment, decimal? fee, ValuationRow? valuation,
         ProjectRow project, BlockUnitRow unit)
     {
-        var valuer = SplitValuer(assignment, valuation);
         var isCondo = ProjectType.IsCondoCode(project.ProjectType);
         var (rai, ngan, wa) = SqWaToRaiNganWa(unit.LandArea);
+        var appraisalValue = unit.TotalAppraisalValueRounded ?? valuation?.AppraisedValue ?? 0m;
+        var valuer = SplitValuer(assignment, appraisalValue, valuation?.ValuationDate);
 
         return BaseResult(header, fee, valuation, valuer) with
         {
-            AppraisalValue = unit.TotalAppraisalValueRounded ?? valuation?.AppraisedValue ?? 0m,
+            AppraisalValue = appraisalValue,
             ForceSaleValue = unit.ForceSellingPrice ?? valuation?.ForcedSaleValue ?? 0m,
             // Block insurance = the unit's coverage amount (falls back to appraisal-level fire insurance).
             BuildingValue = unit.CoverageAmount ?? valuation?.InsuranceValue ?? 0m,
@@ -303,12 +306,14 @@ internal static class LegacyResultMapper
         };
     }
 
-    private static ValuerSplit SplitValuer(AssignmentRow? assignment, ValuationRow? valuation)
+    // The internal/external valuation amount mirrors the result's AppraisalValue (per-unit for block),
+    // so the caller passes the resolved appraisal value rather than reading ValuationAnalyses directly.
+    private static ValuerSplit SplitValuer(AssignmentRow? assignment, decimal appraisalValue, DateTime? valuationDate)
     {
         if (assignment is null) return new ValuerSplit();
 
-        var value = valuation?.AppraisedValue ?? 0m;
-        var date = IsoDate(valuation?.ValuationDate);
+        var value = appraisalValue;
+        var date = IsoDate(valuationDate);
 
         if (string.Equals(assignment.AssignmentType, AssignmentType.External.Code, StringComparison.OrdinalIgnoreCase))
         {


### PR DESCRIPTION
## Summary

Two follow-up refinements to the legacy AS400 appraisal-result endpoint
(`POST /api/v1/appraisals/result`), on top of the feature already on `main` (`6e26625a`).

- **PascalCase response** — this endpoint now serializes in PascalCase and keeps `null`s via a
  dedicated `JsonSerializerOptions`, matching the AS400 contract (`{ "ResultCode": …, "ResultValue": { "LandNo": … } }`).
  The rest of the API keeps its global camelCase / omit-null policy; the v2 endpoints are unaffected.
- **Internal/External valuation = AppraisalValue** — the active valuer side's valuation amount now mirrors
  the resolved `AppraisalValue` (the **unit's** value for block appraisals) instead of
  `ValuationAnalyses.AppraisedValue`, so `InternalValuation`/`ExternalValuation` always equal `AppraisalValue`.

## Scope

Only 2 files (`GetLegacyAppraisalResultEndpoint.cs`, `GetLegacyAppraisalResultQueryHandler.cs`),
26 insertions / 10 deletions. No schema or v2 changes.

## Testing

- `dotnet build` green (Integration + full solution).
- Response verified as PascalCase with nulls preserved (e.g. `"Decorate": null`).
- Block path: `InternalValuation`/`ExternalValuation` now match the per-unit `AppraisalValue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
