### PR TITLE
feat(auth): expose employee ID on admin user create/update

### DIFF
--- a/Modules/Auth/Auth/Application/Dtos/RegisterUserDto.cs
+++ b/Modules/Auth/Auth/Application/Dtos/RegisterUserDto.cs
@@ -14,5 +14,7 @@ public record RegisterUserDto(
     List<Guid> Roles,
     string AuthSource = AuthSources.Local,
     // Bank-internal officer code; only set for bank users (CompanyId == null).
-    string? AoCode = null
+    string? AoCode = null,
+    // Bank staff employee id; only set for bank users (CompanyId == null).
+    string? EmployeeId = null
 );

--- a/Modules/Auth/Auth/Application/Features/Users/CreateUser/CreateUserCommand.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/CreateUser/CreateUserCommand.cs
@@ -16,5 +16,7 @@ public record CreateUserCommand(
     List<Guid>? GroupIds = null,
     List<Guid>? TeamIds = null,
     // Bank-internal officer code; only persisted for bank users (CompanyId == null).
-    string? AoCode = null
+    string? AoCode = null,
+    // Bank staff employee id; only persisted for bank users (CompanyId == null).
+    string? EmployeeId = null
 ) : ICommand<CreateUserResult>, ITransactionalCommand<IAuthUnitOfWork>;

--- a/Modules/Auth/Auth/Application/Features/Users/CreateUser/CreateUserCommandHandler.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/CreateUser/CreateUserCommandHandler.cs
@@ -42,8 +42,9 @@ public class CreateUserCommandHandler(
             Permissions: [],
             Roles: command.Roles,
             AuthSource: command.AuthSource,
-            // Bank-internal attribute — only carry it for bank users (no company).
-            AoCode: command.CompanyId is null ? command.AoCode : null);
+            // Bank-internal attributes — only carry them for bank users (no company).
+            AoCode: command.CompanyId is null ? command.AoCode : null,
+            EmployeeId: command.CompanyId is null ? command.EmployeeId : null);
 
         var user = await registrationService.RegisterUser(registerUserDto, cancellationToken);
 

--- a/Modules/Auth/Auth/Application/Features/Users/CreateUser/CreateUserCommandValidator.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/CreateUser/CreateUserCommandValidator.cs
@@ -44,6 +44,10 @@ public class CreateUserCommandValidator : AbstractValidator<CreateUserCommand>
         RuleFor(x => x.AoCode)
             .MaximumLength(10).WithMessage("AO Code cannot exceed 10 characters.")
             .When(x => x.AoCode != null);
+        // 50 matches ApplicationUser.EmployeeId's column length.
+        RuleFor(x => x.EmployeeId)
+            .MaximumLength(50).WithMessage("Employee ID cannot exceed 50 characters.")
+            .When(x => x.EmployeeId != null);
         RuleFor(x => x.Roles).NotNull().WithMessage("Roles are required.");
         RuleForEach(x => x.Roles).NotEmpty().WithMessage("RoleId is required.");
     }

--- a/Modules/Auth/Auth/Application/Features/Users/CreateUser/CreateUserRequest.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/CreateUser/CreateUserRequest.cs
@@ -14,5 +14,7 @@ public record CreateUserRequest(
     List<Guid>? GroupIds = null,
     List<Guid>? TeamIds = null,
     // Bank-internal officer code; only persisted for bank users (CompanyId == null).
-    string? AoCode = null
+    string? AoCode = null,
+    // Bank staff employee id; only persisted for bank users (CompanyId == null).
+    string? EmployeeId = null
 );

