### PR TITLE
fix(integration): block MethodOfAppraisal from the unit's model approach

### DIFF
--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQueryHandler.cs
@@ -284,11 +284,21 @@ internal static class GetAppraisalResultSql
                                                pt.NumberOfFloors AS TowerFloors,           -- total floors of the building → FloorNumber
                                                pt.BuildingAge    AS TowerBuildingAge,
                                                COALESCE(pm.DecorationType, pt.DecorationType) AS DecorationType,
+                                               modelApproach.ApproachType AS ModelApproachType,   -- selected approach of the unit's model → MethodOfAppraisal
                                                pp.TotalAppraisalValueRounded, pp.ForceSellingPrice, pp.CoverageAmount
                                            FROM appraisal.ProjectUnits pu
                                            LEFT JOIN appraisal.ProjectUnitPrices pp ON pp.ProjectUnitId = pu.Id
                                            LEFT JOIN appraisal.ProjectTowers pt ON pt.Id = pu.ProjectTowerId
                                            LEFT JOIN appraisal.ProjectModels pm ON pm.Id = pu.ProjectModelId
+                                           OUTER APPLY (
+                                               -- Block pricing method lives on the model's PricingAnalysis (SubjectType = 1).
+                                               SELECT TOP 1 papp.ApproachType
+                                               FROM appraisal.PricingAnalysis pamdl
+                                               JOIN appraisal.PricingAnalysisApproaches papp
+                                                   ON papp.PricingAnalysisId = pamdl.Id AND papp.IsSelected = 1
+                                               WHERE pamdl.AnchorId = pu.ProjectModelId AND pamdl.SubjectType = 1
+                                               ORDER BY papp.Id
+                                           ) modelApproach
                                            WHERE pu.ProjectId = @ProjectId
                                            """;
 
@@ -442,6 +452,7 @@ internal sealed record BlockUnitRow(
     int? TowerFloors,
     int? TowerBuildingAge,
     string? DecorationType,
+    string? ModelApproachType,
     decimal? TotalAppraisalValueRounded,
     decimal? ForceSellingPrice,
     decimal? CoverageAmount);

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultQueryHandler.cs
@@ -263,8 +263,8 @@ internal static class LegacyResultMapper
             BuildingValue = unit.CoverageAmount ?? valuation?.InsuranceValue ?? 0m,
             // Block market value = the unit's own selling price (falls back to the request-level total).
             MarketValue = unit.SellingPrice ?? header.MarketValue ?? 0m,
-            // Block has no PricingAnalysis approach → defaults to Market (3); no per-unit rate.
-            MethodOfAppraisal = MapMethod(null),
+            // Block method = the selected approach of the unit's model (defaults to Market when none).
+            MethodOfAppraisal = MapMethod(unit.ModelApproachType),
             // Project-level descriptors.
             BuildingDetails = Str(project.ProjectName),
             Developer = Str(project.Developer),

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultQueryHandler.cs
@@ -263,6 +263,8 @@ internal static class LegacyResultMapper
             BuildingValue = unit.CoverageAmount ?? valuation?.InsuranceValue ?? 0m,
             // Block market value = the unit's own selling price (falls back to the request-level total).
             MarketValue = unit.SellingPrice ?? header.MarketValue ?? 0m,
+            // Block has no PricingAnalysis approach → defaults to Market (3); no per-unit rate.
+            MethodOfAppraisal = MapMethod(null),
             // Project-level descriptors.
             BuildingDetails = Str(project.ProjectName),
             Developer = Str(project.Developer),


### PR DESCRIPTION
## Summary

Follow-up to #337 (PMA support): fixes `MethodOfAppraisal` for **block** appraisals in the legacy
result endpoint (`POST /api/v1/appraisals/result`).

- **Bug:** `MapBlock` never set `MethodOfAppraisal`, so block appraisals fell through to the DTO
  default `0` (the general mapper's default was removed when it moved to the callers).
- **Fix:** block `MethodOfAppraisal` is now sourced from the **unit's model's selected approach** —
  the pricing method is decided per `ProjectModel`, and every unit of that model inherits it:

  ```
  ProjectUnit.ProjectModelId
    → PricingAnalysis (SubjectType = 1, AnchorId = ProjectModelId)
      → PricingAnalysisApproaches (IsSelected = 1)
        → ApproachType  →  MethodOfAppraisal  (Cost=1, Income=2, Market=3)
  ```
  Falls back to Market (3) when the model has no pricing analysis.

## Changes
- `BlockUnitSelect` SQL: `OUTER APPLY` on the model's `PricingAnalysis` → `ModelApproachType`.
- `BlockUnitRow`: `ModelApproachType`.
- `MapBlock`: `MethodOfAppraisal = MapMethod(unit.ModelApproachType)`.

## Testing
- `dotnet build` green.
- Verified against dev data: block `69105453` units (`A-501`…`A-506`) resolve to `Market` → `3`;
  `69105439` (no model pricing) falls back to `3`.

## Commits
1. `fix(integration): default block MethodOfAppraisal to Market (was 0)`
2. `feat(integration): block MethodOfAppraisal from the unit's model approach`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
