### PR TITLE
feat(appraisal): scope fee ladders by appraisal type; fix monitoring task types and summary district

### DIFF
--- a/Modules/Appraisal/Appraisal/Application/Features/FeeStructures/CreateFeeStructure/CreateFeeStructureCommand.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/FeeStructures/CreateFeeStructure/CreateFeeStructureCommand.cs
@@ -5,5 +5,7 @@ public record CreateFeeStructureCommand(
     decimal BaseAmount,
     decimal MinSellingPrice,
     decimal? MaxSellingPrice,
-    bool IsActive
+    bool IsActive,
+    // Null (or omitted) creates a tier on the generic ladder that applies to any appraisal type.
+    string? AppraisalType = null
 ) : ICommand<FeeStructureDto>, ITransactionalCommand<IAppraisalUnitOfWork>;

--- a/Modules/Appraisal/Appraisal/Application/Features/FeeStructures/CreateFeeStructure/CreateFeeStructureCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/FeeStructures/CreateFeeStructure/CreateFeeStructureCommandHandler.cs
@@ -15,6 +15,9 @@ public class CreateFeeStructureCommandHandler(
     {
         var feeCode = cmd.FeeCode.Trim();
 
+        // Blank from a form select means "generic ladder" — normalise so the scope is genuinely null.
+        var appraisalType = string.IsNullOrWhiteSpace(cmd.AppraisalType) ? null : cmd.AppraisalType.Trim();
+
         // The fee code must exist in the TypeOfFee parameter group — otherwise it has no
         // resolvable display name and tier matching keys off a meaningless code.
         var validCodes = await parameterLookup.GetValidCodesAsync(
@@ -23,10 +26,10 @@ public class CreateFeeStructureCommandHandler(
             throw new BadRequestException($"Fee code '{feeCode}' is not a valid {FeeTypeParameterGroup} code.");
 
         await FeeStructureMapping.EnsureNoActiveOverlapAsync(
-            db, feeCode, cmd.MinSellingPrice, cmd.MaxSellingPrice, cmd.IsActive, excludeId: null, ct);
+            db, feeCode, appraisalType, cmd.MinSellingPrice, cmd.MaxSellingPrice, cmd.IsActive, excludeId: null, ct);
 
         var entity = FeeStructure.Create(
-            feeCode, cmd.BaseAmount, cmd.MinSellingPrice, cmd.MaxSellingPrice, cmd.IsActive);
+            feeCode, cmd.BaseAmount, cmd.MinSellingPrice, cmd.MaxSellingPrice, cmd.IsActive, appraisalType);
 
         db.FeeStructures.Add(entity);
         // No SaveChangesAsync — TransactionalBehavior commits the unit of work.

--- a/Modules/Appraisal/Appraisal/Application/Features/FeeStructures/CreateFeeStructure/CreateFeeStructureCommandValidator.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/FeeStructures/CreateFeeStructure/CreateFeeStructureCommandValidator.cs
@@ -14,6 +14,13 @@ public class CreateFeeStructureCommandValidator : AbstractValidator<CreateFeeStr
         RuleFor(x => x.MinSellingPrice)
             .GreaterThanOrEqualTo(0).WithMessage("Min selling price cannot be negative.");
 
+        // Null/blank = generic ladder; anything else must be a recognised appraisal type, otherwise
+        // the tier would be scoped to a value no appraisal can ever carry.
+        RuleFor(x => x.AppraisalType)
+            .Must(AppraisalTypes.IsValid)
+            .When(x => !string.IsNullOrWhiteSpace(x.AppraisalType))
+            .WithMessage($"Appraisal type must be one of: {string.Join(", ", AppraisalTypes.ValidValues)}.");
+
         RuleFor(x => x.MaxSellingPrice)
             .GreaterThanOrEqualTo(x => x.MinSellingPrice)
             .When(x => x.MaxSellingPrice.HasValue)

--- a/Modules/Appraisal/Appraisal/Application/Features/FeeStructures/CreateFeeStructure/CreateFeeStructureEndpoint.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/FeeStructures/CreateFeeStructure/CreateFeeStructureEndpoint.cs
@@ -5,7 +5,9 @@ public record CreateFeeStructureRequest(
     decimal BaseAmount,
     decimal MinSellingPrice,
     decimal? MaxSellingPrice,
-    bool IsActive = true);
+    bool IsActive = true,
+    // Omit or send null to create a tier on the generic ladder that applies to any appraisal type.
+    string? AppraisalType = null);
 
 public class CreateFeeStructureEndpoint : ICarterModule
 {
@@ -24,7 +26,7 @@ public class CreateFeeStructureEndpoint : ICarterModule
             .ProducesProblem(StatusCodes.Status409Conflict)
             .WithTags("Fee Structure Config")
             .WithSummary("Create a fee structure")
-            .WithDescription("Creates a fee structure tier. The fee code must exist in the TypeOfFee parameter group and may not overlap an existing active tier of the same code.")
+            .WithDescription("Creates a fee structure tier. The fee code must exist in the TypeOfFee parameter group and may not overlap an existing active tier in the same ladder (same fee code and appraisal-type scope). Leave appraisalType null for the generic ladder used by any appraisal type.")
             .RequireAuthorization();
     }
 }

--- a/Modules/Appraisal/Appraisal/Application/Features/FeeStructures/FeeStructureDto.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/FeeStructures/FeeStructureDto.cs
@@ -10,22 +10,26 @@ public record FeeStructureDto(
     decimal BaseAmount,
     decimal MinSellingPrice,
     decimal? MaxSellingPrice,
-    bool IsActive);
+    bool IsActive,
+    string? AppraisalType);
 
 internal static class FeeStructureMapping
 {
     public static FeeStructureDto ToDto(this FeeStructure f) =>
-        new(f.Id, f.FeeCode, f.BaseAmount, f.MinSellingPrice, f.MaxSellingPrice, f.IsActive);
+        new(f.Id, f.FeeCode, f.BaseAmount, f.MinSellingPrice, f.MaxSellingPrice, f.IsActive, f.AppraisalType);
 
     /// <summary>
-    /// Rejects a tier whose selling-price range overlaps an existing active tier of the same
-    /// FeeCode. A null max means open-ended (+∞). Inactive tiers are ignored (not used for fee
-    /// matching) and an inactive incoming row is never checked. The predicate is evaluated in the
-    /// database so only the existence of a conflict is fetched, never the rows themselves.
+    /// Rejects a tier whose selling-price range overlaps an existing active tier in the same ladder
+    /// — same FeeCode *and* same AppraisalType scope. A PreAppraisal 0→∞ tier therefore does not
+    /// conflict with the generic (null-scoped) bands. A null max means open-ended (+∞). Inactive
+    /// tiers are ignored (not used for fee matching) and an inactive incoming row is never checked.
+    /// The predicate is evaluated in the database so only the existence of a conflict is fetched,
+    /// never the rows themselves.
     /// </summary>
     public static async Task EnsureNoActiveOverlapAsync(
         AppraisalDbContext db,
         string feeCode,
+        string? appraisalType,
         decimal minSellingPrice,
         decimal? maxSellingPrice,
         bool isActive,
@@ -37,16 +41,24 @@ internal static class FeeStructureMapping
 
         // Overlap of [min,max] with an existing [f.Min,f.Max], treating null max as +∞:
         //   min <= f.Max  AND  f.Min <= max
-        var overlaps = await db.FeeStructures
+        var query = db.FeeStructures
             .Where(f => f.FeeCode == feeCode
                         && f.IsActive
                         && (excludeId == null || f.Id != excludeId)
                         && (f.MaxSellingPrice == null || minSellingPrice <= f.MaxSellingPrice)
-                        && (maxSellingPrice == null || f.MinSellingPrice <= maxSellingPrice))
-            .AnyAsync(ct);
+                        && (maxSellingPrice == null || f.MinSellingPrice <= maxSellingPrice));
 
-        if (overlaps)
+        // Scope to the same ladder. Written as an explicit branch rather than a single
+        // `f.AppraisalType == appraisalType` so the null case provably translates to IS NULL.
+        query = appraisalType is null
+            ? query.Where(f => f.AppraisalType == null)
+            : query.Where(f => f.AppraisalType == appraisalType);
+
+        if (await query.AnyAsync(ct))
+        {
+            var scope = appraisalType is null ? "any appraisal type" : $"appraisal type '{appraisalType}'";
             throw new ConflictException(
-                $"The selling-price range overlaps an existing active tier for fee code '{feeCode}'.");
+                $"The selling-price range overlaps an existing active tier for fee code '{feeCode}' ({scope}).");
+        }
     }
 }

