### PR TITLE
feat(auth): group the main menu under five containers and fix root sort-order collisions

### DIFF
--- a/Database/Migration/Scripts/20260729120000_UpdateSeed_RegroupMainMenu.sql
+++ b/Database/Migration/Scripts/20260729120000_UpdateSeed_RegroupMainMenu.sql
@@ -1,0 +1,178 @@
+-- ============================================================
+-- Regroup the main navigation menu into five admin groups
+-- Schema: auth
+--
+-- The main sidebar had ~32 top-level items, two-thirds of them single-purpose
+-- admin/config screens. This script introduces five CONTAINER menu items
+-- (Path = NULL, so the sidebar renders them as expand-only toggles) and moves
+-- 20 existing roots underneath them, taking the top level from 32 to 17.
+--
+-- It also repairs a real ordering bug: AuthDataSeed.UpsertTreeAsync derives
+-- SortOrder from list position at FIRST INSERT and advances its counter even
+-- for rows it skips. After many mid-list insertions the live roots collided
+-- (40x2, 50x3, 60x2, 120x2, 180x3, 190x2, 220x2, 230x2), and
+-- GetMyMenuQueryHandler orders by SortOrder alone -- so ties broke
+-- non-deterministically in SQL Server and the on-screen order did not match
+-- the seed file. Step 4 gives all 17 roots a unique SortOrder.
+--
+-- MenuSeedData.cs has been restructured to match, which covers FRESH databases.
+-- Because UpsertTreeAsync is INSERT-ONLY (on an ItemKey match it leaves
+-- ParentId/SortOrder untouched), this script is what applies the change to
+-- databases that already have the flat menu.
+--
+-- Both paths converge: on a fresh DB the migrate tool runs DbUp first, so the
+-- inserts below land and the updates match nothing; the seeder then finds the
+-- container ItemKeys already present and parents the children onto these exact
+-- GUIDs. On an existing DB the inserts add the containers and the updates
+-- re-parent. Container GUIDs are fixed literals so they are identical in every
+-- environment.
+--
+-- Notes:
+--   * auth.MenuItems' PK column is MenuItemId (not Id).
+--   * IconStyle 0 = Solid (Auth.Domain.Menu.IconStyle).
+--   * Scope 0 = Main (Auth.Domain.Menu.MenuScope).
+--   * Audit columns (CreatedAt/By/Workstation, Updated*) are all nullable.
+--   * Container gates are chosen so no seeded role loses a screen it can reach
+--     today -- see the rationale comment in MenuSeedData.cs.
+--   * MenuTreeCache ("auth:menu:full") has NO TTL and is only invalidated
+--     in-process by the admin menu handlers, so RESTART THE API after this runs
+--     (every instance -- it is a per-node IMemoryCache).
+--
+-- Idempotent: re-running is a no-op once the containers exist and the
+-- ParentId/SortOrder values already match.
+-- ============================================================
+
+-- auth.MenuItems carries a FILTERED index -- IX_MenuItems_Scope_Path,
+-- WHERE [Path] IS NOT NULL -- and SQL Server refuses INSERT/UPDATE/DELETE on
+-- such a table unless QUOTED_IDENTIFIER and ANSI_NULLS are ON. DbUp already
+-- sets them, but sqlcmd defaults QUOTED_IDENTIFIER OFF, so state them
+-- explicitly: production applies a generated plain-SQL bundle by hand
+-- (deploy/README.md) and must not depend on the caller's session defaults.
+SET QUOTED_IDENTIFIER ON;
+SET ANSI_NULLS ON;
+GO
+
+-- ---------- 1. The five container rows ----------
+DECLARE @Containers TABLE (
+    MenuItemId           UNIQUEIDENTIFIER NOT NULL,
+    ItemKey              NVARCHAR(200)    NOT NULL,
+    LabelEn              NVARCHAR(500)    NOT NULL,
+    LabelTh              NVARCHAR(500)    NOT NULL,
+    IconName             NVARCHAR(100)    NOT NULL,
+    IconColor            NVARCHAR(100)    NULL,
+    SortOrder            INT              NOT NULL,
+    ViewPermissionCode   NVARCHAR(100)    NULL,
+    ViewPermissionPrefix NVARCHAR(200)    NULL
+);
+
+INSERT INTO @Containers
+    (MenuItemId, ItemKey, LabelEn, LabelTh, IconName, IconColor, SortOrder, ViewPermissionCode, ViewPermissionPrefix)
+VALUES
+    ('7C9E0001-4E1A-4C7B-9A01-4D2F5B6E0001', N'main.master-data',    N'Master Data',    N'ข้อมูลหลัก',    N'database',         N'text-cyan-500',   130, N'COLLATERAL_ADMIN', NULL),
+    ('7C9E0002-4E1A-4C7B-9A01-4D2F5B6E0002', N'main.workflow',       N'Workflow',       N'เวิร์กโฟลว์',      N'diagram-project',  N'text-orange-500', 140, NULL,                N'WORKFLOW_'),
+    ('7C9E0003-4E1A-4C7B-9A01-4D2F5B6E0003', N'main.business-rules', N'Business Rules', N'กฎเกณฑ์ธุรกิจ',   N'sliders',          N'text-rose-500',   150, N'SLA_CONFIG_MANAGE', NULL),
+    ('7C9E0004-4E1A-4C7B-9A01-4D2F5B6E0004', N'main.access',         N'Users & Access', N'ผู้ใช้และสิทธิ์',    N'shield-halved',    N'text-violet-500', 160, N'USER_MANAGE',      NULL),
+    ('7C9E0005-4E1A-4C7B-9A01-4D2F5B6E0005', N'main.system',         N'System',         N'ระบบ',          N'server',           N'text-slate-500',  170, N'LOGS_VIEW',        NULL);
+
+INSERT INTO auth.MenuItems
+    (MenuItemId, ItemKey, Scope, ParentId, Path, IconName, IconStyle, IconColor,
+     SortOrder, ViewPermissionCode, ViewPermissionPrefix, EditPermissionCode, IsSystem, CreatedAt)
+SELECT c.MenuItemId, c.ItemKey, 0, NULL, NULL, c.IconName, 0, c.IconColor,
+       c.SortOrder, c.ViewPermissionCode, c.ViewPermissionPrefix, NULL, 1, SYSDATETIME()
+FROM @Containers c
+WHERE NOT EXISTS (SELECT 1 FROM auth.MenuItems m WHERE m.ItemKey = c.ItemKey);
+
+-- ---------- 2. Container translations (en / th / zh) ----------
+-- zh mirrors the English label, matching AuthDataSeed.BuildTranslations.
+-- Resolve ids from the table (not the literals) so this still works if a row
+-- was created by the seeder first.
+INSERT INTO auth.MenuItemTranslations (MenuItemId, LanguageCode, Label, CreatedAt)
+SELECT m.MenuItemId, t.LanguageCode, t.Label, SYSDATETIME()
+FROM @Containers c
+INNER JOIN auth.MenuItems m ON m.ItemKey = c.ItemKey
+CROSS APPLY (VALUES
+    (N'en', c.LabelEn),
+    (N'th', c.LabelTh),
+    (N'zh', c.LabelEn)
+) AS t(LanguageCode, Label)
+WHERE NOT EXISTS (
+    SELECT 1 FROM auth.MenuItemTranslations x
+    WHERE x.MenuItemId = m.MenuItemId AND x.LanguageCode = t.LanguageCode);
+
+-- ---------- 3. Re-parent the 20 moved items ----------
+DECLARE @Moves TABLE (
+    ItemKey       NVARCHAR(200) NOT NULL,
+    ParentItemKey NVARCHAR(200) NOT NULL,
+    SortOrder     INT           NOT NULL
+);
+
+INSERT INTO @Moves (ItemKey, ParentItemKey, SortOrder) VALUES
+    -- Master Data
+    (N'main.collateral-master',          N'main.master-data',    10),
+    (N'main.template-management',        N'main.master-data',    20),
+    -- Workflow
+    (N'main.workflow-builder',           N'main.workflow',       10),
+    (N'main.workflow-step-validation',   N'main.workflow',       20),
+    (N'main.workflow-assignment-config', N'main.workflow',       30),
+    (N'main.workflow-roundrobin-config', N'main.workflow',       40),
+    -- Business Rules
+    (N'main.parameter',                  N'main.business-rules', 10),
+    (N'main.document-requirements',      N'main.business-rules', 20),
+    (N'main.fee-structures',             N'main.business-rules', 30),
+    (N'main.fee-approval-tiers',         N'main.business-rules', 40),
+    (N'main.appointment-approval-rule',  N'main.business-rules', 50),
+    (N'main.evaluation-config',          N'main.business-rules', 60),
+    (N'main.sla-config',                 N'main.business-rules', 70),
+    -- Users & Access
+    (N'main.user-management',            N'main.access',         10),
+    (N'main.oauth',                      N'main.access',         20),
+    (N'main.audit-log',                  N'main.access',         30),
+    (N'main.access-report',              N'main.access',         40),
+    -- System
+    (N'main.logs',                       N'main.system',         10),
+    (N'main.webhook-subscriptions',      N'main.system',         20),
+    (N'main.webhook-deliveries',         N'main.system',         30);
+
+UPDATE m
+SET m.ParentId  = p.MenuItemId,
+    m.SortOrder = mv.SortOrder,
+    m.UpdatedAt = SYSDATETIME()
+FROM auth.MenuItems m
+INNER JOIN @Moves mv       ON mv.ItemKey = m.ItemKey
+INNER JOIN auth.MenuItems p ON p.ItemKey = mv.ParentItemKey
+WHERE m.ParentId IS NULL
+   OR m.ParentId <> p.MenuItemId
+   OR m.SortOrder <> mv.SortOrder;
+
+-- ---------- 4. Unique SortOrder for all 17 roots ----------
+-- This is the duplicate-ordering fix; it must cover the twelve untouched
+-- operational roots too, not just the new groups.
+DECLARE @Roots TABLE (ItemKey NVARCHAR(200) NOT NULL, SortOrder INT NOT NULL);
+INSERT INTO @Roots (ItemKey, SortOrder) VALUES
+    (N'main.dashboard',      10),
+    (N'main.request',        20),
+    (N'main.task',           30),
+    (N'main.task-monitor',   40),
+    (N'main.monitoring',     50),
+    (N'main.appraisal',      60),
+    (N'main.quotation',      70),
+    (N'main.invoice',        80),
+    (N'main.meetings',       90),
+    (N'main.reports',       100),
+    (N'main.notification',  110),
+    (N'main.standalone',    120),
+    (N'main.master-data',   130),
+    (N'main.workflow',      140),
+    (N'main.business-rules',150),
+    (N'main.access',        160),
+    (N'main.system',        170);
+
+UPDATE m
+SET m.SortOrder = r.SortOrder,
+    m.UpdatedAt = SYSDATETIME()
+FROM auth.MenuItems m
+INNER JOIN @Roots r ON r.ItemKey = m.ItemKey
+WHERE m.SortOrder <> r.SortOrder;
+
+PRINT 'Regrouped main menu: 5 container groups added, 20 items re-parented, 17 roots renumbered 10-170';
+GO

