### PR TITLE
feat(deploy): create the database from the SQL bundle

### DIFF
--- a/Bootstrapper/Api/Api.csproj
+++ b/Bootstrapper/Api/Api.csproj
@@ -47,7 +47,27 @@
 
     <ItemGroup>
         <Content Remove="wwwroot\*"/>
-        <None Include="wwwroot\*" CopyToOutputDirectory="Always" CopyToPublishDirectory="PreserveNewest"/>
+        <!-- Exclude .DS_Store: macOS build boxes would otherwise ship Finder metadata. -->
+        <None Include="wwwroot\*" Exclude="wwwroot\.DS_Store"
+              CopyToOutputDirectory="Always" CopyToPublishDirectory="PreserveNewest"/>
+    </ItemGroup>
+
+    <!--
+      Runtime user uploads must never be built or published.
+
+      The Web SDK includes wwwroot\** as Content by default. The `wwwroot\*` remove
+      above is single-level, so it never matched wwwroot\uploads\documents\*.png — the
+      local dev uploads were being copied into every publish, which put ~1.2 GB of test
+      documents into the deployment artifact and onto the app servers. They are not used
+      in production either: FileStorage:Mode is "Nas" there, rooted at NasBasePath.
+
+      .gitignore already excludes these folders; this is the build-side equivalent.
+      Recursive globs, so new subfolders are covered automatically.
+    -->
+    <ItemGroup>
+        <Content Remove="wwwroot\uploads\**"/>
+        <None Remove="wwwroot\uploads\**"/>
+        <Compile Remove="wwwroot\uploads\**"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -57,30 +77,4 @@
         <Folder Include="wwwroot\"/>
     </ItemGroup>
 
-    <ItemGroup>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\06cd8422-6cc4-47eb-8ca8-f58f0be7c17f.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\09e0d9ff-061f-462f-b711-f2cb5a5ec335.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\16a97543-29ac-43e5-808e-d1d171beabd0.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\23f5306c-dbf9-4982-9ace-85a7f0ef833d.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\3044977d-c59a-408f-91aa-c3381086e49d.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\48dae943-f204-4314-a92f-e3ddd84c9409.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\4b3d8697-fdb2-4427-8028-3c99b57af711.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\5b0922a4-6785-4f78-84dd-22a9d1612734.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\6002fdd1-8f8e-4c0a-b944-c2f657ce1197.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\8472b197-a966-4502-a416-8cf9990dbb70.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\872413e3-7085-411d-9c82-1d290fd0dad9.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\91c73c2f-99f9-4690-8b41-8ff88dafb403.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\94cc4295-33b8-4854-9da2-c21336542f5b.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\990836ad-bdd2-41a1-9a75-2249c9c2094f.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\9a661767-83de-467e-be18-cedc04aeb238.pdf"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\a22e42bc-3fa8-41c0-9277-32085e1cd23f.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\a5fad263-eb00-4f7e-8606-e56d1c2fa938.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\d4f6659c-1906-4f3c-8101-455448096789.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\d825ceba-d75e-4cac-bf97-534f8b277c00.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\df11c0c4-cd02-4498-9de2-4b2a9cc6932a.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\e0083f59-0d2f-4d44-a506-cd94912968c0.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\e899cfcc-3fb2-4d1c-ad4e-4a8a04f15995.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\fab83314-1aba-442b-9045-9501e3b75656.png"/>
-        <_ContentIncludedByDefault Remove="wwwroot\uploads\documents\ff6611a5-80a6-4a5d-a084-775aa0e94172.png"/>
-    </ItemGroup>
 </Project>

--- a/deploy/Invoke-SqlDeploy.ps1
+++ b/deploy/Invoke-SqlDeploy.ps1
@@ -6,10 +6,17 @@
 .DESCRIPTION
     Executes, in order and aborting on the first error (-b):
 