--- a/Modules/Appraisal/Appraisal/Application/Features/FeeStructures/GetFeeStructures/GetFeeStructuresQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/FeeStructures/GetFeeStructures/GetFeeStructuresQueryHandler.cs
@@ -9,9 +9,10 @@ public class GetFeeStructuresQueryHandler(AppraisalDbContext db)
         return await db.FeeStructures
             .AsNoTracking()
             .OrderBy(f => f.FeeCode)
+            .ThenBy(f => f.AppraisalType)
             .ThenBy(f => f.MinSellingPrice)
             .Select(f => new FeeStructureDto(
-                f.Id, f.FeeCode, f.BaseAmount, f.MinSellingPrice, f.MaxSellingPrice, f.IsActive))
+                f.Id, f.FeeCode, f.BaseAmount, f.MinSellingPrice, f.MaxSellingPrice, f.IsActive, f.AppraisalType))
             .ToListAsync(ct);
     }
 }

--- a/Modules/Appraisal/Appraisal/Application/Features/FeeStructures/UpdateFeeStructure/UpdateFeeStructureCommandHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/FeeStructures/UpdateFeeStructure/UpdateFeeStructureCommandHandler.cs
@@ -8,8 +8,11 @@ public class UpdateFeeStructureCommandHandler(AppraisalDbContext db)
         var entity = await db.FeeStructures.FindAsync([cmd.Id], ct)
             ?? throw new NotFoundException("FeeStructure", cmd.Id);
 
+        // FeeCode and AppraisalType are immutable — the ladder the tier belongs to is read off the
+        // entity, not the command.
         await FeeStructureMapping.EnsureNoActiveOverlapAsync(
-            db, entity.FeeCode, cmd.MinSellingPrice, cmd.MaxSellingPrice, cmd.IsActive, excludeId: cmd.Id, ct);
+            db, entity.FeeCode, entity.AppraisalType, cmd.MinSellingPrice, cmd.MaxSellingPrice, cmd.IsActive,
+            excludeId: cmd.Id, ct);
 
         entity.Update(cmd.BaseAmount, cmd.MinSellingPrice, cmd.MaxSellingPrice, cmd.IsActive);
         // No SaveChangesAsync — TransactionalBehavior commits the unit of work.

--- a/Modules/Appraisal/Appraisal/Application/Services/AssignmentFeeService.cs
+++ b/Modules/Appraisal/Appraisal/Application/Services/AssignmentFeeService.cs
@@ -94,30 +94,47 @@ public class AssignmentFeeService(
         // Step 3 — Add the appropriate item based on source.
         switch (source)
         {
-            case AssignmentFeeSource.TierBased:
+            case AssignmentFeeSource.TierBased tierSource:
             {
                 var totalSellingPrice = fee.TotalSellingPrice ?? 0m;
+                var appraisalType = tierSource.AppraisalType;
 
                 var tiers = await dbContext.FeeStructures
-                    .Where(fs => fs.IsActive && fs.FeeCode == "01")
+                    .Where(fs => fs.IsActive && fs.FeeCode == "01"
+                                 && (fs.AppraisalType == null || fs.AppraisalType == appraisalType))
                     .OrderBy(fs => fs.MinSellingPrice)
                     .ToListAsync(ct);
 
-                var matched = tiers.FirstOrDefault(t => t.IsApplicableFor(totalSellingPrice));
+                // A type-scoped ladder replaces the generic one outright rather than merging with
+                // it — otherwise a flat per-type rate (e.g. PreAppraisal 10,000) would be silently
+                // outranked by a generic selling-price band.
+                var candidates = tiers.Where(t => t.AppraisalType != null).ToList();
+                if (candidates.Count == 0)
+                    candidates = tiers;
+
+                if (candidates.Count == 0)
+                {
+                    logger.LogError(
+                        "No active fee tier (FeeCode=01) configured for AppraisalType={AppraisalType}. Leaving fee {FeeId} without items for AssignmentId={AssignmentId}.",
+                        appraisalType, fee.Id, assignmentId);
+                    return;
+                }
+
+                var matched = candidates.FirstOrDefault(t => t.IsApplicableFor(totalSellingPrice));
                 if (matched is null)
                 {
-                    matched = tiers.OrderByDescending(t => t.MinSellingPrice).First();
+                    matched = candidates.OrderByDescending(t => t.MinSellingPrice).First();
                     logger.LogWarning(
-                        "No fee tier matched TotalSellingPrice {TotalSellingPrice} for AppraisalFee {FeeId}. Falling back to highest tier (BaseAmount={BaseAmount})",
-                        totalSellingPrice, fee.Id, matched.BaseAmount);
+                        "No fee tier matched TotalSellingPrice {TotalSellingPrice} (AppraisalType={AppraisalType}) for AppraisalFee {FeeId}. Falling back to highest tier (BaseAmount={BaseAmount})",
+                        totalSellingPrice, appraisalType, fee.Id, matched.BaseAmount);
                 }
 
                 var feeName = await ResolveFeeNameAsync(matched.FeeCode, ct);
                 fee.AddItem(matched.FeeCode, feeName, matched.BaseAmount);
 
                 logger.LogInformation(
-                    "Appraisal fee created: fee {FeeId} assigned tier item (FeeCode={FeeCode}, BaseAmount={BaseAmount}) for AssignmentId={AssignmentId} (TotalSellingPrice={TotalSellingPrice})",
-                    fee.Id, matched.FeeCode, matched.BaseAmount, assignmentId, totalSellingPrice);
+                    "Appraisal fee created: fee {FeeId} assigned tier item (FeeCode={FeeCode}, BaseAmount={BaseAmount}, TierAppraisalType={TierAppraisalType}) for AssignmentId={AssignmentId} (AppraisalType={AppraisalType}, TotalSellingPrice={TotalSellingPrice})",
+                    fee.Id, matched.FeeCode, matched.BaseAmount, matched.AppraisalType, assignmentId, appraisalType, totalSellingPrice);
                 break;
             }
 