--- a/Modules/Auth/Auth/Infrastructure/Seed/MenuSeedData.cs
+++ b/Modules/Auth/Auth/Infrastructure/Seed/MenuSeedData.cs
@@ -24,6 +24,29 @@ public static class MenuSeedData
         string? ViewPermissionPrefix = null,
         string? LabelTh = null);
 
+    // Root order is load-bearing: UpsertTreeAsync derives SortOrder from position in this list
+    // (10, 20, 30 …). Keep the twelve operational roots first, then the five admin groups.
+    //
+    // The five admin groups (master-data / workflow / business-rules / access / system) are
+    // CONTAINERS: Path is null, so the sidebar renders them as expand-only toggles. A container
+    // still needs a view permission — MenuItem.Create requires a code or a prefix — and that
+    // gate hides the WHOLE subtree, because GetMyMenuQueryHandler skips a hidden node before it
+    // builds any children.
+    //
+    // Each gate below is therefore chosen so that no role loses a screen it can reach today:
+    //   Admin holds every permission; IntAdmin holds WORKFLOW_MANAGE, WORKFLOW_ADMIN,
+    //   USER_MANAGE, COLLATERAL_ADMIN, EVALUATION_CONFIG_MANAGE, SLA_CONFIG_MANAGE,
+    //   FEE_APPROVAL_CONFIG, APPOINTMENT_APPROVAL_CONFIG; ExtAdmin holds USER_MANAGE. No other
+    //   seeded role holds PARAMETER_MANAGE, TEMPLATE_MANAGE, AUTH_AUDIT_VIEW, LOGS_VIEW,
+    //   WEBHOOK_*, OAUTH_* or MENU_MANAGE.
+    //
+    // CAVEAT: only main.workflow's prefix is semantically exact. The other four gates work
+    // because the seeded roles happen to line up, not because the permission "means" the group.
+    // A custom role added later at /admin/roles holding only PARAMETER_MANAGE would see no
+    // Business Rules group. (main.user-management already has this same coupling: it is gated on
+    // USER_MANAGE while its children need ROLE_MANAGE, MENU_MANAGE, …) The durable fix, if custom
+    // admin roles appear, is in GetMyMenuQueryHandler.BuildFilteredTree: build children first and
+    // let a Path==null container be visible whenever any child is.
     public static List<MenuSeedNode> GetMainMenuSeed() => new()
     {
         new("main.dashboard", "Dashboard", "gauge", IconStyle.Solid, "text-blue-500", "/", "DASHBOARD_VIEW", null),
@@ -90,6 +113,14 @@ public static class MenuSeedData
                 new("main.invoice.list", "All Invoices", "list", IconStyle.Solid, "text-lime-500", "/admin/invoices", "INVOICE_VIEW", null),
                 new("main.invoice.external", "External Co. Portal", "building", IconStyle.Solid, "text-lime-500", "/ext/invoices", "INVOICE_EXT_VIEW", null),
             }),