+        00_CreateDatabase.sql       (against [master]; -v DbName is supplied from -Database)
         00_Prepare.sql
         01_EF_01..11_*.sql          (EF Core schema, module dependency order)
         02_Repeatable_ViewsAndProcs.sql
         03_OneTime_DataScripts.sql
+
+    00_CreateDatabase.sql is the only one that runs against [master] — the target
+    database may not exist yet, and every other script runs inside it. Edit that
+    file's DECLARE block first if the environment needs a different collation or
+    file sizing. After it runs, the database's existence is verified before
+    anything else is attempted.
 
     Every file is idempotent, so a failed run can be fixed and re-run.
     99_Verify.sql is NOT run automatically — run it afterwards and read the output.
@@ -52,9 +59,14 @@ if (-not (Get-Command sqlcmd -ErrorAction SilentlyContinue)) {
     throw 'sqlcmd not found. Install "Microsoft ODBC Driver + sqlcmd utility" (or SSMS) on this machine.'
 }
 
+# 00_CreateDatabase.sql is special: it runs against [master] because the target
+# database may not exist yet. Everything else runs inside the target database.
+$createDbScript = Get-ChildItem -Path $ScriptPath -Filter '00_CreateDatabase.sql' -File |
+    Select-Object -First 1
+
 # Deterministic run order: 00, then 01_EF_* by their two-digit index, then 02, 03.
 $files = @(Get-ChildItem -Path $ScriptPath -Filter '*.sql' -File |
-    Where-Object { $_.Name -notlike '99_*' } |
+    Where-Object { $_.Name -notlike '99_*' -and $_.Name -ne '00_CreateDatabase.sql' } |
     Sort-Object Name)
 if ($files.Count -eq 0) { throw "No .sql files in '$ScriptPath'." }
 
@@ -77,6 +89,44 @@ if ($TrustedConnection) {
     $auth += @('-U', $Username, '-P', $plain)
 }
 if ($TrustServerCertificate) { $auth += '-C' }
