### PR TITLE
feat(integration): serve PMA / pre-completion appraisals in the legacy result API

### DIFF
--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQueryHandler.cs
@@ -61,12 +61,12 @@ public class GetAppraisalResultsByCaseKeyQueryHandler(
 
 internal static class GetAppraisalResultSql
 {
-    // Only completed appraisals are served to external systems.
+    // Lookup by appraisal number returns any status (PMA / in-progress appraisals are retrieved before
+    // completion). The by-external-case-key path below still restricts to completed appraisals.
     public const string ByAppraisalNumber = """
                                             SELECT a.Id, a.AppraisalNumber, a.Status, a.Purpose, a.CompletedAt, a.RequestId
                                             FROM appraisal.Appraisals a
                                             WHERE a.AppraisalNumber = @AppraisalNumber AND a.IsDeleted = 0
-                                              AND a.Status = 'Completed'
                                             """;
 
     public const string ByExternalCaseKey = """
@@ -99,7 +99,6 @@ internal static class GetAppraisalResultSql
                                             LEFT JOIN parameter.DopaDistricts    ddist ON ddist.Code = rd.District
                                             LEFT JOIN parameter.DopaSubDistricts dsub  ON dsub.Code  = rd.SubDistrict
                                             WHERE a.AppraisalNumber = @AppraisalNumber AND a.IsDeleted = 0
-                                              AND a.Status = 'Completed'
                                             """;
 
     public const string ActiveAssignment = """
@@ -148,6 +147,7 @@ internal static class GetAppraisalResultSql
                                                    pfv.LandValue AS GroupLandValue,
                                                    pfv.BuildingValue AS GroupBuildingValue,
                                                    pfv.FinalValueAdjusted AS GroupUnitPrice,
+                                                   pfv.ValuePerUnit AS GroupValuePerUnit,   -- selected method's per-Wa/Sqm rate → AppraisalValueWaOrM
                                                    ap.Id AS PropertyId, ap.PropertyType,
                                                    -- Land/LB fields (from LandAppraisalDetails + first LandTitle)
                                                    lad.Province, lad.District, lad.SubDistrict, lad.LandOffice,
@@ -190,8 +190,16 @@ internal static class GetAppraisalResultSql
                                                    bad.TotalBuildingArea   AS TotalBuildingArea,
                                                    -- LandOffice code resolved to its Thai description (legacy variant only)
                                                    COALESCE(pLandOffice.[description],    lad.LandOffice) AS LandOfficeName,
-                                                   COALESCE(pCadLandOffice.[description], cad.LandOffice) AS CadLandOfficeName
-                                               FROM appraisal.PropertyGroups pg
+                                                   COALESCE(pCadLandOffice.[description], cad.LandOffice) AS CadLandOfficeName,
+                                                   -- PMA / pre-completion prices stored directly on the property (no ValuationAnalyses yet)
+                                                   ap.SellingPrice           AS PropSellingPrice,
+                                                   ap.ForcedSalePrice        AS PropForcedSalePrice,
+                                                   ap.BuildingInsurancePrice AS PropBuildingInsurancePrice
+                                               -- Keyed on AppraisalProperties (not PropertyGroups) so UNGROUPED properties
+                                               -- (e.g. PMA input) are still returned; grouping/pricing are LEFT JOINed.
+                                               FROM appraisal.AppraisalProperties ap
+                                               LEFT JOIN appraisal.PropertyGroupItems pgi ON pgi.AppraisalPropertyId = ap.Id
+                                               LEFT JOIN appraisal.PropertyGroups pg ON pg.Id = pgi.PropertyGroupId
                                                LEFT JOIN appraisal.PricingAnalysis pa ON pa.AnchorId = pg.Id AND pa.SubjectType = 0
                                                OUTER APPLY (
                                                    SELECT TOP 1 ApproachType
@@ -200,15 +208,14 @@ internal static class GetAppraisalResultSql
                                                    ORDER BY Id
                                                ) paa
                                                OUTER APPLY (
-                                                   SELECT TOP 1 fv.LandValue, fv.BuildingValue, fv.FinalValueAdjusted
+                                                   SELECT TOP 1 fv.LandValue, fv.BuildingValue, fv.FinalValueAdjusted,
+                                                          pm.ValuePerUnit
                                                    FROM appraisal.PricingAnalysisApproaches pap
                                                    JOIN appraisal.PricingAnalysisMethods pm ON pm.ApproachId = pap.Id AND pm.IsSelected = 1
                                                    JOIN appraisal.PricingFinalValues fv ON fv.PricingMethodId = pm.Id
                                                    WHERE pap.PricingAnalysisId = pa.Id AND pap.IsSelected = 1
                                                    ORDER BY pm.Id
                                                ) pfv
-                                               JOIN appraisal.PropertyGroupItems pgi ON pgi.PropertyGroupId = pg.Id
-                                               JOIN appraisal.AppraisalProperties ap ON ap.Id = pgi.AppraisalPropertyId
                                                LEFT JOIN appraisal.LandAppraisalDetails lad ON lad.AppraisalPropertyId = ap.Id
                                                LEFT JOIN (
                                                    SELECT *, ROW_NUMBER() OVER (PARTITION BY LandAppraisalDetailId ORDER BY Id) AS rn
@@ -226,8 +233,8 @@ internal static class GetAppraisalResultSql
                                                LEFT JOIN parameter.Parameters pCadLandOffice
                                                    ON pCadLandOffice.[group] = 'LandOffice' AND pCadLandOffice.[language] = 'TH'
                                                   AND pCadLandOffice.[isactive] = 1 AND pCadLandOffice.[code] = cad.LandOffice
-                                               WHERE pg.AppraisalId = @AppraisalId
-                                               ORDER BY pg.GroupNumber, pgi.SequenceInGroup
+                                               WHERE ap.AppraisalId = @AppraisalId
+                                               ORDER BY pg.GroupNumber, pgi.SequenceInGroup, ap.Id
                                                """;
 
     // Latest VAL_REPORT document per code for the appraisal (one row per DocumentTypeCode,
@@ -326,13 +333,14 @@ internal sealed record ValuationRow(
     DateTime? ValuationDate);
 
 internal sealed record CollateralRow(
-    Guid GroupId,
+    Guid? GroupId,        // null for ungrouped properties (e.g. PMA input not assigned to a group)
     string? GroupName,
     decimal? GroupAppraisedValue,
     string? AppraisalMethod,
     decimal? GroupLandValue,
     decimal? GroupBuildingValue,
     decimal? GroupUnitPrice,
+    decimal? GroupValuePerUnit,
     Guid PropertyId,
     string? PropertyType,
     string? Province,
@@ -385,7 +393,11 @@ internal sealed record CollateralRow(
     string? Village,
     decimal? TotalBuildingArea,
     string? LandOfficeName,
-    string? CadLandOfficeName);
+    string? CadLandOfficeName,
+    // PMA / pre-completion prices stored on the property (used when ValuationAnalyses is absent)
+    decimal? PropSellingPrice,
+    decimal? PropForcedSalePrice,
+    decimal? PropBuildingInsurancePrice);
 
 // Legacy (AS400) appraisal header row: appraisal identity + type, request-level MarketValue and the
 // DOPA address already resolved to Thai names.

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultQueryHandler.cs
@@ -159,13 +159,21 @@ internal static class LegacyResultMapper
     public static LegacyAppraisalResult MapCondo(
         LegacyAppraisalRow header, AssignmentRow? assignment, decimal? fee, ValuationRow? valuation, CollateralRow row)
     {
-        var appraisalValue = valuation?.AppraisedValue ?? 0m;
-        var valuer = SplitValuer(assignment, appraisalValue, valuation?.ValuationDate);
+        // Completed → use ValuationAnalyses (same as every other appraisal). Before completion (e.g. PMA)
+        // there is no real valuation yet, so use the keyed-in property prices.
+        var completed = IsCompleted(header.Status);
+        var appraisalValue = completed ? (valuation?.AppraisedValue ?? 0m) : (row.PropSellingPrice ?? 0m);
+        // Internal/External valuer fields are only meaningful once completed; leave them empty before that.
+        var valuer = completed ? SplitValuer(assignment, appraisalValue, valuation?.ValuationDate) : new ValuerSplit();
 
-        return BaseResult(header, fee, valuation, valuer) with
+        return BaseResult(header, assignment, fee, valuation, valuer) with
         {
             AppraisalValue = appraisalValue,
-            ForceSaleValue = valuation?.ForcedSaleValue ?? 0m,
+            ForceSaleValue = completed ? (valuation?.ForcedSaleValue ?? 0m) : (row.PropForcedSalePrice ?? 0m),
+            BuildingValue = completed ? (valuation?.InsuranceValue ?? 0m) : (row.PropBuildingInsurancePrice ?? 0m),
+            MarketValue = completed ? (header.MarketValue ?? 0m) : (row.PropSellingPrice ?? header.MarketValue ?? 0m),
+            MethodOfAppraisal = MapMethod(row.AppraisalMethod),
+            AppraisalValueWaOrM = row.GroupValuePerUnit ?? 0m,  // selected method's per-Wa/Sqm rate (usually cost only)
             LandOffice = Str(row.LandOfficeName ?? row.CadLandOfficeName),
             LandValue = row.GroupLandValue ?? 0m,
             LandNo = Str(row.LandNo),
@@ -195,13 +203,24 @@ internal static class LegacyResultMapper
         LegacyAppraisalRow header, AssignmentRow? assignment, decimal? fee, ValuationRow? valuation,
         CollateralRow? land, CollateralRow? building, decimal? groupLandValue)
     {
-        var appraisalValue = valuation?.AppraisedValue ?? 0m;
-        var valuer = SplitValuer(assignment, appraisalValue, valuation?.ValuationDate);
+        // Completed → use ValuationAnalyses (same as others). Before completion (e.g. PMA), no real
+        // valuation yet → use the keyed-in property prices (land row first, then building).
+        var propSelling = land?.PropSellingPrice ?? building?.PropSellingPrice;
+        var propForced = land?.PropForcedSalePrice ?? building?.PropForcedSalePrice;
+        var propInsurance = land?.PropBuildingInsurancePrice ?? building?.PropBuildingInsurancePrice;
+        var completed = IsCompleted(header.Status);
+        var appraisalValue = completed ? (valuation?.AppraisedValue ?? 0m) : (propSelling ?? 0m);
+        // Internal/External valuer fields are only meaningful once completed; leave them empty before that.
+        var valuer = completed ? SplitValuer(assignment, appraisalValue, valuation?.ValuationDate) : new ValuerSplit();
 
-        return BaseResult(header, fee, valuation, valuer) with
+        return BaseResult(header, assignment, fee, valuation, valuer) with
         {
             AppraisalValue = appraisalValue,
-            ForceSaleValue = valuation?.ForcedSaleValue ?? 0m,
+            ForceSaleValue = completed ? (valuation?.ForcedSaleValue ?? 0m) : (propForced ?? 0m),
+            BuildingValue = completed ? (valuation?.InsuranceValue ?? 0m) : (propInsurance ?? 0m),
+            MarketValue = completed ? (header.MarketValue ?? 0m) : (propSelling ?? header.MarketValue ?? 0m),
+            MethodOfAppraisal = MapMethod(land?.AppraisalMethod ?? building?.AppraisalMethod),
+            AppraisalValueWaOrM = (land?.GroupValuePerUnit ?? building?.GroupValuePerUnit) ?? 0m,
             LandOffice = Str(land?.LandOfficeName ?? building?.LandOfficeName),
             LandValue = groupLandValue ?? 0m,
             // Land row
@@ -231,10 +250,12 @@ internal static class LegacyResultMapper
     {
         var isCondo = ProjectType.IsCondoCode(project.ProjectType);
         var (rai, ngan, wa) = SqWaToRaiNganWa(unit.LandArea);
+        var completed = IsCompleted(header.Status);
         var appraisalValue = unit.TotalAppraisalValueRounded ?? valuation?.AppraisedValue ?? 0m;
-        var valuer = SplitValuer(assignment, appraisalValue, valuation?.ValuationDate);
+        // Internal/External valuer fields are only meaningful once completed; leave them empty before that.
+        var valuer = completed ? SplitValuer(assignment, appraisalValue, valuation?.ValuationDate) : new ValuerSplit();
 
-        return BaseResult(header, fee, valuation, valuer) with
+        return BaseResult(header, assignment, fee, valuation, valuer) with
         {
             AppraisalValue = appraisalValue,
             ForceSaleValue = unit.ForceSellingPrice ?? valuation?.ForcedSaleValue ?? 0m,
@@ -278,9 +299,10 @@ internal static class LegacyResultMapper
 
     // Appraisal-level fields shared by both paths (identity, fee, dates, address, valuer, type).
     private static LegacyAppraisalResult BaseResult(
-        LegacyAppraisalRow header, decimal? fee, ValuationRow? valuation, ValuerSplit valuer)
+        LegacyAppraisalRow header, AssignmentRow? assignment, decimal? fee, ValuationRow? valuation, ValuerSplit valuer)
     {
-        var appraisalDate = IsoDate(valuation?.ValuationDate ?? header.CompletedAt);
+        // AppraisalDate = the appointment date (when the property was appraised), not the completed date.
+        var appraisalDate = IsoDate(assignment?.AppointmentDateTime);
 
         return new LegacyAppraisalResult
         {
@@ -288,7 +310,7 @@ internal static class LegacyResultMapper
             AppraisalFee = fee ?? 0m,
             SequenceOfApprove = Str(header.SequenceOfApprove),
             AppraisalType = MapAppraisalType(header.AppraisalType),
-            MethodOfAppraisal = 1, // TODO revisit: currently a fixed default per the legacy contract.
+            // MethodOfAppraisal + AppraisalValueWaOrM are set per selected collateral by the callers.
             MarketValue = header.MarketValue ?? 0m,
             BuildingValue = valuation?.InsuranceValue ?? 0m, // legacy BuildingValue = fire-insurance value
             Province = Str(header.Province),
@@ -350,6 +372,15 @@ internal static class LegacyResultMapper
         _ => 0,
     };
 
+    // Legacy MethodOfAppraisal ← our pricing ApproachType: 1 = Cost, 2 = Income, 3 = Market.
+    // Defaults to 3 (Market) when there is no selected approach (e.g. PMA / block / unknown).
+    private static int MapMethod(string? approachType) => approachType?.Trim().ToLowerInvariant() switch
+    {
+        "cost" => 1,
+        "income" => 2,
+        _ => 3,
+    };
+
     // Legacy Decorate is our DecorationType code with the leading zero stripped ("01" → 1, "99" → 99).
     // Returns null when there is no usable value (the legacy contract wants null, not 0, for "unknown").
     private static int? ParseDecorate(string? code) =>
@@ -369,6 +400,9 @@ internal static class LegacyResultMapper
 
     private static bool Eq(string? a, string? b) =>
         string.Equals((a ?? string.Empty).Trim(), (b ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsCompleted(string? status) =>
+        string.Equals(status, "Completed", StringComparison.OrdinalIgnoreCase);
 
     private static string Str(string? value) => value ?? string.Empty;
 


### PR DESCRIPTION
## Summary

Adds **PMA / pre-completion** support to the legacy AS400 result endpoint
(`POST /api/v1/appraisals/result`), plus two mapping fixes. Completed appraisals are unchanged.

### PMA support
- **Status filter:** by-appraisal-number lookups (legacy + v2) no longer require `Status = Completed`
  (PMA is retrieved before completion). The **by-external-case-key** path still returns completed only.
- **Ungrouped properties:** the collateral query is re-keyed on `appraisal.AppraisalProperties`
  (LEFT JOIN grouping), so PMA properties that aren't assigned to a `PropertyGroup` are still returned.
  `CollateralRow.GroupId` is now nullable.
- **Values before completion:** taken from the property's own `SellingPrice` / `ForcedSalePrice` /
  `BuildingInsurancePrice` (and `MarketValue` prefers the property price). **Completed** appraisals use
  `ValuationAnalyses` exactly as before — byte-identical, no impact to others.
- **Valuer fields** (`Internal*` / `External*`) are left empty until the appraisal is completed.

### Mapping fixes
- **AppraisalDate** now = the **appointment date** (`AppointmentDateTime`), matching the v2 builder —
  previously it wrongly used `ValuationDate` / `CompletedAt`.
- **MethodOfAppraisal** mapped from the selected pricing `ApproachType`: Cost=1, Income=2, else **Market=3**
  (default 3 when no approach is selected — PMA/block).
- **AppraisalValueWaOrM** now = the selected method's `ValuePerUnit` (the per-Wa/Sqm rate), read from the
  selected approach's selected method — not the ambiguous `FinalValueAdjusted` total.

## Scope
2 files (`GetAppraisalResultQueryHandler.cs`, `GetLegacyAppraisalResultQueryHandler.cs`).
No schema changes. The shared collateral query now also returns ungrouped properties, so the (unconsumed)
v2 endpoints include them too.

## Testing
- `dotnet build` green.
- Verified against dev data: PMA appraisal `69105439` (InProgress, property prices `2,000,000`) now returns
  `AppraisalValue`/`ForceSaleValue`/`BuildingValue`/`MarketValue` = `2,000,000`, empty valuer fields, and
  `AppraisalDate` = the appointment date `2026-07-16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