+        new("main.meetings", "Meetings", "people-arrows", IconStyle.Solid, "text-blue-500", "/meetings", "MEETING_MANAGE", null,
+            new List<MenuSeedNode>
+            {
+                new("main.meetings.all", "All Meetings", "list", IconStyle.Solid, "text-blue-500", "/meetings", "MEETING_MANAGE", null),
+                new("main.meetings.queue", "Awaiting Meeting Queue", "hourglass-half", IconStyle.Solid, "text-blue-500", "/meetings/queue", "MEETING_MANAGE", null),
+            }),
+        // NOT nested under an admin group: this subtree already uses all three allowed levels
+        // (Reports → Operational Reports → RCAS001…012). Wrapping it would make RCAS level 4.
         new("main.reports", "Reports", "chart-line", IconStyle.Solid, "text-indigo-500", "/reports", "REPORT_VIEW", null,
             new List<MenuSeedNode>
             {
@@ -113,12 +144,6 @@ public static class MenuSeedData
                         new("main.reports.operational.rcas012", "Company Follow-up (RCAS012)", "magnifying-glass-chart", IconStyle.Solid, "text-indigo-500", "/reports/operational/rcas012", "REPORT_OP_VIEW", null, LabelTh: "ติดตามงานบริษัทประเมิน (RCAS012)"),
                     }, LabelTh: "รายงานเชิงปฏิบัติการ"),
             }, LabelTh: "รายงาน"),
