### PR TITLE
fix(reporting): committee name column fits its title, and blank comments say so

### DIFF
--- a/Modules/Reporting/Reporting/Templates/partials/approver-block.html
+++ b/Modules/Reporting/Reporting/Templates/partials/approver-block.html
@@ -35,11 +35,13 @@
   <tr>
     <th style="width:55px;">อนุมัติ</th>
     <th style="width:55px;">ไม่อนุมัติ</th>
-    <!-- Sized to its content (130px signature line + 10px gap + the position text) rather than
-         left auto: as the auto column it swallowed all the slack and left ความเห็นเพิ่มเติม —
-         free text, the column that actually needs room — pinned at 230px. The table is not
-         table-layout:fixed, so an unusually long position still widens this column. -->
-    <th style="width:250px;">รายชื่อคณะกรรมการ (ลงนาม)</th>
+    <!-- Shrink-to-fit: width:1px on an auto-layout table collapses the column to its
+         min-content width, and the nowrap on .c-pos (summary-styles) makes that min-content
+         the full one-line width of the signature line + position title. So the column is
+         exactly as wide as the longest member row needs and never wraps a title, and
+         ความเห็นเพิ่มเติม — free text, the column that actually needs room — takes the rest
+         instead of being pinned at 230px. -->
+    <th style="width:1px;">รายชื่อคณะกรรมการ (ลงนาม)</th>
     <th>ความเห็นเพิ่มเติม</th>
   </tr>
   {{ for a in model.approvers }}

--- a/Modules/Reporting/Reporting/Templates/partials/approver-block.html
+++ b/Modules/Reporting/Reporting/Templates/partials/approver-block.html
@@ -49,7 +49,11 @@
     <td class="ctr"><span class="chk {{ if a.approved == true }}on{{ end }}"></span></td>
     <td class="ctr"><span class="chk {{ if a.approved == false }}on{{ end }}"></span></td>
     <td><div class="committee-member"><span class="nm-name">{{ a.name }}</span><span class="c-pos">{{ a.position }}</span></div></td>
-    <td>{{ a.comment }}</td>
+    <!-- Comments come straight off workflow.ApprovalVotes and are often null / blank; an empty
+         cell reads as "not filled in yet" on a signed-off form, so say it explicitly. Tested
+         against null AND "" rather than for mere truthiness: Scriban follows Liquid, where an
+         empty string is true. string.strip also catches whitespace-only comments. -->
+    <td>{{ cmt = a.comment | string.strip }}{{ if cmt == null || cmt == "" }}ไม่มีความเห็นเพิ่มเติม{{ else }}{{ cmt }}{{ end }}</td>
   </tr>
   {{ end }}
   <tr>

--- a/Modules/Reporting/Reporting/Templates/partials/summary-styles.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-styles.html
@@ -256,7 +256,11 @@ table.grid.comparison th:first-child, table.grid.comparison td:first-child { wid
 /* Committee member: signature line (with name) on the LEFT, position to the RIGHT. */
 .committee-member { display:flex; align-items:center; gap:10px; }
 .committee-member .nm-name { flex:0 0 130px; text-align:center; }
-.committee-member .c-pos { flex:1; text-align:left; }
+/* nowrap: a real Thai position title ("ประธานเจ้าหน้าที่บริหารปฏิบัติการ") has no spaces, so it
+   wraps at any ICU break and would silently fold to 2–3 lines inside whatever width the column
+   happened to get. Keeping it on one line is what lets the shrink-to-fit column in
+   approver-block size itself to the longest title instead of squeezing it. */
+.committee-member .c-pos { flex:1; text-align:left; white-space:nowrap; }
 /* Member rows: taller (room for a handwritten signature) and vertically centered. */
 table.grid tr.cm-row td { vertical-align:middle; padding-top:24px; padding-bottom:24px; }
 


### PR DESCRIPTION
Follow-up to #334 — two fixes to the committee block (`partials/approver-block.html`), which is shared by **every** summary report (land-building, condo, construction, machine, block).

---

## 1. รายชื่อคณะกรรมการ (ลงนาม) fits its content

#334 gave the column a 250px preferred width, on the assumption that a longer title would widen it. **It doesn't.** `.c-pos` is a flex item and a Thai position title has no spaces, so ICU breaks it at any character — the title quietly folded to 2–3 lines and inflated the member rows instead:

| | ประธานเจ้าหน้าที่บริหารปฏิบัติการ | หัวหน้ากลุ่มงานกฎหมายและกำกับดูแลธนาคาร |
|---|---|---|
| before | 2 lines | 3 lines |
| after | 1 line | 1 line |

Fix is two parts, and both are needed:

- `white-space:nowrap` on `.committee-member .c-pos` (`partials/summary-styles.html`) raises the cell's min-content width to the full one-line width of signature line + title.
- `width:1px` on the `<th>` collapses the column, on an auto-layout table, to exactly that min-content.

Net effect: the column is as wide as the longest member row needs — no more, no less — and `ความเห็นเพิ่มเติม` takes whatever is left.

## 2. Blank comment → ไม่มีความเห็นเพิ่มเติม

Comments come straight off `workflow.ApprovalVotes` and are frequently null or blank, so the cell rendered empty. On a signed-off form an empty cell reads as *"not filled in yet"* rather than *"the member had nothing to add"*.

Tested against `null` **and** `""` rather than for mere truthiness — Scriban follows Liquid, where an empty string is `true`, so a bare `if` would never take the fallback. `string.strip` in front also catches whitespace-only comments.

> ⚠️ Gotcha for future edits: Scriban executes `{{ }}` tokens **inside HTML comments** too. An explanatory comment that merely mentions one fails the template parse with a 500. `summary-styles.html` carries the same warning in its header.

## Verification

Rendered through the real PDF pipeline (`appraisal-summary-land-building`, 5mm margins) against a dev appraisal that has both a genuine long Thai title and a mix of filled/blank comments:

- `หัวหน้ากลุ่มงานกฎหมายและกำกับดูแลธนาคาร` on one line, column sized to it
- blank comment → `ไม่มีความเห็นเพิ่มเติม`; real comments pass through untouched

Also rendered the before/after committee table standalone in Chrome against the real `summary-styles.html` to confirm the wrap fix in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7aTHL144dH83KXxrRZfbK