@@ -198,7 +215,12 @@ public class AssignmentFeeService(
         if (appraisal.AppraisalType != AppraisalTypes.Progressive ||
             appraisal.PrevAppraisalId is not { } prevId)
         {
-            return defaultSource;
+            // Stamp the appraisal type onto a tier lookup so it can pick the type-scoped ladder
+            // (e.g. the flat PreAppraisal/block rate). Quotation sources bypass tiers entirely and
+            // are returned untouched.
+            return defaultSource is AssignmentFeeSource.TierBased
+                ? new AssignmentFeeSource.TierBased(appraisal.AppraisalType)
+                : defaultSource;
         }
 
         var ciFee = await mediator.Send(

--- a/Modules/Appraisal/Appraisal/Application/Services/IAssignmentFeeService.cs
+++ b/Modules/Appraisal/Appraisal/Application/Services/IAssignmentFeeService.cs
@@ -5,8 +5,13 @@ namespace Appraisal.Application.Services;
 /// </summary>
 public abstract record AssignmentFeeSource
 {
-    /// <summary>Look up the applicable tier from FeeStructures (FeeCode="01") using TotalSellingPrice.</summary>
-    public sealed record TierBased : AssignmentFeeSource;
+    /// <summary>
+    /// Look up the applicable tier from FeeStructures (FeeCode="01") using TotalSellingPrice.
+    /// <paramref name="AppraisalType"/> selects the ladder: when the table holds rows scoped to
+    /// that type they are used exclusively, otherwise the generic (null-scoped) ladder applies.
+    /// Null means "no type known" and always resolves to the generic ladder.
+    /// </summary>
+    public sealed record TierBased(string? AppraisalType = null) : AssignmentFeeSource;
 
     /// <summary>
     /// Use the price agreed through the quotation process.
@@ -44,7 +49,8 @@ public interface IAssignmentFeeService
     /// Returns a CI-aware fee source: when the appraisal is a Construction Inspection follow-up
     /// (AppraisalType=ConstructionInspection AND PrevAppraisalId is set), looks up the prior
     /// engagement's CI fee via Collateral and returns <see cref="AssignmentFeeSource.ConstructionInspection"/>.
-    /// Otherwise returns <paramref name="defaultSource"/> unchanged.
+    /// A <see cref="AssignmentFeeSource.TierBased"/> default is stamped with the appraisal's type so
+    /// the tier lookup can pick the type-scoped ladder. Any other source is returned unchanged.
     /// </summary>
     Task<AssignmentFeeSource> ResolveSourceForAppraisalAsync(
         Domain.Appraisals.Appraisal appraisal,

--- a/Modules/Appraisal/Appraisal/Domain/Appraisals/FeeStructure.cs
+++ b/Modules/Appraisal/Appraisal/Domain/Appraisals/FeeStructure.cs
@@ -4,10 +4,21 @@ namespace Appraisal.Domain.Appraisals;
 /// Master fee configuration table. Defines available fee types and their base amounts.
 /// FeeCode "01" (Appraisal Fee) has multiple rows for selling-price tiers. The human-readable
 /// name is NOT stored here — it is resolved from the <c>TypeOfFee</c> parameter group by code.
+///
+/// Tiers are optionally scoped to a single <see cref="AppraisalType"/>; a null scope is the
+/// generic ladder that applies to any appraisal type.
 /// </summary>
 public class FeeStructure : Entity<Guid>
 {
     public string FeeCode { get; private set; } = null!;
+
+    /// <summary>
+    /// Appraisal type this tier applies to (values from <see cref="AppraisalTypes"/>), or null
+    /// for the generic ladder that applies to any type. A type-scoped ladder replaces the generic
+    /// one for that type rather than merging with it — see AssignmentFeeService.
+    /// </summary>
+    public string? AppraisalType { get; private set; }
+
     public decimal BaseAmount { get; private set; }
     public decimal MinSellingPrice { get; private set; }
     public decimal? MaxSellingPrice { get; private set; }
@@ -22,7 +33,8 @@ public class FeeStructure : Entity<Guid>
         decimal baseAmount,
         decimal minSellingPrice = 0,
         decimal? maxSellingPrice = null,
-        bool isActive = true)
+        bool isActive = true,
+        string? appraisalType = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(feeCode);
 
@@ -30,6 +42,7 @@ public class FeeStructure : Entity<Guid>
         {
             Id = Guid.CreateVersion7(),
             FeeCode = feeCode,
+            AppraisalType = string.IsNullOrWhiteSpace(appraisalType) ? null : appraisalType,
             BaseAmount = baseAmount,
             MinSellingPrice = minSellingPrice,
             MaxSellingPrice = maxSellingPrice,
@@ -38,8 +51,8 @@ public class FeeStructure : Entity<Guid>
     }
 
     /// <summary>
-    /// Updates the mutable fields of the fee structure. FeeCode is immutable — a tier's
-    /// fee code identifies which fee family it belongs to and must not change in place.
+    /// Updates the mutable fields of the fee structure. FeeCode and AppraisalType are immutable —
+    /// together they identify which ladder the tier belongs to and must not change in place.
     /// </summary>
     public void Update(
         decimal baseAmount,

--- a/Modules/Appraisal/Appraisal/Infrastructure/Configurations/FeeStructureConfiguration.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Configurations/FeeStructureConfiguration.cs
@@ -14,6 +14,10 @@ public class FeeStructureConfiguration : IEntityTypeConfiguration<FeeStructure>
             .IsRequired()
             .HasMaxLength(20);
 
+        // Null = generic ladder (any appraisal type). Matches Appraisals.AppraisalType's length.
+        builder.Property(f => f.AppraisalType)
+            .HasMaxLength(50);
+
         builder.Property(f => f.BaseAmount)
             .HasPrecision(18, 2);
 
@@ -27,20 +31,27 @@ public class FeeStructureConfiguration : IEntityTypeConfiguration<FeeStructure>
             .IsRequired()
             .HasDefaultValue(true);
 
-        // Composite unique: same FeeCode can have multiple tiers distinguished by MinSellingPrice
-        builder.HasIndex(f => new { f.FeeCode, f.MinSellingPrice })
-            .IsUnique();
+        // Composite unique: same FeeCode can have multiple tiers distinguished by MinSellingPrice,
+        // and a separate ladder per AppraisalType. SQL Server treats NULLs as equal in a unique
+        // index, so the generic (null-type) ladder still allows only one row per FeeCode+Min.
+        // HasFilter(null) suppresses EF's default "[AppraisalType] IS NOT NULL" filter for nullable
+        // key columns — without it the generic ladder would lose its uniqueness guarantee entirely.
+        builder.HasIndex(f => new { f.FeeCode, f.AppraisalType, f.MinSellingPrice })
+            .IsUnique()
+            .HasFilter(null);
 
-        // Seed data — Appraisal Fee (01) has 3 selling-price tiers. Fee names resolve from the
-        // TypeOfFee parameter group by code, so only the code is stored here.
+        // Seed data — Appraisal Fee (01) has 3 generic selling-price tiers plus a flat
+        // PreAppraisal (block / M-F project) tier. Fee names resolve from the TypeOfFee
+        // parameter group by code, so only the code is stored here.
         builder.HasData(
             new
             {
                 Id = new Guid("00000000-0000-0000-0000-000000000001"),
                 FeeCode = "01",
-                BaseAmount = 3_500m,
+                AppraisalType = (string?)null,
+                BaseAmount = 2_500m,
                 MinSellingPrice = 0m,
-                MaxSellingPrice = (decimal?)5_000_000m,
+                MaxSellingPrice = (decimal?)7_000_000m,
                 IsActive = true,
                 CreatedOn = (DateTime?)new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
                 CreatedBy = (string?)"System"
@@ -49,8 +60,9 @@ public class FeeStructureConfiguration : IEntityTypeConfiguration<FeeStructure>
             {
                 Id = new Guid("00000000-0000-0000-0000-000000000004"),
                 FeeCode = "01",
-                BaseAmount = 5_000m,
-                MinSellingPrice = 5_000_001m,
+                AppraisalType = (string?)null,
+                BaseAmount = 3_000m,
+                MinSellingPrice = 7_000_001m,
                 MaxSellingPrice = (decimal?)10_000_000m,
                 IsActive = true,
                 CreatedOn = (DateTime?)new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
@@ -60,8 +72,26 @@ public class FeeStructureConfiguration : IEntityTypeConfiguration<FeeStructure>
             {
                 Id = new Guid("00000000-0000-0000-0000-000000000005"),
                 FeeCode = "01",
-                BaseAmount = 7_000m,
+                AppraisalType = (string?)null,
+                BaseAmount = 3_500m,
                 MinSellingPrice = 10_000_001m,
+                MaxSellingPrice = (decimal?)null,
+                IsActive = true,
+                CreatedOn = (DateTime?)new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                CreatedBy = (string?)"System"
+            },
+            // Block / M-F project deals are charged a flat 10,000 (ex-VAT) regardless of selling
+            // price, so this ladder is a single open-ended band.
+            // NOTE: block *reappraisals* (Purpose "09") are stamped AppraisalType "ReAppraisal",
+            // not "PreAppraisal" (AppraisalCreationService gives ReAppraisal precedence over the
+            // block check), so they deliberately stay on the generic ladder for now.
+            new
+            {
+                Id = new Guid("00000000-0000-0000-0000-000000000006"),
+                FeeCode = "01",
+                AppraisalType = (string?)AppraisalTypes.PreAppraisal,
+                BaseAmount = 10_000m,
+                MinSellingPrice = 0m,
                 MaxSellingPrice = (decimal?)null,
                 IsActive = true,
                 CreatedOn = (DateTime?)new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),

--- a/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260729093917_AddAppraisalTypeToFeeStructure.Designer.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260729093917_AddAppraisalTypeToFeeStructure.Designer.cs
@@ -4,16 +4,19 @@ using Appraisal.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace Appraisal.Infrastructure.Migrations
+namespace Appraisal.infrastructure.Migrations
 {
     [DbContext(typeof(AppraisalDbContext))]
-    partial class AppraisalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260729093917_AddAppraisalTypeToFeeStructure")]
+    partial class AddAppraisalTypeToFeeStructure
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260729093917_AddAppraisalTypeToFeeStructure.cs
+++ b/Modules/Appraisal/Appraisal/Infrastructure/Migrations/20260729093917_AddAppraisalTypeToFeeStructure.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Appraisal.infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAppraisalTypeToFeeStructure : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_FeeStructures_FeeCode_MinSellingPrice",
+                schema: "appraisal",
+                table: "FeeStructures");
+
+            migrationBuilder.AddColumn<string>(
+                name: "AppraisalType",
+                schema: "appraisal",
+                table: "FeeStructures",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                schema: "appraisal",
+                table: "FeeStructures",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000001"),
+                columns: new[] { "AppraisalType", "BaseAmount", "MaxSellingPrice" },
+                values: new object[] { null, 2500m, 7000000m });
+
+            migrationBuilder.UpdateData(
+                schema: "appraisal",
+                table: "FeeStructures",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000004"),
+                columns: new[] { "AppraisalType", "BaseAmount", "MinSellingPrice" },
+                values: new object[] { null, 3000m, 7000001m });
+
+            migrationBuilder.UpdateData(
+                schema: "appraisal",
+                table: "FeeStructures",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000005"),
+                columns: new[] { "AppraisalType", "BaseAmount" },
+                values: new object[] { null, 3500m });
+
+            migrationBuilder.InsertData(
+                schema: "appraisal",
+                table: "FeeStructures",
+                columns: new[] { "Id", "AppraisalType", "BaseAmount", "CreatedAt", "CreatedBy", "CreatedWorkstation", "FeeCode", "IsActive", "MaxSellingPrice", "MinSellingPrice", "UpdatedAt", "UpdatedBy", "UpdatedWorkstation" },
+                values: new object[] { new Guid("00000000-0000-0000-0000-000000000006"), "PreAppraisal", 10000m, null, "System", null, "01", true, null, 0m, null, null, null });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FeeStructures_FeeCode_AppraisalType_MinSellingPrice",
+                schema: "appraisal",
+                table: "FeeStructures",
+                columns: new[] { "FeeCode", "AppraisalType", "MinSellingPrice" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_FeeStructures_FeeCode_AppraisalType_MinSellingPrice",
+                schema: "appraisal",
+                table: "FeeStructures");
+
+            migrationBuilder.DeleteData(
+                schema: "appraisal",
+                table: "FeeStructures",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000006"));
+
+            migrationBuilder.DropColumn(
+                name: "AppraisalType",
+                schema: "appraisal",
+                table: "FeeStructures");
+
+            migrationBuilder.UpdateData(
+                schema: "appraisal",
+                table: "FeeStructures",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000001"),
+                columns: new[] { "BaseAmount", "MaxSellingPrice" },
+                values: new object[] { 3500m, 5000000m });
+
+            migrationBuilder.UpdateData(
+                schema: "appraisal",
+                table: "FeeStructures",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000004"),
+                columns: new[] { "BaseAmount", "MinSellingPrice" },
+                values: new object[] { 5000m, 5000001m });
+
+            migrationBuilder.UpdateData(
+                schema: "appraisal",
+                table: "FeeStructures",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000005"),
+                column: "BaseAmount",
+                value: 7000m);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FeeStructures_FeeCode_MinSellingPrice",
+                schema: "appraisal",
+                table: "FeeStructures",
+                columns: new[] { "FeeCode", "MinSellingPrice" },
+                unique: true);
+        }
+    }
+}

--- a/Modules/Common/Common/Application/Features/Monitoring/GetTaskTypes/GetTaskTypesEndpoint.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetTaskTypes/GetTaskTypesEndpoint.cs
@@ -12,9 +12,10 @@ public class GetTaskTypesEndpoint : ICarterModule
     {
         app.MapGet(
                 "/monitoring/task-types",
-                async (ISender sender, CancellationToken cancellationToken) =>
+                async (string? monitoringType, ISender sender, CancellationToken cancellationToken) =>
                 {
-                    var result = await sender.Send(new GetTaskTypesQuery(), cancellationToken);
+                    var query = new GetTaskTypesQuery(MonitoringTypes.Normalize(monitoringType));
+                    var result = await sender.Send(query, cancellationToken);
                     return Results.Ok(result);
                 })
             .WithName("MonitoringGetTaskTypes")
@@ -22,7 +23,7 @@ public class GetTaskTypesEndpoint : ICarterModule
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status403Forbidden)
             .WithSummary("Monitoring: Task types")
-            .WithDescription("Returns the universe of all task types defined across active workflow definitions. Used to populate the taskType filter on monitoring screens.")
+            .WithDescription("Returns the task types present on the given monitoring screen (monitoringType=Internal|External, default Internal), scoped to the caller's monitoring permissions. Used to populate the taskType filter.")
             .WithTags("Monitoring")
             .RequireAuthorization();
     }

--- a/Modules/Common/Common/Application/Features/Monitoring/GetTaskTypes/GetTaskTypesQuery.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetTaskTypes/GetTaskTypesQuery.cs
@@ -2,4 +2,23 @@ using Shared.CQRS;
 
 namespace Common.Application.Features.Monitoring.GetTaskTypes;
 
-public record GetTaskTypesQuery : IQuery<IReadOnlyList<TaskTypeOption>>;
+/// <summary>
+/// Task-type filter options for a monitoring screen.
+/// <paramref name="MonitoringType"/> selects the screen: "Internal" or "External".
+/// </summary>
+public record GetTaskTypesQuery(string MonitoringType = MonitoringTypes.Internal)
+    : IQuery<IReadOnlyList<TaskTypeOption>>;
+
+/// <summary>Allowed values for <see cref="GetTaskTypesQuery.MonitoringType"/>.</summary>
+public static class MonitoringTypes
+{
+    public const string Internal = "Internal";
+    public const string External = "External";
+
+    /// <summary>
+    /// Maps caller input onto a known value, falling back to Internal. Used instead of passing the
+    /// raw string through so an unrecognised value can never reach the query.
+    /// </summary>
+    public static string Normalize(string? value) =>
+        string.Equals(value, External, StringComparison.OrdinalIgnoreCase) ? External : Internal;
+}

--- a/Modules/Common/Common/Application/Features/Monitoring/GetTaskTypes/GetTaskTypesQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetTaskTypes/GetTaskTypesQueryHandler.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+using Common.Application.Features.Monitoring.Shared;
 using Dapper;
 using Shared.CQRS;
 using Shared.Data;
@@ -6,74 +6,56 @@ using Shared.Data;
 namespace Common.Application.Features.Monitoring.GetTaskTypes;
 
 /// <summary>
-/// Returns the universe of all task types defined across active workflow definitions.
-/// Reads JsonDefinition from workflow.WorkflowDefinitions, parses workflowSchema.activities[],
-/// filters to entries whose type is one of the pending-task-producing kinds
-/// (TaskActivity, FanOutTaskActivity, ApprovalActivity),
-/// extracts name (label) and properties.activityName (value), dedupes by value, and sorts by label.
+/// Returns the task types actually present on a monitoring screen, for its taskType filter.
+///
+/// Sourced from common.vw_MonitoringPendingTasks — the same view the grid reads — so every option
+/// is guaranteed to match at least one visible row, and its label matches the grid's Task Type
+/// column (both are PendingTask.TaskDescription, i.e. the workflow activity's display name).
+///
+/// This deliberately does NOT read workflow.WorkflowDefinitions.JsonDefinition. That column holds
+/// two different JSON shapes — the seeders store the whole config file (root "workflowSchema"),
+/// while the Workflow Builder stores the bare WorkflowSchema — so parsing it dropped whole
+/// workflows from the list depending only on how each definition happened to be saved.
 /// </summary>
-public class GetTaskTypesQueryHandler(ISqlConnectionFactory connectionFactory)
+public class GetTaskTypesQueryHandler(
+    ISqlConnectionFactory connectionFactory,
+    MonitoringScopeService scopeService)
     : IQueryHandler<GetTaskTypesQuery, IReadOnlyList<TaskTypeOption>>
 {
-    private static readonly HashSet<string> PendingTaskProducingTypes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "TaskActivity",
-        "FanOutTaskActivity",
-        "ApprovalActivity"
-    };
-
     public async Task<IReadOnlyList<TaskTypeOption>> Handle(
         GetTaskTypesQuery query,
         CancellationToken cancellationToken)
     {
-        const string sql = "SELECT JsonDefinition FROM workflow.WorkflowDefinitions WHERE IsActive = 1";
+        var monitoringType = MonitoringTypes.Normalize(query.MonitoringType);
+
+        var scope = monitoringType == MonitoringTypes.External
+            ? scopeService.ResolveExternalScope()
+            : scopeService.ResolveInternalScope();
+
+        var conditions = new List<string> { "MonitoringType = @MonitoringType", "TaskType IS NOT NULL" };
+        var parameters = new DynamicParameters();
+        parameters.Add("MonitoringType", monitoringType);
+
+        // Same activity + team scope as the grid — a user may only filter by what they can see.
+        // Empty scope ⇒ user holds no monitoring permission for this screen.
+        if (!scopeService.TryBuildActivityFilter(scope, conditions, parameters))
+            return [];
+
+        // GROUP BY (not DISTINCT) so a task type whose rows carry differing descriptions still
+        // yields exactly one option — the dropdown's value must be unique.
+        // Column order MUST match TaskTypeOption's positional record constructor (Value, Label).
+        var sql = $@"
+SELECT
+    TaskType                                                  AS Value,
+    COALESCE(NULLIF(MIN(TaskDescription), ''), TaskType)      AS Label
+FROM common.vw_MonitoringPendingTasks
+WHERE {string.Join(" AND ", conditions)}
+GROUP BY TaskType
+ORDER BY Label";
 
         var conn = connectionFactory.GetOpenConnection();
-        var jsonDefinitions = await conn.QueryAsync<string>(sql);
+        var options = await conn.QueryAsync<TaskTypeOption>(sql, parameters);
 
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var results = new List<TaskTypeOption>();
-
-        foreach (var json in jsonDefinitions)
-        {
-            if (string.IsNullOrWhiteSpace(json)) continue;
-
-            try
-            {
-                using var doc = JsonDocument.Parse(json);
-                if (!doc.RootElement.TryGetProperty("workflowSchema", out var schema)) continue;
-                if (!schema.TryGetProperty("activities", out var activities)) continue;
-
-                foreach (var activity in activities.EnumerateArray())
-                {
-                    if (!activity.TryGetProperty("type", out var typeProp)) continue;
-                    var type = typeProp.GetString() ?? string.Empty;
-
-                    if (!PendingTaskProducingTypes.Contains(type)) continue;
-
-                    if (!activity.TryGetProperty("properties", out var props)) continue;
-                    if (!props.TryGetProperty("activityName", out var activityNameProp)) continue;
-
-                    var value = activityNameProp.GetString();
-                    if (string.IsNullOrWhiteSpace(value)) continue;
-
-                    if (!seen.Add(value)) continue;
-
-                    var label = activity.TryGetProperty("name", out var nameProp)
-                        ? nameProp.GetString() ?? value
-                        : value;
-
-                    results.Add(new TaskTypeOption(value, label));
-                }
-            }
-            catch (JsonException)
-            {
-                // Malformed definition — skip silently
-            }
-        }
-
-        return results
-            .OrderBy(x => x.Label, StringComparer.OrdinalIgnoreCase)
-            .ToList();
+        return options.ToList();
     }
 }

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultQueryHandler.cs
@@ -187,7 +187,7 @@ internal static class LegacyResultMapper
             Wah = row.Wa ?? 0m,
             RoomNo = Str(row.RoomNo),
             FloorNo = Str(row.FloorNo),                 // the unit's own floor
-            FloorNumber = NumStr(row.CondoTotalFloor),  // total floors of the building
+            FloorNumber = FloorNumberStr(row.CondoTotalFloor, Str(row.FloorNo)),  // total floors (default from FloorNo)
             BuildingNo = Str(row.BuildingNo),
             BuildingAge = row.CondoBuildingAge ?? row.BuildingAge ?? 0,
             AreaUtilize = row.AreaUtilize ?? 0m,
@@ -237,7 +237,7 @@ internal static class LegacyResultMapper
             HouseNo = Str(building?.HouseNo),
             BuildingNo = Str(building?.BuildingNo),
             BuildingAge = building?.BuildingAge ?? 0,
-            FloorNumber = NumStr(building?.TotalFloor),   // total floors of the building
+            FloorNumber = FloorNumberStr(building?.TotalFloor, ""),   // non-condo has no unit floor → default 1
             AreaUtilize = building?.TotalBuildingArea ?? 0m,
             Decorate = ParseDecorate(building?.BuildingDecorationType),
             BuildingDetails = Str(FirstNonEmpty(land?.Village, building?.CondoName)),
@@ -275,7 +275,7 @@ internal static class LegacyResultMapper
             HouseNo = isCondo ? "" : Str(unit.HouseNumber),
             RoomNo = isCondo ? Str(unit.UnitRoomNo ?? unit.RoomNumber) : "",
             FloorNo = isCondo ? IntStr(unit.Floor) : "",                       // the unit's own floor
-            FloorNumber = IntStr(unit.TowerFloors ?? unit.NumberOfFloors),     // total floors (from the tower)
+            FloorNumber = FloorNumberStr(unit.TowerFloors ?? unit.NumberOfFloors, isCondo ? IntStr(unit.Floor) : ""),   // total floors from tower (default from FloorNo)
             BuildingAge = unit.TowerBuildingAge ?? 0,
             BuildingNo = isCondo ? Str(unit.TowerName) : "",
             BuildingRegisterNo = isCondo ? Str(unit.CondoRegistrationNumber) : "",
@@ -426,6 +426,23 @@ internal static class LegacyResultMapper
             : (value.Value == Math.Truncate(value.Value)
                 ? ((long)value.Value).ToString(CultureInfo.InvariantCulture)
                 : value.Value.ToString(CultureInfo.InvariantCulture));
+
+    // Total floors as a string. Uses the real value when present; otherwise derives from the unit's own
+    // floor (FloorNo): empty → "1"; contains a non-digit char (e.g. "25A") → floor + 1; else → the floor.
+    private static string FloorNumberStr(decimal? totalFloors, string floorNo)
+    {
+        if (totalFloors is > 0m) return NumStr(totalFloors);
+
+        floorNo = floorNo?.Trim() ?? string.Empty;
+        if (floorNo.Length == 0) return "1";
+
+        var leadingDigits = new string(floorNo.TakeWhile(char.IsDigit).ToArray());
+        if (!int.TryParse(leadingDigits, NumberStyles.Integer, CultureInfo.InvariantCulture, out var floor))
+            return "1";
+
+        var hasNonDigit = floorNo.Any(c => !char.IsDigit(c));
+        return (hasNonDigit ? floor + 1 : floor).ToString(CultureInfo.InvariantCulture);
+    }
 
     private static string IsoDate(DateTime? value) =>
         value?.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture) ?? string.Empty;

--- a/Modules/Reporting/Reporting/Application/Models/AppraisalSummaryModel.cs
+++ b/Modules/Reporting/Reporting/Application/Models/AppraisalSummaryModel.cs
@@ -59,7 +59,13 @@ public sealed class AppraisalSummaryModel
     /// <summary>Field 7 — Full collateral address built via ThaiAddressFormatter.</summary>
     public string? CollateralAddress { get; init; }
 
-    /// <summary>Field 8 — Administrative sub-district (ตำบล/แขวง).</summary>
+    /// <summary>
+    /// Field 8 — Administrative sub-district (เขตการปกครอง). Sourced from
+    /// request.RequestDetails — the same sub-district that feeds the ตำบล/แขวง segment of
+    /// <see cref="CollateralAddress"/>, so the two header lines always agree. Resolved against
+    /// the DOPA master, falling back to Title for rows saved while the Location form still
+    /// captured Title geocodes.
+    /// </summary>
     public string? AdministrativeDistrict { get; init; }
 
     /// <summary>Field 9 — Land Office name.</summary>

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryBlockDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryBlockDataProvider.cs
@@ -362,7 +362,7 @@ public sealed class AppraisalSummaryBlockDataProvider(
 
             // ที่ตั้งทรัพย์สิน from the Request detail (same as the land-building form)
             CollateralAddress       = common.CollateralAddress,
-            AdministrativeDistrict  = project.SubDistrict,
+            AdministrativeDistrict  = common.AdministrativeDistrict,
             LandOffice              = project.LandOffice,
             OldAppraisalValue       = common.PrevAppraisedValue,
             HasPrevAppraisal        = common.HasPrevAppraisal,

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryCommonLoader.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryCommonLoader.cs
@@ -97,15 +97,18 @@ internal static class AppraisalSummaryCommonLoader
                 a.FacilityLimit,
                 rd.AdditionalFacilityLimit,
                 rd.PreviousFacilityLimit,
-                -- Collateral address (ที่ตั้งทรัพย์สิน) from the Request detail, same as land-building
+                -- Collateral address (ที่ตั้งทรัพย์สิน) from the Request detail, same as land-building.
+                -- The Location form captures these as DOPA geocodes (กรมการปกครอง), so DOPA wins;
+                -- Title is the fallback for rows saved while that form still used the Title picker,
+                -- and the raw geocode is the last resort.
                 rd.HouseNumber,
                 rd.ProjectName,
                 rd.Moo,
                 rd.Soi,
                 rd.Road,
-                COALESCE(tsub.NameTh,  rd.SubDistrict) AS ReqSubDistrict,
-                COALESCE(tdist.NameTh, rd.District)    AS ReqDistrict,
-                COALESCE(tprov.NameTh, rd.Province)    AS ReqProvince
+                COALESCE(dsub.NameTh,  tsub.NameTh,  rd.SubDistrict) AS ReqSubDistrict,
+                COALESCE(ddist.NameTh, tdist.NameTh, rd.District)    AS ReqDistrict,
+                COALESCE(dprov.NameTh, tprov.NameTh, rd.Province)    AS ReqProvince
             FROM appraisal.Appraisals a
             LEFT JOIN parameter.Parameters pPurpose
                 ON pPurpose.[group]    = 'AppraisalPurpose'
@@ -113,6 +116,9 @@ internal static class AppraisalSummaryCommonLoader
                AND pPurpose.[isactive] = 1
                AND pPurpose.[code]     = a.Purpose
             LEFT JOIN request.RequestDetails rd ON rd.RequestId = a.RequestId
+            LEFT JOIN parameter.DopaProvinces     dprov ON dprov.Code = rd.Province
+            LEFT JOIN parameter.DopaDistricts     ddist ON ddist.Code = rd.District
+            LEFT JOIN parameter.DopaSubDistricts  dsub  ON dsub.Code  = rd.SubDistrict
             LEFT JOIN parameter.TitleProvinces    tprov ON tprov.Code = rd.Province
             LEFT JOIN parameter.TitleDistricts    tdist ON tdist.Code = rd.District
             LEFT JOIN parameter.TitleSubDistricts tsub  ON tsub.Code  = rd.SubDistrict
@@ -505,11 +511,11 @@ internal static class AppraisalSummaryCommonLoader
         latestByActivity.TryGetValue("int-appraisal-verification", out var verifyTask);
 
         string? staffName = string.IsNullOrWhiteSpace(staffTask?.FullName) ? null : staffTask.FullName!.Trim();
-        string? staffPosition = string.IsNullOrWhiteSpace(staffTask?.Position) ? null : staffTask.Position;
+        string? staffPosition = NormalizePosition(staffTask?.Position);
         string? checkerName = string.IsNullOrWhiteSpace(checkerTask?.FullName) ? null : checkerTask.FullName!.Trim();
-        string? checkerPosition = string.IsNullOrWhiteSpace(checkerTask?.Position) ? null : checkerTask.Position;
+        string? checkerPosition = NormalizePosition(checkerTask?.Position);
         string? verifyName = string.IsNullOrWhiteSpace(verifyTask?.FullName) ? null : verifyTask.FullName!.Trim();
-        string? verifyPosition = string.IsNullOrWhiteSpace(verifyTask?.Position) ? null : verifyTask.Position;
+        string? verifyPosition = NormalizePosition(verifyTask?.Position);
 
         // ── CollateralType map ───────────────────────────────────────────────────
         var collateralTypeMap = collateralTypeParams
@@ -558,6 +564,9 @@ internal static class AppraisalSummaryCommonLoader
             AppraisalType: header.AppraisalType,
             AppraisalPurpose: header.AppraisalPurpose,
             CollateralAddress: string.IsNullOrEmpty(reqCollateralAddress) ? null : reqCollateralAddress,
+            // เขตการปกครอง — the same Request-detail sub-district that feeds the ตำบล/แขวง segment
+            // of CollateralAddress above, so the two header lines can never disagree.
+            AdministrativeDistrict: header.ReqSubDistrict,
             FacilityLimit: header.FacilityLimit,
             CustomerName: customerName,
             AppraisalDate: appraisalDate,
@@ -598,6 +607,14 @@ internal static class AppraisalSummaryCommonLoader
             PrevAppraisedValue: prevAppraisal?.PrevAppraisedValue,
             HasPrevAppraisal: prevAppraisal?.PrevAppraisalId is not null);
     }
+
+    /// <summary>
+    /// Normalizes a sign-off position (auth.AspNetUsers.Position) for display. Blank — or a lone
+    /// "-", the placeholder convention used elsewhere in this module — becomes null so the
+    /// template drops the line rather than printing a stray dash under someone's name.
+    /// </summary>
+    internal static string? NormalizePosition(string? position) =>
+        string.IsNullOrWhiteSpace(position) || position.Trim() == "-" ? null : position.Trim();
 
     // ── Private flat DTOs for Dapper mapping ─────────────────────────────────────
 
@@ -736,6 +753,7 @@ internal sealed record CommonAppraisalData(
     string? AppraisalType,
     string? AppraisalPurpose,
     string? CollateralAddress,
+    string? AdministrativeDistrict,
     decimal? FacilityLimit,
     string? CustomerName,
     DateTime? AppraisalDate,

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryCondoDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryCondoDataProvider.cs
@@ -336,7 +336,7 @@ public sealed class AppraisalSummaryCondoDataProvider(
             PropertyType = "ห้องชุด",
             SummaryPropertyType = "ห้องชุด",
             CollateralAddress = common.CollateralAddress,
-            AdministrativeDistrict = firstCondo?.SubDistrict,
+            AdministrativeDistrict = common.AdministrativeDistrict,
             LandOffice = firstCondo?.LandOffice,
             OldAppraisalValue = common.PrevAppraisedValue,
             HasPrevAppraisal = common.HasPrevAppraisal,

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryConstructionDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryConstructionDataProvider.cs
@@ -349,7 +349,7 @@ public sealed class AppraisalSummaryConstructionDataProvider(
             AppraisalPurpose    = common.AppraisalPurpose,
             PropertyType        = propertyType,
             CollateralAddress   = string.IsNullOrEmpty(collateralAddress) ? null : collateralAddress,
-            AdministrativeDistrict = landAddr?.SubDistrict,
+            AdministrativeDistrict = common.AdministrativeDistrict,
             LandOffice          = landAddr?.LandOffice,
             OldAppraisalValue   = common.PrevAppraisedValue,
             HasPrevAppraisal    = common.HasPrevAppraisal,

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryLandBuildingDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryLandBuildingDataProvider.cs
@@ -445,20 +445,26 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
             WHERE pg.AppraisalId = @AppraisalId
             ORDER BY pgi.PropertyGroupId, pgi.SequenceInGroup;
 
-            -- RS20: Collateral address + loan limits from the Request detail (geocodes resolved)
+            -- RS20: Collateral address + loan limits from the Request detail (geocodes resolved).
+            -- The Location form captures these as DOPA geocodes (กรมการปกครอง), so DOPA wins; Title
+            -- is the fallback for rows saved while that form still used the Title picker, and the
+            -- raw geocode is the last resort.
             SELECT TOP 1
                 rd.HouseNumber,
                 rd.ProjectName,
                 rd.Moo,
                 rd.Soi,
                 rd.Road,
-                COALESCE(tsub.NameTh,  rd.SubDistrict) AS SubDistrict,
-                COALESCE(tdist.NameTh, rd.District)    AS District,
-                COALESCE(tprov.NameTh, rd.Province)    AS Province,
+                COALESCE(dsub.NameTh,  tsub.NameTh,  rd.SubDistrict) AS SubDistrict,
+                COALESCE(ddist.NameTh, tdist.NameTh, rd.District)    AS District,
+                COALESCE(dprov.NameTh, tprov.NameTh, rd.Province)    AS Province,
                 rd.FacilityLimit,
                 rd.AdditionalFacilityLimit,
                 rd.PreviousFacilityLimit
             FROM request.RequestDetails rd
+            LEFT JOIN parameter.DopaProvinces     dprov ON dprov.Code = rd.Province
+            LEFT JOIN parameter.DopaDistricts     ddist ON ddist.Code = rd.District
+            LEFT JOIN parameter.DopaSubDistricts  dsub  ON dsub.Code  = rd.SubDistrict
             LEFT JOIN parameter.TitleProvinces    tprov ON tprov.Code = rd.Province
             LEFT JOIN parameter.TitleDistricts    tdist ON tdist.Code = rd.District
             LEFT JOIN parameter.TitleSubDistricts tsub  ON tsub.Code  = rd.SubDistrict
@@ -806,11 +812,11 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
         latestByActivity.TryGetValue("int-appraisal-verification", out var verifyTask);
 
         string? staffName = string.IsNullOrWhiteSpace(staffTask?.FullName) ? null : staffTask.FullName!.Trim();
-        string? staffPosition = string.IsNullOrWhiteSpace(staffTask?.Position) ? null : staffTask.Position;
+        string? staffPosition = AppraisalSummaryCommonLoader.NormalizePosition(staffTask?.Position);
         string? checkerName = string.IsNullOrWhiteSpace(checkerTask?.FullName) ? null : checkerTask.FullName!.Trim();
-        string? checkerPosition = string.IsNullOrWhiteSpace(checkerTask?.Position) ? null : checkerTask.Position;
+        string? checkerPosition = AppraisalSummaryCommonLoader.NormalizePosition(checkerTask?.Position);
         string? verifyName = string.IsNullOrWhiteSpace(verifyTask?.FullName) ? null : verifyTask.FullName!.Trim();
-        string? verifyPosition = string.IsNullOrWhiteSpace(verifyTask?.Position) ? null : verifyTask.Position;
+        string? verifyPosition = AppraisalSummaryCommonLoader.NormalizePosition(verifyTask?.Position);
 
         // ── Build group lookups ───────────────────────────────────────────────────
         var titlesByGroup = groupTitleRows
@@ -1283,7 +1289,7 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
             PropertyType = firstPropertyType,
             SummaryPropertyType = firstPropertyType,
             CollateralAddress = string.IsNullOrEmpty(collateralAddress) ? null : collateralAddress,
-            AdministrativeDistrict = land?.SubDistrict,
+            AdministrativeDistrict = requestAddress?.SubDistrict,
             LandOffice = land?.LandOffice,
             OldAppraisalValue = oldAppraisalValue,
             HasPrevAppraisal = hasPrevAppraisal,

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryMachineDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryMachineDataProvider.cs
@@ -207,7 +207,7 @@ public sealed class AppraisalSummaryMachineDataProvider(
             SummaryPropertyType = "เครื่องจักร",
             // ที่ตั้งทรัพย์สิน from the Request detail (same as land-building); fall back to the machine's own address.
             CollateralAddress = common.CollateralAddress ?? collateralAddress,
-            AdministrativeDistrict = null,
+            AdministrativeDistrict = common.AdministrativeDistrict,
             LandOffice = null,
             OldAppraisalValue = common.PrevAppraisedValue,
             HasPrevAppraisal = common.HasPrevAppraisal,

--- a/Modules/Reporting/Reporting/Templates/partials/summary-signoff.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-signoff.html
@@ -2,6 +2,10 @@
   Partial: shared 3-column sign-off (ผู้นำเสนอ / ผู้จัดการส่วน / ผู้ช่วยผู้อำนวยการ), identical across
   all summary bodies. Shares the parent Scriban scope; expects model.* fields.
 
+  Each column ends with the signer's own position (auth.AspNetUsers.Position of whoever completed
+  the activity), under the fixed role label. It is omitted entirely when unknown — a column whose
+  activity has not been completed yet has neither a name nor a position.
+
   The committee block is NOT included here — each body includes partials/approver-block as a sibling
   so the two paginate independently. See .signoff / .committee-block in partials/summary-styles.
 -->
@@ -10,15 +14,18 @@
     <div class="nm-name">{{ model.appraisal_staff_name }}</div>
     <div class="nm-paren">{{ if model.appraisal_staff_name }}( {{ model.appraisal_staff_name }} ){{ end }}</div>
     <div>ผู้นำเสนอ</div>
+    {{ if model.appraisal_staff_position }}<div class="pos">{{ model.appraisal_staff_position }}</div>{{ end }}
   </div>
   <div class="cell">
     <div class="nm-name">{{ model.appraisal_checker_name }}</div>
     <div class="nm-paren">{{ if model.appraisal_checker_name }}( {{ model.appraisal_checker_name }} ){{ end }}</div>
     <div>ผู้จัดการส่วน</div>
+    {{ if model.appraisal_checker_position }}<div class="pos">{{ model.appraisal_checker_position }}</div>{{ end }}
   </div>
   <div class="cell">
     <div class="nm-name">{{ model.appraisal_verify_name }}</div>
     <div class="nm-paren">{{ if model.appraisal_verify_name }}( {{ model.appraisal_verify_name }} ){{ end }}</div>
     <div>ผู้ช่วยผู้อำนวยการ</div>
+    {{ if model.appraisal_verify_position }}<div class="pos">{{ model.appraisal_verify_position }}</div>{{ end }}
   </div>
 </div>

--- a/Tests/Unit/Appraisal.Tests/Application/Services/AssignmentFeeServiceTierTests.cs
+++ b/Tests/Unit/Appraisal.Tests/Application/Services/AssignmentFeeServiceTierTests.cs
@@ -1,0 +1,150 @@
+using Appraisal.Application.Services;
+using Appraisal.Domain.Appraisals;
+using Appraisal.Infrastructure;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Parameter.Contracts.Parameters;
+using Parameter.Contracts.Parameters.Dtos;
+
+namespace Appraisal.Tests.Application.Services;
+
+/// <summary>
+/// Covers the TierBased branch of <see cref="AssignmentFeeService"/> — specifically the
+/// AppraisalType-scoped ladder. A tier scoped to an appraisal type replaces the generic
+/// (null-scoped) ladder for that type rather than competing with it, which is what lets
+/// PreAppraisal (block / M-F project) carry a flat rate at any selling price.
+/// </summary>
+public class AssignmentFeeServiceTierTests
+{
+    private const decimal PreAppraisalFlatFee = 10_000m;
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1_000_000)]
+    [InlineData(500_000_000)]
+    public async Task PreAppraisal_UsesFlatTypeScopedTier_RegardlessOfSellingPrice(decimal sellingPrice)
+    {
+        await using var db = NewDb();
+        SeedGenericLadder(db);
+        db.FeeStructures.Add(FeeStructure.Create(
+            "01", PreAppraisalFlatFee, 0m, null, true, AppraisalTypes.PreAppraisal));
+        var assignmentId = SeedFeeShell(db, sellingPrice);
+        await db.SaveChangesAsync();
+
+        await BuildService(db).EnsureAssignmentFeeItemsAsync(
+            Guid.NewGuid(), assignmentId,
+            new AssignmentFeeSource.TierBased(AppraisalTypes.PreAppraisal),
+            CancellationToken.None);
+
+        var fee = db.AppraisalFees.Include(f => f.Items).Single();
+        var item = Assert.Single(fee.Items);
+        Assert.Equal("01", item.FeeCode);
+        Assert.Equal(PreAppraisalFlatFee, item.FeeAmount);
+        // Ex-VAT in, VAT added on top by the aggregate.
+        Assert.Equal(PreAppraisalFlatFee, fee.TotalFeeBeforeVAT);
+        Assert.Equal(700m, fee.VATAmount);
+        Assert.Equal(10_700m, fee.TotalFeeAfterVAT);
+    }
+
+    [Theory]
+    [InlineData(AppraisalTypes.New, 1_000_000, 2_500)]
+    [InlineData(AppraisalTypes.New, 8_000_000, 3_000)]
+    [InlineData(AppraisalTypes.ReAppraisal, 50_000_000, 3_500)]
+    // A type with no scoped rows of its own still resolves to the generic ladder.
+    [InlineData(AppraisalTypes.Progressive, 1_000_000, 2_500)]
+    public async Task TypesWithoutTheirOwnLadder_FallBackToGenericBands(
+        string appraisalType, decimal sellingPrice, decimal expectedAmount)
+    {
+        await using var db = NewDb();
+        SeedGenericLadder(db);
+        db.FeeStructures.Add(FeeStructure.Create(
+            "01", PreAppraisalFlatFee, 0m, null, true, AppraisalTypes.PreAppraisal));
+        var assignmentId = SeedFeeShell(db, sellingPrice);
+        await db.SaveChangesAsync();
+
+        await BuildService(db).EnsureAssignmentFeeItemsAsync(
+            Guid.NewGuid(), assignmentId,
+            new AssignmentFeeSource.TierBased(appraisalType),
+            CancellationToken.None);
+
+        var fee = db.AppraisalFees.Include(f => f.Items).Single();
+        Assert.Equal(expectedAmount, Assert.Single(fee.Items).FeeAmount);
+    }
+
+    [Fact]
+    public async Task NoTierConfiguredAtAll_LeavesFeeWithoutItems_AndDoesNotThrow()
+    {
+        // Guards the assignment consumer: an admin deleting every FeeCode "01" row used to throw
+        // out of the fee service and nack the integration event into a retry loop.
+        await using var db = NewDb();
+        var assignmentId = SeedFeeShell(db, 1_000_000m);
+        await db.SaveChangesAsync();
+
+        await BuildService(db).EnsureAssignmentFeeItemsAsync(
+            Guid.NewGuid(), assignmentId,
+            new AssignmentFeeSource.TierBased(AppraisalTypes.New),
+            CancellationToken.None);
+
+        var fee = db.AppraisalFees.Include(f => f.Items).Single();
+        Assert.Empty(fee.Items);
+        Assert.Equal(0m, fee.TotalFeeAfterVAT);
+    }
+
+    [Fact]
+    public async Task SellingPriceInTheGapBetweenBands_FallsBackToTheHighestBand()
+    {
+        // The seeded generic bands are 0–7,000,000 then 7,000,001–… so a fractional value in
+        // between matches nothing. Existing behaviour: take the highest band.
+        await using var db = NewDb();
+        SeedGenericLadder(db);
+        var assignmentId = SeedFeeShell(db, 7_000_000.50m);
+        await db.SaveChangesAsync();
+
+        await BuildService(db).EnsureAssignmentFeeItemsAsync(
+            Guid.NewGuid(), assignmentId,
+            new AssignmentFeeSource.TierBased(AppraisalTypes.New),
+            CancellationToken.None);
+
+        var fee = db.AppraisalFees.Include(f => f.Items).Single();
+        Assert.Equal(3_500m, Assert.Single(fee.Items).FeeAmount);
+    }
+
+    // ── Helpers ──
+
+    private static AppraisalDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<AppraisalDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    /// <summary>The three null-scoped bands seeded by FeeStructureConfiguration.</summary>
+    private static void SeedGenericLadder(AppraisalDbContext db)
+    {
+        db.FeeStructures.AddRange(
+            FeeStructure.Create("01", 2_500m, 0m, 7_000_000m),
+            FeeStructure.Create("01", 3_000m, 7_000_001m, 10_000_000m),
+            FeeStructure.Create("01", 3_500m, 10_000_001m, null));
+    }
+
+    private static Guid SeedFeeShell(AppraisalDbContext db, decimal totalSellingPrice)
+    {
+        var assignmentId = Guid.CreateVersion7();
+        db.AppraisalFees.Add(AppraisalFee.Create(assignmentId, totalSellingPrice: totalSellingPrice));
+        return assignmentId;
+    }
+
+    private static AssignmentFeeService BuildService(AppraisalDbContext db)
+    {
+        var parameterLookup = Substitute.For<IParameterLookupService>();
+        parameterLookup
+            .GetDescriptionAsync(Arg.Any<ParameterDto>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null); // service falls back to the fee code as the name
+
+        return new AssignmentFeeService(
+            db,
+            Substitute.For<ISender>(),
+            parameterLookup,
+            NullLogger<AssignmentFeeService>.Instance);
+    }
+}


### PR DESCRIPTION
Backend half of a pair. Frontend: **immortalgky/collateral-appraisal-system-app#293** — the monitoring change is a breaking hook-signature change, so these must be released together.

## Fee ladders scoped by appraisal type

`FeeStructure` gains a nullable `AppraisalType` that partitions the table into **ladders**. `null` = the generic ladder that applies to any type; a value scopes the ladder to one `AppraisalTypes` constant. When a scoped ladder exists it **replaces** the generic one rather than merging with it.

This gives block / M-F project deals (`PreAppraisal`) their flat **10,000 ex-VAT** fee regardless of selling price. The generic bands are rebanded at the same time:

| Tier | Before | After |
|---|---|---|
| 1 | 3,500 / 0–5M | **2,500 / 0–7M** |
| 4 | 5,000 / 5,000,001–10M | **3,000 / 7,000,001–10M** |
| 5 | 7,000 | **3,500** |

- Unique index widens `(FeeCode, MinSellingPrice)` → `(FeeCode, AppraisalType, MinSellingPrice)` with `.HasFilter(null)`, suppressing EF's default `IS NOT NULL` filter so the generic ladder keeps its uniqueness.
- `TierBased` becomes `record TierBased(string? AppraisalType = null)`. The default keeps all three call sites compiling, and all three route through `ResolveSourceForAppraisalAsync`, so type stamping is universal.
- `Update()` deliberately does not touch `AppraisalType` — `FeeCode` + `AppraisalType` are together the immutable ladder identity.
- Resolving a fee with **zero** candidate rows now logs an error instead of throwing out of `.First()`.

## Monitoring task types: new data source

`GetTaskTypesQueryHandler` stops parsing `workflow.WorkflowDefinitions.JsonDefinition`. That column holds **two different shapes** — the seeder writes an API envelope with a `workflowSchema` root, the Workflow Builder writes a bare schema — so the old handler silently dropped whole workflows.

It now reads `common.vw_MonitoringPendingTasks` (which already exposes `TaskType`, `TaskDescription`, `MonitoringType` — no view change needed), grouped and labelled, and scoped through the same `MonitoringScopeService.TryBuildActivityFilter` the grid queries use. Query and endpoint take a `monitoringType` (`Internal`/`External`, defaulting to `Internal`) so each section gets its own option list.

## Appraisal summary report

- **Administrative district (field 8)** is the *request's* own sub-district, not the collateral's, and resolves `COALESCE(dopa.NameTh, title.NameTh, raw geocode)`. Four providers now read it from `AppraisalSummaryCommonLoader`; `AppraisalSummaryLandBuildingDataProvider` keeps its own copy of the SQL because it does not use that loader.
- **Sign-off positions** are printed, with `NormalizePosition()` treating a lone `"-"` as blank.

`parameter.Dopa*` and its seed scripts already exist and are untouched here.

## Legacy AS400 result `FloorNumber`

Never emits an empty or zero floor: prefers the total floor count, otherwise derives from the unit's own floor — `"25A"` → `26`, empty or unparseable → `"1"`.

## Testing

- `dotnet build collateral-appraisal-system-api.sln -c Release` — 39 projects, 0 errors.
- `dotnet test Tests/Unit/Appraisal.Tests` — the 9 new `AssignmentFeeServiceTierTests` all pass (PreAppraisal flat 10,000 at 0 / 1M / 500M incl. VAT, fallback to generic bands for unscoped types, empty fee table → no items and no throw, and the 7,000,000.50 band-gap case).
- The 13 other failures in that project are **pre-existing on `main`** — verified by running the same suite on `main` (13 failed / 222 passed there vs 13 failed / 231 passed here, the delta being exactly these 9 new tests). They are in `IncomeCalculationService`, `PricingGroupValidator` and `FeeAppointmentApproval`, none of which this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AEHGsHaUt7oiyxXRfaTtp