-        new("main.meetings", "Meetings", "people-arrows", IconStyle.Solid, "text-blue-500", "/meetings", "MEETING_MANAGE", null,
-            new List<MenuSeedNode>
-            {
-                new("main.meetings.all", "All Meetings", "list", IconStyle.Solid, "text-blue-500", "/meetings", "MEETING_MANAGE", null),
-                new("main.meetings.queue", "Awaiting Meeting Queue", "hourglass-half", IconStyle.Solid, "text-blue-500", "/meetings/queue", "MEETING_MANAGE", null),
-            }),
         new("main.notification", "Notification", "bell", IconStyle.Solid, "text-amber-500", "/notifications", "DASHBOARD_VIEW", null),
         new("main.standalone", "Standalone", "puzzle-piece", IconStyle.Solid, "text-teal-500", "/standalone", "STANDALONE_USE", null,
             new List<MenuSeedNode>
@@ -131,63 +156,102 @@ public static class MenuSeedData
                 new("main.standalone.reappraisal-testgen", "Generate Reappraisal File", "file-circle-plus", IconStyle.Solid, "text-teal-500", "/reappraisal/generate-test-file", "REAPPRAISAL_GENERATE_TEST_FILE", null),
                 new("main.standalone.block-reappraisal", "Block Reappraisal", "building-circle-arrow-right", IconStyle.Solid, "text-teal-500", "/standalone/block-reappraisal", "BLOCK_REAPPRAISAL_VIEW", "BLOCK_REAPPRAISAL_CREATE"),
             }),