--- a/Modules/Auth/Auth/Application/Features/Users/GetUserById/GetUserByIdQueryHandler.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/GetUserById/GetUserByIdQueryHandler.cs
@@ -69,6 +69,7 @@ public class GetUserByIdQueryHandler(
             user.Position,
             user.Department,
             user.AoCode,
+            user.EmployeeId,
             user.CompanyId,
             companyName,
             user.AuthSource,

--- a/Modules/Auth/Auth/Application/Features/Users/GetUserById/GetUserByIdResult.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/GetUserById/GetUserByIdResult.cs
@@ -19,6 +19,8 @@ public record GetUserByIdResult(
     string? Department,
     // Bank-internal officer code (joins to auth.Officers); null for company users.
     string? AoCode,
+    // Bank staff employee id; null for company users.
+    string? EmployeeId,
     Guid? CompanyId,
     string? CompanyName,
     string AuthSource,

--- a/Modules/Auth/Auth/Application/Features/Users/UpdateUser/UpdateUserCommand.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/UpdateUser/UpdateUserCommand.cs
@@ -11,4 +11,6 @@ public record UpdateUserCommand(
     // null = leave AuthSource unchanged (see UpdateUserRequest).
     string? AuthSource = null,
     // Bank-internal officer code; only persisted for bank users (CompanyId == null).
-    string? AoCode = null) : ICommand;
+    string? AoCode = null,
+    // Bank staff employee id; only persisted for bank users (CompanyId == null).
+    string? EmployeeId = null) : ICommand;

--- a/Modules/Auth/Auth/Application/Features/Users/UpdateUser/UpdateUserCommandHandler.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/UpdateUser/UpdateUserCommandHandler.cs
@@ -22,9 +22,10 @@ public class UpdateUserCommandHandler(
         user.Position = command.Position;
         user.Department = command.Department;
         user.CompanyId = command.CompanyId;
-        // AO Code is a bank-internal attribute — only persist it for bank users (no company);
-        // company users must never carry one.
+        // AO Code and Employee ID are bank-internal attributes — only persist them for bank users
+        // (no company); company users must never carry one.
         user.AoCode = command.CompanyId is null ? command.AoCode : null;
+        user.EmployeeId = command.CompanyId is null ? command.EmployeeId : null;
 
         // AuthSource changes only when explicitly sent (null = unchanged) and only to a different
         // value. Switching an LDAP account to Local would strand it — the account has no local

--- a/Modules/Auth/Auth/Application/Features/Users/UpdateUser/UpdateUserCommandValidator.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/UpdateUser/UpdateUserCommandValidator.cs
@@ -16,6 +16,8 @@ public class UpdateUserCommandValidator : AbstractValidator<UpdateUserCommand>
         RuleFor(x => x.Position).MaximumLength(100);
         RuleFor(x => x.Department).MaximumLength(100);
         RuleFor(x => x.AoCode).MaximumLength(10);
+        // 50 matches ApplicationUser.EmployeeId's column length.
+        RuleFor(x => x.EmployeeId).MaximumLength(50);
 
         // AuthSource is optional on update (null = unchanged). Validate only when a value is sent.
         When(x => x.AuthSource is not null, () =>

--- a/Modules/Auth/Auth/Application/Features/Users/UpdateUser/UpdateUserEndpoint.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/UpdateUser/UpdateUserEndpoint.cs
@@ -17,7 +17,8 @@ public class UpdateUserEndpoint : ICarterModule
                         request.Department,
                         request.CompanyId,
                         request.AuthSource,
-                        request.AoCode);
+                        request.AoCode,
+                        request.EmployeeId);
                     await sender.Send(command, cancellationToken);
                     return Results.NoContent();
                 })

--- a/Modules/Auth/Auth/Application/Features/Users/UpdateUser/UpdateUserRequest.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/UpdateUser/UpdateUserRequest.cs
@@ -11,4 +11,6 @@ public record UpdateUserRequest(
     // switch auth mode — omitting it must NOT silently flip an LDAP user to Local.
     string? AuthSource = null,
     // Bank-internal officer code; only persisted for bank users (CompanyId == null).
-    string? AoCode = null);
+    string? AoCode = null,
+    // Bank staff employee id; only persisted for bank users (CompanyId == null).
+    string? EmployeeId = null);

--- a/Modules/Auth/Auth/Application/Services/RegistrationService.cs
+++ b/Modules/Auth/Auth/Application/Services/RegistrationService.cs
@@ -36,6 +36,7 @@ public class RegistrationService(
             Department = registerUserDto.Department,
             CompanyId = registerUserDto.CompanyId,
             AoCode = registerUserDto.AoCode,
+            EmployeeId = registerUserDto.EmployeeId,
             AuthSource = registerUserDto.AuthSource,
             // Make the account lockable per-row so failed-attempt lockout actually engages — including
             // the LDAP login path, where UserManager.AccessFailedAsync only locks when this flag is set.


### PR DESCRIPTION
## Why

`ApplicationUser.EmployeeId` already exists — it was added in the AS400 legacy result work, where it is surfaced as `InternalValuerCode` — but **there was no way to set it**. Admins had to reach into the database, and any user created through `/admin/users` came out with a `null` employee ID, so the legacy result feed had nothing to report for them.

## What changed

Threads `EmployeeId` through create, update and the by-id read.

**No migration needed** — the column arrives via the already-merged `20260726134432_AddEmployeeIdToApplicationUser`, and the new `MaximumLength(50)` rule matches the existing `nvarchar(50)`.

## Bank-only, enforced server-side

Employee IDs identify the bank's own staff, so the field is bank-only. Both handlers enforce this rather than trusting the caller:

```csharp
EmployeeId = command.CompanyId is null ? command.EmployeeId : null
```

A company user with an employee ID in the payload gets `null` persisted rather than a validation error — the UI hides the field for company scope, so a value arriving there means a malformed client, not user input worth rejecting.

## Two deliberate omissions

- **`GetUsers` (the list) is untouched.** The detail panel is the only screen that needs the value, and widening the list projection would cost a column on every page load for no reader.
- **`CreateUserEndpoint` needs no change** — it maps with `request.Adapt<CreateUserCommand>()` and Mapster picks the new property up by name. `UpdateUserEndpoint` builds its command by hand, so that one is threaded explicitly.

## Companion PR

Frontend: `feat/user-employee-id` in `collateral-appraisal-system-app` (same branch name). Merge order does not matter — the field is optional on both sides.

## Verification

- `dotnet build` green.
- Create a **Bank** user with an employee ID via `/admin/users`; confirm it persists to `auth.AspNetUsers.EmployeeId` and returns on the by-id endpoint.
- Repeat with a **Company** user and an employee ID in the payload; confirm `null` is stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127SHKex23dLLdqoYEX37Gm