+
+# Step 1 of 2 for the database itself: create it (against [master]) if the bundle
+# ships 00_CreateDatabase.sql. Idempotent — an existing database is left in place.
+if ($createDbScript -and $PSCmdlet.ShouldProcess($createDbScript.Name, "sqlcmd against $ServerInstance/master")) {
+    $log = Join-Path $LogDirectory "$runStamp`_$($createDbScript.BaseName).log"
+    Write-Host "  -> $($createDbScript.Name)  (against master)" -ForegroundColor Cyan
+    & sqlcmd -S $ServerInstance -d master @auth `
+             -i $createDbScript.FullName -o $log `
+             -b -V 16 -t $QueryTimeoutSeconds
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "FAILED on $($createDbScript.Name) — last lines of $log :"
+        Get-Content $log -Tail 25 | ForEach-Object { Write-Host "    $_" }
+        throw "sqlcmd exit $LASTEXITCODE on $($createDbScript.Name)."
+    }
+    Get-Content $log -Tail 40 | ForEach-Object { Write-Host "    $_" -ForegroundColor DarkGray }
+}
+
+# Step 2: confirm the database is really there before running anything inside it,
+# so a missing one reports the fix instead of failing obscurely in 00_Prepare.sql.
+if (-not $WhatIfPreference) {
+    $probe = & sqlcmd -S $ServerInstance -d master @auth -h -1 -W -b `
+        -Q "SET NOCOUNT ON; SELECT ISNULL(DB_ID(N'$Database'), 0);" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Cannot query $ServerInstance with the supplied credentials: $probe"
+    }
+    $dbId = ($probe | Where-Object { $_ -match '^\s*\d+\s*$' } | Select-Object -Last 1)
+    if (-not $dbId -or $dbId.Trim() -eq '0') {
+        throw @"
+Database [$Database] does not exist on $ServerInstance.
+
+00_CreateDatabase.sql ran without error, so the most likely cause is a name
+mismatch: that script sets the name in its own `DECLARE @DbName` line, and it
+must match the -Database value passed here ('$Database').
+
+Open 00_CreateDatabase.sql, check the EDIT block at the top, and re-run.
+"@
+    }
+}
 
 try {
     foreach ($f in $files) {

--- a/deploy/New-DbDeploymentScripts.ps1
+++ b/deploy/New-DbDeploymentScripts.ps1
@@ -35,7 +35,15 @@ param(
     [string]$Version = (Get-Date -Format 'yyyyMMdd-HHmmss'),
     [string]$OutDir,
     [string]$Environment = 'Production',
-    [switch]$SkipEf                       # regenerate only the SQL-file sections (fast)
+    [switch]$SkipEf,                      # regenerate only the SQL-file sections (fast)
+
+    # Defaults baked into 00_CreateDatabase.sql's DECLARE block. The DBA can edit
+    # them in the generated file; these only set the starting point.
+    [string]$Collation   = 'SQL_Latin1_General_CP1_CI_AS',
+    [int]$DataSizeMB     = 4096,
+    [int]$DataGrowthMB   = 512,
+    [int]$LogSizeMB      = 2048,
+    [int]$LogGrowthMB    = 256
 )
 
 $ErrorActionPreference = 'Stop'
@@ -107,10 +115,235 @@ $header = @"
    Collateral Appraisal System — database deployment
    Release  : $Version
    Generated: $stamp  (deploy/New-DbDeploymentScripts.ps1)
-   Target   : SQL Server 2019+   Run with SQLCMD mode / sqlcmd -b
+   Target   : SQL Server 2019+   Plain T-SQL - runs in SSMS or sqlcmd -b
    Every script in this bundle is IDEMPOTENT and safe to re-run.
    =========================================================================== */
 "@
+
+# ---------------------------------------------------------------------------
+# 00 — create the database (runs against [master], NOT the target database)
+#
+# The app no longer creates it: EF's Database.Migrate() used to do so implicitly,
+# but startup migration was removed, and every other script in this bundle runs
+# *inside* the database so none of them can create it.
+#
+# Uses the instance default data/log paths (SQL Server picks them from
+# InstanceDefaultDataPath / InstanceDefaultLogPath), then resizes the files
+# explicitly — production wants fixed-MB autogrowth, not the small defaults.
+# ---------------------------------------------------------------------------
+Write-Host '==> 00_CreateDatabase.sql' -ForegroundColor Cyan
+
+$createDbEditBlock = @"
+    ------------------------------------------------------------------------
+    -- EDIT THIS BLOCK, THEN RUN THE WHOLE FILE.
+    ------------------------------------------------------------------------
+    -- The database to create. If you change it, pass the same name to
+    -- Invoke-SqlDeploy.ps1 -Database (that script verifies the two agree).
+    DECLARE @DbName     sysname = N'CollateralAppraisal';
+
+    -- MUST match UAT. Nothing in the application pins a collation, so whatever
+    -- is set here is what production gets. Thai text is nvarchar, so this
+    -- governs sorting and comparison rather than storage -- but a database that
+    -- differs from UAT sorts and compares differently, silently.
+    DECLARE @Collation  sysname = N'$Collation';
+
+    -- Size up front so autogrowth never fires in normal operation.
+    -- Fixed MB, never percent.
+    DECLARE @DataSizeMB int = $DataSizeMB;
+    DECLARE @DataGrowMB int = $DataGrowthMB;
+    DECLARE @LogSizeMB  int = $LogSizeMB;
+    DECLARE @LogGrowMB  int = $LogGrowthMB;
+    ------------------------------------------------------------------------
+    -- END EDIT BLOCK
+    ------------------------------------------------------------------------
+"@
+
+# Single-quoted here-string: no PowerShell interpolation inside the T-SQL.
+$createDbBody = @'
+
+    SET NOCOUNT ON;
+
+    DECLARE @db  nvarchar(300) = QUOTENAME(@DbName);
+    DECLARE @sql nvarchar(max);
+
+    PRINT '=== Target database: ' + @DbName + ' ===';
+
+    -- Catch a mistyped collation here rather than via a cryptic CREATE failure.
+    IF NOT EXISTS (SELECT 1 FROM sys.fn_helpcollations() WHERE name = @Collation)
+    BEGIN
+        RAISERROR('Unknown collation "%s" - fix the EDIT block above.', 16, 1, @Collation);
+        RETURN;
+    END
+
+    /*------------------------------------------------------------------------
+      1. Create the database on the instance default data/log paths
+    ------------------------------------------------------------------------*/
+    IF DB_ID(@DbName) IS NULL
+    BEGIN
+        SET @sql = N'CREATE DATABASE ' + @db + N' COLLATE ' + @Collation + N';';
+        EXEC sys.sp_executesql @sql;
+        PRINT '  created (instance default data/log paths).';
+    END
+    ELSE
+        PRINT '  already exists - skipping CREATE; options below still applied.';
+
+    /*------------------------------------------------------------------------
+      2. File size and autogrowth
+
+      Logical file names are looked up rather than assumed, so this also works
+      on a database created by someone else. SIZE can only grow a file, so it is
+      applied only when the file is currently smaller - that keeps re-runs safe.
+    ------------------------------------------------------------------------*/
+    DECLARE @dataFile sysname, @logFile sysname, @dataMB int, @logMB int;
+
+    SELECT @dataFile = name, @dataMB = size / 128
+    FROM sys.master_files
+    WHERE database_id = DB_ID(@DbName) AND type = 0 AND file_id = 1;
+
+    SELECT TOP (1) @logFile = name, @logMB = size / 128
+    FROM sys.master_files
+    WHERE database_id = DB_ID(@DbName) AND type = 1
+    ORDER BY file_id;
+
+    IF @dataFile IS NULL OR @logFile IS NULL
+    BEGIN
+        RAISERROR('Could not resolve the data/log logical file names.', 16, 1);
+        RETURN;
+    END
+
+    IF @dataMB < @DataSizeMB
+    BEGIN
+        SET @sql = N'ALTER DATABASE ' + @db + N' MODIFY FILE (NAME = ' + QUOTENAME(@dataFile)
+                 + N', SIZE = ' + CAST(@DataSizeMB AS nvarchar(20)) + N'MB);';
+        EXEC sys.sp_executesql @sql;
+        PRINT '  data file grown to ' + CAST(@DataSizeMB AS varchar(20)) + ' MB.';
+    END
+    ELSE
+        PRINT '  data file already >= target size - left alone.';
+
+    SET @sql = N'ALTER DATABASE ' + @db + N' MODIFY FILE (NAME = ' + QUOTENAME(@dataFile)
+             + N', FILEGROWTH = ' + CAST(@DataGrowMB AS nvarchar(20)) + N'MB);';
+    EXEC sys.sp_executesql @sql;
+
+    IF @logMB < @LogSizeMB
+    BEGIN
+        SET @sql = N'ALTER DATABASE ' + @db + N' MODIFY FILE (NAME = ' + QUOTENAME(@logFile)
+                 + N', SIZE = ' + CAST(@LogSizeMB AS nvarchar(20)) + N'MB);';
+        EXEC sys.sp_executesql @sql;
+        PRINT '  log file grown to ' + CAST(@LogSizeMB AS varchar(20)) + ' MB.';
+    END
+    ELSE
+        PRINT '  log file already >= target size - left alone.';
+
+    SET @sql = N'ALTER DATABASE ' + @db + N' MODIFY FILE (NAME = ' + QUOTENAME(@logFile)
+             + N', FILEGROWTH = ' + CAST(@LogGrowMB AS nvarchar(20)) + N'MB);';
+    EXEC sys.sp_executesql @sql;
+
+    /*------------------------------------------------------------------------
+      3. Recovery model
+
+      FULL is required for point-in-time restore. It also means the log grows
+      until a LOG backup truncates it - a transaction-log backup schedule MUST
+      be in place before go-live, or the log volume will fill.
+    ------------------------------------------------------------------------*/
+    SET @sql = N'ALTER DATABASE ' + @db + N' SET RECOVERY FULL;';
+    EXEC sys.sp_executesql @sql;
+
+    /*------------------------------------------------------------------------
+      4. Read Committed Snapshot Isolation
+
+      Recommended by docs/SQL_Server_Locking_&_Isolation_Reference.md ("Enable
+      RCSI for OLTP systems to reduce reader/writer blocking", and again for
+      heavy reporting) - this system is both: OLTP writes plus many reporting
+      views and Dapper reads over the same tables.
+
+      Explicit lock hints keep working: AppraisalNumberGenerator's
+      UPDATE ... WITH (UPDLOCK, ROWLOCK, HOLDLOCK) still serialises, and the
+      background-job lease patterns are unaffected. Cost: row versions live in
+      tempdb, so size and monitor tempdb accordingly.
+
+      ROLLBACK IMMEDIATE is safe here only because this runs before the
+      application is deployed; it terminates open sessions on the database.
+    ------------------------------------------------------------------------*/
+    SET @sql = N'ALTER DATABASE ' + @db + N' SET READ_COMMITTED_SNAPSHOT ON WITH ROLLBACK IMMEDIATE;';
+    EXEC sys.sp_executesql @sql;
+
+    /*------------------------------------------------------------------------
+      5. Standard production options
+    ------------------------------------------------------------------------*/
+    SET @sql =
+          N'ALTER DATABASE ' + @db + N' SET AUTO_SHRINK OFF;'                  -- fragments indexes; space is reused anyway
+        + N'ALTER DATABASE ' + @db + N' SET AUTO_CREATE_STATISTICS ON;'        -- plan quality
+        + N'ALTER DATABASE ' + @db + N' SET AUTO_UPDATE_STATISTICS ON;'
+        + N'ALTER DATABASE ' + @db + N' SET AUTO_UPDATE_STATISTICS_ASYNC ON;'
+        + N'ALTER DATABASE ' + @db + N' SET PAGE_VERIFY CHECKSUM;'             -- detect storage corruption on read
+        + N'ALTER DATABASE ' + @db + N' SET AUTO_CLOSE OFF;';                  -- keep the database warm
+    EXEC sys.sp_executesql @sql;
+
+    -- Query Store: the most useful thing to already have on when a production
+    -- query regresses. READ_WRITE so it captures from day one.
+    SET @sql = N'ALTER DATABASE ' + @db + N' SET QUERY_STORE = ON;';
+    EXEC sys.sp_executesql @sql;
+
+    SET @sql = N'ALTER DATABASE ' + @db + N' SET QUERY_STORE ('
+             + N'OPERATION_MODE = READ_WRITE, '
+             + N'CLEANUP_POLICY = (STALE_QUERY_THRESHOLD_DAYS = 30), '
+             + N'DATA_FLUSH_INTERVAL_SECONDS = 900, '
+             + N'INTERVAL_LENGTH_MINUTES = 60, '
+             + N'MAX_STORAGE_SIZE_MB = 1024, '
+             + N'QUERY_CAPTURE_MODE = AUTO, '
+             + N'SIZE_BASED_CLEANUP_MODE = AUTO);';
+    EXEC sys.sp_executesql @sql;
+
+    PRINT '  production options applied.';
+
+    /*------------------------------------------------------------------------
+      6. Report the result - read this before continuing to 00_Prepare.sql
+    ------------------------------------------------------------------------*/
+    SELECT
+        d.name                            AS [Database],
+        d.collation_name                  AS [Collation],
+        d.recovery_model_desc             AS [Recovery],
+        d.is_read_committed_snapshot_on   AS [RCSI],
+        d.is_auto_shrink_on               AS [AutoShrink],
+        d.page_verify_option_desc         AS [PageVerify],
+        d.is_query_store_on               AS [QueryStore],
+        d.compatibility_level             AS [CompatLevel]
+    FROM sys.databases d
+    WHERE d.name = @DbName;
+
+    SELECT
+        mf.name                                       AS [LogicalName],
+        mf.type_desc                                  AS [FileType],
+        mf.physical_name                              AS [Path],
+        CAST(mf.size * 8.0 / 1024 AS decimal(18,0))   AS [SizeMB],
+        CASE WHEN mf.is_percent_growth = 1
+             THEN CAST(mf.growth AS varchar(10)) + ' %'
+             ELSE CAST(CAST(mf.growth * 8.0 / 1024 AS decimal(18,0)) AS varchar(20)) + ' MB'
+        END                                           AS [Autogrowth]
+    FROM sys.master_files mf
+    WHERE mf.database_id = DB_ID(@DbName);
+END
+GO
+'@
+
+Write-Sql (Join-Path $OutDir '00_CreateDatabase.sql') (@"
+$header
+$(New-Banner '00 — Create the database.  RUN THIS AGAINST [master].
+
+   Plain T-SQL: no SQLCMD mode, no :setvar, no sqlcmd required. Open it in SSMS,
+   edit the DECLARE block at the top, press Execute. Invoke-SqlDeploy.ps1 also
+   runs it automatically, against master, as the first file in the bundle.
+
+   The database is created on the INSTANCE DEFAULT data/log paths; the files are
+   then resized explicitly. Idempotent - safe to re-run.')
+USE [master];
+GO
+
+BEGIN
+$createDbEditBlock
+$createDbBody
+"@)
 
 # ---------------------------------------------------------------------------
 # 00 — journal table (mirrors MigrationService.EnsureMigrationHistoryTableAsync)
@@ -349,7 +582,12 @@ WHERE t.name = N'__EFMigrationsHistory';
 IF @sql = N''
     PRINT '  *** NO __EFMigrationsHistory TABLE FOUND — the 01_EF_* scripts did not run. ***';
 ELSE
-    EXEC sp_executesql (@sql + N' ORDER BY [Schema];');
+BEGIN
+    -- sp_executesql takes a variable or literal, never an expression: passing
+    -- (@sql + N'...') is a syntax error, so build the statement first.
+    SET @sql = @sql + N' ORDER BY [Schema];';
+    EXEC sys.sp_executesql @sql;
+END
 GO
 
 PRINT '--- 1b. Stray history tables (expect none outside the module schemas) --';

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,6 +13,7 @@ deploy/
   Publish.ps1                 # build box (macOS or Windows, pwsh): produce CAS-<ver>.zip
   New-DbDeploymentScripts.ps1 # build box: generate the db/ SQL bundle (called by Publish.ps1)
   Invoke-SqlDeploy.ps1        # DBA: run the db/ SQL bundle with sqlcmd, in order, abort on error
+                              #      (00_CreateDatabase.sql in that bundle creates the database)
   Invoke-DbMigrate.ps1        # legacy fallback: run Database.exe instead of the SQL bundle
   Deploy-App.ps1              # server: safe in-place backend swap (run on each server)
   Deploy-Web.ps1              # server: frontend static-file swap (run on each server)
@@ -76,19 +77,57 @@ The `db/` folder is plain SQL; `Database.exe` is not needed on the server.
 > fail its health check. Data seeding is a separate thing that still happens at app start —
 > see step 4.
 
+**On a new environment, review `00_CreateDatabase.sql` first.** The bundle creates the database
+itself — this used to happen implicitly (`Database.Migrate()` creates a missing database; the app
+no longer migrates). It runs against `[master]`, uses the **instance default data/log paths**, and
+then applies production settings: fixed-MB autogrowth, `RECOVERY FULL`,
+`READ_COMMITTED_SNAPSHOT ON`, `AUTO_SHRINK OFF`, statistics options, `PAGE_VERIFY CHECKSUM` and
+Query Store. Its `DECLARE` block at the top is the only part to edit:
+
+- **Collation** — nothing in the codebase pins one, so whatever is set here is what production
+  gets. Thai text is `nvarchar`, so this governs sorting and comparison rather than storage — but
+  a production database that differs from UAT will sort and compare differently with nothing to
+  catch it. **Match UAT** unless the bank mandates otherwise.
+- **File sizes / growth** — sized so autogrowth never fires in normal operation. Adjust to the
+  environment.
+- **`@DbName`** — the database to create. If you change it, pass the same name to
+  `Invoke-SqlDeploy.ps1 -Database`; that script verifies the database exists afterwards and fails
+  with a pointed message if the two disagree.
+
+Two consequences worth planning for: `RECOVERY FULL` means the transaction log grows until a log
+backup truncates it, so **a transaction-log backup schedule must exist before go-live** or the log
+volume will fill; and RCSI (enabled per this repo's own
+[`docs/SQL_Server_Locking_&_Isolation_Reference.md`](../docs/SQL_Server_Locking_&_Isolation_Reference.md))
+keeps row versions in tempdb, so size and monitor tempdb accordingly. Explicit lock hints in the
+application are unaffected.
+
+The deploy login needs `db_owner` on the database, plus permission to create it. Schemas
+(`appraisal`, `request`, `workflow`, `auth`, …) are created by the EF scripts.
+
 ```powershell
 .\deploy\Invoke-SqlDeploy.ps1 -ServerInstance SQLHOST -Database CollateralAppraisal `
     -ScriptPath C:\Deploy\temp\20260723-101500\db -TrustedConnection
 ```
 or, in SSMS/sqlcmd, run the files in this order — every one is idempotent:
 
-| File | Contents |
-|---|---|
-| `00_Prepare.sql` | `dbo.DatabaseMigrationHistory` (the journal table) |
-| `01_EF_01..11_*.sql` | EF Core idempotent schema scripts, **in numeric order** |
-| `02_Repeatable_ViewsAndProcs.sql` | 60 views/procs, `CREATE OR ALTER`, dependency-ordered |
-| `03_OneTime_DataScripts.sql` | 39 seed/data scripts, each skipped if already journaled |
-| `99_Verify.sql` | read-only verification — run last, read the output |
+| File | Runs against | Contents |
+|---|---|---|
+| `00_CreateDatabase.sql` | **`master`** | creates the database (default file paths) + production settings |
+| `00_Prepare.sql` | target db | `dbo.DatabaseMigrationHistory` (the journal table) |
+| `01_EF_01..11_*.sql` | target db | EF Core idempotent schema scripts, **in numeric order** |
+| `02_Repeatable_ViewsAndProcs.sql` | target db | 60 views/procs, `CREATE OR ALTER`, dependency-ordered |
+| `03_OneTime_DataScripts.sql` | target db | 40 seed/data scripts, each skipped if already journaled |
+| `99_Verify.sql` | target db | read-only verification — run last, read the output |
+
+`Invoke-SqlDeploy.ps1` handles the `master` connection for the first file automatically, then
+verifies the database exists before running anything inside it.
+
+**Running the files by hand in SSMS?** All of them are plain T-SQL — no SQLCMD Mode, no `:setvar`,
+nothing to enable. Just connect to the right database and press Execute. Two points only:
+
+- `00_CreateDatabase.sql` must be run against **`master`**, and its `DECLARE @DbName` in the EDIT
+  block at the top must match the database you then use for the rest.
+- `99_Verify.sql` is read-only; run it last and read the output.
 
 **4. Deploy the app on each server** (elevated PowerShell, **one server at a time**):
 ```powershell


### PR DESCRIPTION
## Why

The app stopped migrating on startup in `34eb5172`, and with it went the implicit database creation that `Database.Migrate()` used to do for a missing database. **Nothing replaced it**, so the DBA bundle assumed a database that no longer got created — and if it was created by hand, it inherited whatever collation and recovery settings the instance happened to default to.

## `00_CreateDatabase.sql`

Generated as the **first** file in the bundle. It runs against `master`, validates the requested collation against `fn_helpcollations()`, creates the database on the instance default paths, then applies production settings: fixed-MB autogrowth, `RECOVERY FULL`, `READ_COMMITTED_SNAPSHOT ON`, `AUTO_SHRINK OFF`, statistics options, `PAGE_VERIFY CHECKSUM`, Query Store.

File resizing is **grow-only**, so re-running is safe. Everything an operator should change sits in one `DECLARE` block at the top, driven by five new parameters: `-Collation`, `-DataSizeMB`, `-DataGrowthMB`, `-LogSizeMB`, `-LogGrowthMB`.

`Invoke-SqlDeploy.ps1` pulls that file out of the normal loop, runs it against `master` first, then probes `DB_ID` and fails with a pointed message if the database still is not there — otherwise a mismatch between the script's `@DbName` and `-Database` surfaces later as a wall of confusing errors.

## 🚨 Three things to decide before running this on a new environment

- **Collation** — nothing in the codebase pins one, so whatever this script sets is what production gets. Thai text is `nvarchar`, so it governs sorting and comparison rather than storage — but a production database that differs from UAT will sort and compare differently *with nothing to catch it*. **Match UAT.**
- **`RECOVERY FULL`** — the transaction log grows until a log backup truncates it. **A transaction-log backup schedule must exist before go-live**, or the log volume fills.
- **RCSI** — keeps row versions in tempdb, so tempdb needs sizing and monitoring.

## Bug fix: every generated bundle's verify step was broken

The generated `99_Verify.sql` called:

```sql
EXEC sp_executesql (@sql + N' ORDER BY [Schema];')
```

That is invalid T-SQL — `sp_executesql` takes a variable or a literal, not an expression — so the **final verification step of every generated bundle failed**. Now assigns to `@sql` first and calls `sys.sp_executesql @sql`.

## `Api.csproj` — same artifact, 1.2 GB smaller

The Web SDK globs `wwwroot\**` as `Content`, and the existing `wwwroot\*` remove is **single-level**, so it never matched `wwwroot\uploads\documents\*`. That folder is **1.2 GB** of local dev uploads and was being copied into every publish and onto every app server — where `FileStorage:Mode = "Nas"` means nothing reads it. Now removed recursively, plus `.DS_Store` excluded.

The 24 deleted lines are the per-file `_ContentIncludedByDefault Remove` block the IDE had accumulated, now redundant given the recursive globs.

## Reviewer notes

- The `39 → 40` seed-script count in `README.md` assumes #345 and #346 have landed (they net +1 script). If this merges first, that number is off by one.
- `deploy/README.md` is also touched by #344 (the `win-x64` paragraph only); whichever merges second may need a trivial rebase.
- **Out of scope, but worth knowing:** 24 PNGs (54 MB) under `wwwroot/uploads/documents/` are still *tracked* in git despite `.gitignore` covering the folder. This PR stops them being *published*; it does not remove them from history.

## Verification

Run `New-DbDeploymentScripts.ps1` and inspect the bundle: `00_CreateDatabase.sql` present and first, `99_Verify.sql` containing the corrected `sys.sp_executesql @sql`. Confirm `dotnet publish` output has **no** `wwwroot\uploads\` tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127SHKex23dLLdqoYEX37Gm