-        new("main.parameter", "Parameter", "sliders", IconStyle.Solid, "text-rose-500", "/parameter", "PARAMETER_MANAGE", null),
-        new("main.document-requirements", "Document Requirements", "file-lines", IconStyle.Solid, "text-rose-500", "/admin/document-requirements", "PARAMETER_MANAGE", "PARAMETER_MANAGE"),
-        new("main.user-management", "User Management", "users", IconStyle.Solid, "text-violet-500", "/users", "USER_MANAGE", null,
+
+        // ── Admin groups (containers: Path = null) ────────────────────────────────────────────
+        // Gate rationale is documented on the class-level comment above.
+
+        // Gate COLLATERAL_ADMIN: held by Admin + IntAdmin. TEMPLATE_MANAGE is Admin-only, and
+        // Admin holds COLLATERAL_ADMIN, so nothing becomes unreachable.
+        new("main.master-data", "Master Data", "database", IconStyle.Solid, "text-cyan-500", null, "COLLATERAL_ADMIN", null,
             new List<MenuSeedNode>
             {
-                new("main.user-management.permissions", "Permissions", "shield-halved", IconStyle.Solid, "text-violet-500", "/admin/permissions", "PERMISSION_MANAGE", null),
-                new("main.user-management.roles", "Roles", "user-shield", IconStyle.Solid, "text-violet-500", "/admin/roles", "ROLE_MANAGE", null),
-                new("main.user-management.groups", "Groups", "users-rectangle", IconStyle.Solid, "text-violet-500", "/admin/groups", "GROUP_MANAGE", null),
-                new("main.user-management.users", "Users", "circle-user", IconStyle.Solid, "text-violet-500", "/admin/users", "USER_MANAGE", null),
-                new("main.user-management.menus", "Menus", "bars", IconStyle.Solid, "text-violet-500", "/admin/menus", "MENU_MANAGE", "MENU_MANAGE"),
-                new("main.user-management.teams", "Teams", "people-group", IconStyle.Solid, "text-violet-500", "/admin/teams", "TEAM_MANAGE", null),
-                new("main.user-management.companies", "Companies", "building", IconStyle.Solid, "text-violet-500", "/admin/companies", "COMPANY_MANAGE", null),
-                new("main.user-management.password-policy", "Password Policy", "lock", IconStyle.Solid, "text-violet-500", "/admin/password-policy", "PASSWORD_POLICY_MANAGE", "PASSWORD_POLICY_MANAGE"),
-            }),
-        new("main.collateral-master", "Collateral Master", "buildings", IconStyle.Solid, "text-cyan-500", "/admin/collateral-masters", "COLLATERAL_ADMIN", null,
+                new("main.collateral-master", "Collateral Master", "buildings", IconStyle.Solid, "text-cyan-500", "/admin/collateral-masters", "COLLATERAL_ADMIN", null,
+                    new List<MenuSeedNode>
+                    {
+                        new("main.collateral-master.catalog", "Catalog", "list", IconStyle.Solid, "text-cyan-500", "/admin/collateral-masters", "COLLATERAL_ADMIN", null),
+                        new("main.collateral-master.backfill", "Backfill Report", "rotate", IconStyle.Solid, "text-cyan-500", "/admin/collateral-masters/backfill", "COLLATERAL_ADMIN", null),
+                        new("main.collateral-master.host-id-backfill", "Host ID Backfill", "id-card", IconStyle.Solid, "text-cyan-500", "/admin/collateral-masters/host-id-backfill", "COLLATERAL_ADMIN", null),
+                    }),
+                new("main.template-management", "Template Management", "layer-group", IconStyle.Solid, "text-teal-500", "/market-comparable-factors", "TEMPLATE_MANAGE", "TEMPLATE_MANAGE",
+                    new List<MenuSeedNode>
+                    {
+                        new("main.template-management.mc-factors", "MC Factors", "database", IconStyle.Solid, "text-teal-500", "/market-comparable-factors", "TEMPLATE_MANAGE", "TEMPLATE_MANAGE"),
+                        new("main.template-management.mc-templates", "MC Templates", "rectangle-list", IconStyle.Solid, "text-teal-500", "/market-comparable-templates", "TEMPLATE_MANAGE", "TEMPLATE_MANAGE"),
+                        new("main.template-management.comparative-templates", "Comparative Templates", "chart-mixed", IconStyle.Solid, "text-teal-500", "/comparative-templates", "TEMPLATE_MANAGE", "TEMPLATE_MANAGE"),
+                    }),
+            }, LabelTh: "ข้อมูลหลัก"),
+
+        // Prefix WORKFLOW_ exactly covers WORKFLOW_MANAGE + WORKFLOW_ADMIN — the only gate here
+        // that is semantically exact rather than incidental.
+        new("main.workflow", "Workflow", "diagram-project", IconStyle.Solid, "text-orange-500", null, null, null,
             new List<MenuSeedNode>
             {
-                new("main.collateral-master.catalog", "Catalog", "list", IconStyle.Solid, "text-cyan-500", "/admin/collateral-masters", "COLLATERAL_ADMIN", null),
-                new("main.collateral-master.backfill", "Backfill Report", "rotate", IconStyle.Solid, "text-cyan-500", "/admin/collateral-masters/backfill", "COLLATERAL_ADMIN", null),
-                new("main.collateral-master.host-id-backfill", "Host ID Backfill", "id-card", IconStyle.Solid, "text-cyan-500", "/admin/collateral-masters/host-id-backfill", "COLLATERAL_ADMIN", null),
-            }),
-        new("main.workflow-builder", "Workflow Builder", "diagram-project", IconStyle.Solid, "text-orange-500", "/workflow-builder", "WORKFLOW_MANAGE", "WORKFLOW_MANAGE",
-            new List<MenuSeedNode>
-            {
-                new("main.workflow-builder.list", "Workflow Listing", "list", IconStyle.Solid, "text-orange-500", "/workflow-builder", "WORKFLOW_MANAGE", null),
-                new("main.workflow-builder.create", "Create Workflow", "file-circle-plus", IconStyle.Solid, "text-orange-500", "/workflow-builder/new", "WORKFLOW_MANAGE", "WORKFLOW_MANAGE"),
-            }),
-        new("main.workflow-step-validation", "Workflow Step Validation", "shield-check", IconStyle.Solid, "text-orange-500", "/admin/workflow-step-validation", "WORKFLOW_ADMIN", "WORKFLOW_ADMIN"),
-        new("main.workflow-assignment-config", "Task Assignment Overrides", "users-gear", IconStyle.Solid, "text-orange-500", "/admin/workflow-assignment-config", "WORKFLOW_ADMIN", "WORKFLOW_ADMIN"),
-        new("main.workflow-roundrobin-config", "Company Round-Robin Pools", "shuffle", IconStyle.Solid, "text-orange-500", "/admin/workflow-roundrobin-config", "WORKFLOW_ADMIN", "WORKFLOW_ADMIN"),
-        new("main.fee-approval-tiers", "Fee Approval Tiers", "layer-group", IconStyle.Solid, "text-orange-500", "/admin/fee-approval-tiers", "FEE_APPROVAL_CONFIG", "FEE_APPROVAL_CONFIG"),
-        new("main.appointment-approval-rule", "Appointment Approval Rule", "calendar-xmark", IconStyle.Solid, "text-orange-500", "/admin/appointment-approval-rule", "APPOINTMENT_APPROVAL_CONFIG", "APPOINTMENT_APPROVAL_CONFIG"),
-        new("main.evaluation-config", "Evaluation Criteria Config", "star-half-stroke", IconStyle.Solid, "text-orange-500", "/admin/evaluation-config", "EVALUATION_CONFIG_MANAGE", "EVALUATION_CONFIG_MANAGE"),
-        new("main.sla-config", "OLA / SLA Targets", "stopwatch", IconStyle.Solid, "text-orange-500", "/admin/sla-config", "SLA_CONFIG_MANAGE", "SLA_CONFIG_MANAGE"),
-        new("main.fee-structures", "Fee Structure", "money-bill-1", IconStyle.Solid, "text-orange-500", "/admin/fee-structures", "PARAMETER_MANAGE", "PARAMETER_MANAGE"),
-        new("main.webhook-subscriptions", "Webhook Subscriptions", "plug-circle-bolt", IconStyle.Solid, "text-slate-500", "/admin/webhook-subscriptions", "WEBHOOK_SUBSCRIPTIONS_MANAGE", null),
-        new("main.webhook-deliveries", "Webhook Deliveries", "satellite-dish", IconStyle.Solid, "text-slate-500", "/admin/webhook-deliveries", "WEBHOOK_DELIVERIES_VIEW", null),
-        // OAuth client/scope registration + token administration (OpenIddict).
-        // Parent visible to anyone holding any OAUTH_* permission; children gated individually.
-        new("main.oauth", "OAuth", "key", IconStyle.Solid, "text-slate-500", "/admin/oauth-clients", null, null,
-            new List<MenuSeedNode>
-            {
-                new("main.oauth.clients", "Clients", "key", IconStyle.Solid, "text-slate-500", "/admin/oauth-clients", "OAUTH_CLIENTS_MANAGE", null),
-                new("main.oauth.scopes", "Scopes", "shield-halved", IconStyle.Solid, "text-slate-500", "/admin/oauth-scopes", "OAUTH_SCOPES_MANAGE", null),
-                new("main.oauth.tokens", "Tokens & Authorizations", "ticket", IconStyle.Solid, "text-slate-500", "/admin/oauth-tokens", "OAUTH_TOKENS_REVOKE", null),
+                new("main.workflow-builder", "Workflow Builder", "diagram-project", IconStyle.Solid, "text-orange-500", "/workflow-builder", "WORKFLOW_MANAGE", "WORKFLOW_MANAGE",
+                    new List<MenuSeedNode>
+                    {
+                        new("main.workflow-builder.list", "Workflow Listing", "list", IconStyle.Solid, "text-orange-500", "/workflow-builder", "WORKFLOW_MANAGE", null),
+                        new("main.workflow-builder.create", "Create Workflow", "file-circle-plus", IconStyle.Solid, "text-orange-500", "/workflow-builder/new", "WORKFLOW_MANAGE", "WORKFLOW_MANAGE"),
+                    }),
+                new("main.workflow-step-validation", "Workflow Step Validation", "shield-check", IconStyle.Solid, "text-orange-500", "/admin/workflow-step-validation", "WORKFLOW_ADMIN", "WORKFLOW_ADMIN"),
+                new("main.workflow-assignment-config", "Task Assignment Overrides", "users-gear", IconStyle.Solid, "text-orange-500", "/admin/workflow-assignment-config", "WORKFLOW_ADMIN", "WORKFLOW_ADMIN"),
+                new("main.workflow-roundrobin-config", "Company Round-Robin Pools", "shuffle", IconStyle.Solid, "text-orange-500", "/admin/workflow-roundrobin-config", "WORKFLOW_ADMIN", "WORKFLOW_ADMIN"),
             },
-            ViewPermissionPrefix: "OAUTH_"),
-        new("main.logs", "Application Logs", "file-lines", IconStyle.Solid, "text-slate-500", "/admin/logs", "LOGS_VIEW", null),
-        new("main.audit-log", "Audit Log", "clock-rotate-left", IconStyle.Solid, "text-slate-500", "/admin/audit-logs", "AUTH_AUDIT_VIEW", null),
-        new("main.access-report", "Access Report", "table-list", IconStyle.Solid, "text-slate-500", "/admin/access-report", "AUTH_AUDIT_VIEW", null),
-        new("main.template-management", "Template Management", "layer-group", IconStyle.Solid, "text-teal-500", "/market-comparable-factors", "TEMPLATE_MANAGE", "TEMPLATE_MANAGE",
+            ViewPermissionPrefix: "WORKFLOW_", LabelTh: "เวิร์กโฟลว์"),
+
+        // Gate SLA_CONFIG_MANAGE: held by Admin + IntAdmin, so IntAdmin keeps the four config
+        // screens it can reach. The PARAMETER_MANAGE children are Admin-only, and Admin holds
+        // SLA_CONFIG_MANAGE.
+        new("main.business-rules", "Business Rules", "sliders", IconStyle.Solid, "text-rose-500", null, "SLA_CONFIG_MANAGE", null,
             new List<MenuSeedNode>
             {
-                new("main.template-management.mc-factors", "MC Factors", "database", IconStyle.Solid, "text-teal-500", "/market-comparable-factors", "TEMPLATE_MANAGE", "TEMPLATE_MANAGE"),
-                new("main.template-management.mc-templates", "MC Templates", "rectangle-list", IconStyle.Solid, "text-teal-500", "/market-comparable-templates", "TEMPLATE_MANAGE", "TEMPLATE_MANAGE"),
-                new("main.template-management.comparative-templates", "Comparative Templates", "chart-mixed", IconStyle.Solid, "text-teal-500", "/comparative-templates", "TEMPLATE_MANAGE", "TEMPLATE_MANAGE"),
-            }),
+                new("main.parameter", "Parameter", "sliders", IconStyle.Solid, "text-rose-500", "/parameter", "PARAMETER_MANAGE", null),
+                new("main.document-requirements", "Document Requirements", "file-lines", IconStyle.Solid, "text-rose-500", "/admin/document-requirements", "PARAMETER_MANAGE", "PARAMETER_MANAGE"),
+                new("main.fee-structures", "Fee Structure", "money-bill-1", IconStyle.Solid, "text-orange-500", "/admin/fee-structures", "PARAMETER_MANAGE", "PARAMETER_MANAGE"),
+                new("main.fee-approval-tiers", "Fee Approval Tiers", "layer-group", IconStyle.Solid, "text-orange-500", "/admin/fee-approval-tiers", "FEE_APPROVAL_CONFIG", "FEE_APPROVAL_CONFIG"),
+                new("main.appointment-approval-rule", "Appointment Approval Rule", "calendar-xmark", IconStyle.Solid, "text-orange-500", "/admin/appointment-approval-rule", "APPOINTMENT_APPROVAL_CONFIG", "APPOINTMENT_APPROVAL_CONFIG"),
+                new("main.evaluation-config", "Evaluation Criteria Config", "star-half-stroke", IconStyle.Solid, "text-orange-500", "/admin/evaluation-config", "EVALUATION_CONFIG_MANAGE", "EVALUATION_CONFIG_MANAGE"),
+                new("main.sla-config", "OLA / SLA Targets", "stopwatch", IconStyle.Solid, "text-orange-500", "/admin/sla-config", "SLA_CONFIG_MANAGE", "SLA_CONFIG_MANAGE"),
+            }, LabelTh: "กฎเกณฑ์ธุรกิจ"),
+
+        // Gate USER_MANAGE: held by Admin + IntAdmin + ExtAdmin. OAuth / Audit Log / Access
+        // Report are Admin-only, and Admin holds USER_MANAGE.
+        new("main.access", "Users & Access", "shield-halved", IconStyle.Solid, "text-violet-500", null, "USER_MANAGE", null,
+            new List<MenuSeedNode>
+            {
+                new("main.user-management", "User Management", "users", IconStyle.Solid, "text-violet-500", "/users", "USER_MANAGE", null,
+                    new List<MenuSeedNode>
+                    {
+                        new("main.user-management.permissions", "Permissions", "shield-halved", IconStyle.Solid, "text-violet-500", "/admin/permissions", "PERMISSION_MANAGE", null),
+                        new("main.user-management.roles", "Roles", "user-shield", IconStyle.Solid, "text-violet-500", "/admin/roles", "ROLE_MANAGE", null),
+                        new("main.user-management.groups", "Groups", "users-rectangle", IconStyle.Solid, "text-violet-500", "/admin/groups", "GROUP_MANAGE", null),
+                        new("main.user-management.users", "Users", "circle-user", IconStyle.Solid, "text-violet-500", "/admin/users", "USER_MANAGE", null),
+                        new("main.user-management.menus", "Menus", "bars", IconStyle.Solid, "text-violet-500", "/admin/menus", "MENU_MANAGE", "MENU_MANAGE"),
+                        new("main.user-management.teams", "Teams", "people-group", IconStyle.Solid, "text-violet-500", "/admin/teams", "TEAM_MANAGE", null),
+                        new("main.user-management.companies", "Companies", "building", IconStyle.Solid, "text-violet-500", "/admin/companies", "COMPANY_MANAGE", null),
+                        new("main.user-management.password-policy", "Password Policy", "lock", IconStyle.Solid, "text-violet-500", "/admin/password-policy", "PASSWORD_POLICY_MANAGE", "PASSWORD_POLICY_MANAGE"),
+                    }),
+                // OAuth client/scope registration + token administration (OpenIddict).
+                // Parent visible to anyone holding any OAUTH_* permission; children gated individually.
+                new("main.oauth", "OAuth", "key", IconStyle.Solid, "text-slate-500", "/admin/oauth-clients", null, null,
+                    new List<MenuSeedNode>
+                    {
+                        new("main.oauth.clients", "Clients", "key", IconStyle.Solid, "text-slate-500", "/admin/oauth-clients", "OAUTH_CLIENTS_MANAGE", null),
+                        new("main.oauth.scopes", "Scopes", "shield-halved", IconStyle.Solid, "text-slate-500", "/admin/oauth-scopes", "OAUTH_SCOPES_MANAGE", null),
+                        new("main.oauth.tokens", "Tokens & Authorizations", "ticket", IconStyle.Solid, "text-slate-500", "/admin/oauth-tokens", "OAUTH_TOKENS_REVOKE", null),
+                    },
+                    ViewPermissionPrefix: "OAUTH_"),
+                new("main.audit-log", "Audit Log", "clock-rotate-left", IconStyle.Solid, "text-slate-500", "/admin/audit-logs", "AUTH_AUDIT_VIEW", null),
+                new("main.access-report", "Access Report", "table-list", IconStyle.Solid, "text-slate-500", "/admin/access-report", "AUTH_AUDIT_VIEW", null),
+            }, LabelTh: "ผู้ใช้และสิทธิ์"),
+
+        // Gate LOGS_VIEW: all three children are Admin-only, and Admin holds it.
+        new("main.system", "System", "server", IconStyle.Solid, "text-slate-500", null, "LOGS_VIEW", null,
+            new List<MenuSeedNode>
+            {
+                new("main.logs", "Application Logs", "file-lines", IconStyle.Solid, "text-slate-500", "/admin/logs", "LOGS_VIEW", null),
+                new("main.webhook-subscriptions", "Webhook Subscriptions", "plug-circle-bolt", IconStyle.Solid, "text-slate-500", "/admin/webhook-subscriptions", "WEBHOOK_SUBSCRIPTIONS_MANAGE", null),
+                new("main.webhook-deliveries", "Webhook Deliveries", "satellite-dish", IconStyle.Solid, "text-slate-500", "/admin/webhook-deliveries", "WEBHOOK_DELIVERIES_VIEW", null),
+            }, LabelTh: "ระบบ"),
     };
 
     public static List<MenuSeedNode> GetAppraisalMenuSeed() => new()


### PR DESCRIPTION
## Why

The sidebar had grown to **32 root entries** — more than anyone can scan. This groups 20 of them under five new containers, taking the root count to **17**.

| New container | Adopts |
|---|---|
| **Master Data** / ข้อมูลหลัก | Collateral Master, Template Management (each keeps its own children) |
| **Workflow** / เวิร์กโฟลว์ | Workflow Builder (+2), Step Validation, Assignment Config, Round-robin Config |
| **Business Rules** / กฎเกณฑ์ธุรกิจ | Parameter, Document Requirements, Fee Structures, Fee Approval Tiers, Appointment Approval Rule, Evaluation Config, SLA Config |
| **Users & Access** / ผู้ใช้และสิทธิ์ | User Management (+8), OAuth (+3), Audit Log, Access Report |
| **System** / ระบบ | Logs, Webhook Subscriptions, Webhook Deliveries |

Containers have `Path = null`, so they render as expand-only toggles rather than navigable pages. `main.meetings` moves above `main.reports`; **`main.reports` deliberately stays a root** — nesting it would push RCAS001–012 to a fourth level.

## Why two files

`MenuSeedData`'s `UpsertTreeAsync` is **INSERT-ONLY** and leaves `ParentId`/`SortOrder` alone when it matches an existing `ItemKey`, so the C# change alone would never reshape a database that already has these rows.

- **`MenuSeedData.cs`** — fresh databases.
- **`20260729120000_UpdateSeed_RegroupMainMenu.sql`** — existing ones: inserts the containers with **fixed literal GUIDs** so every environment agrees, adds `en`/`th`/`zh` translations, re-parents the 20 items, renumbers the 17 roots.

⚠️ These two must stay in lockstep — they share container ItemKeys, GUIDs and SortOrders, and **neither is correct alone**. The script is idempotent (`NOT EXISTS`-guarded inserts; updates match nothing once values are right) and resolves container ids by joining on `ItemKey` rather than trusting the literals, so it also works if the seeder created the row first.

## The sort-order fix (step 4 — not cosmetics)

`UpsertTreeAsync` advances its SortOrder counter **even for rows it skips**, so live root SortOrders had collided: **40×2, 50×3, 60×2, 120×2, 180×3, 190×2, 220×2, 230×2**. `GetMyMenuQueryHandler` orders by SortOrder alone, so those ties resolved non-deterministically and the sidebar could reorder between restarts.

## Two things to know while reviewing

- **`SET QUOTED_IDENTIFIER ON` / `ANSI_NULLS ON` are deliberate.** `auth.MenuItems` carries the filtered index `IX_MenuItems_Scope_Path`; SQL Server refuses DML on such a table unless both are ON. DbUp sets them, but production applies this as a generated bundle via `sqlcmd`, which defaults `QUOTED_IDENTIFIER` **OFF**.
- **Container permission gates are incidental, not semantic.** Each was picked so no seeded role loses a screen it could previously reach. This matters because `BuildFilteredTree` evaluates a node *before* building its children, so a hidden `Path == null` container hides its whole subtree. The durable fix is to build children first; that is **not** attempted here.

## 🚨 Deploy requirement

`MenuTreeCache` (`auth:menu:full`) is a per-node `IMemoryCache` with **no TTL**, invalidated only in-process. **Every API instance must be restarted** after this script is applied, or nodes will keep serving the old tree indefinitely.

## No frontend change needed

The sidebar is fully backend-driven — `useNavigation.ts` builds `NavItem[]` from the menu-tree API — so the new structure flows through from the seeded DB.

## Verification

1. Apply on an **existing** dev DB, restart the API, confirm 17 roots and that the five containers expand correctly.
2. Confirm root order is now stable across restarts.
3. Re-run `migrate` — the script should be a genuine no-op.
4. Verify the fresh-DB path separately (drop + recreate) so both paths converge on the same tree.
5. Spot-check a non-admin seeded role for screens that became unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127SHKex23dLLdqoYEX37Gm