### PR TITLE
Meeting roster replaces committee members in approval rounds

### DIFF
--- a/Modules/Workflow/Workflow/Domain/Committees/QuorumRule.cs
+++ b/Modules/Workflow/Workflow/Domain/Committees/QuorumRule.cs
@@ -1,0 +1,28 @@
+namespace Workflow.Domain.Committees;
+
+/// <summary>
+/// Single source of truth for how many votes a round needs before it can resolve.
+/// Used by the approval engine (<c>ApprovalActivity.GetRequiredQuorum</c>) and by the
+/// meeting release gate (<c>MeetingRosterEligibility</c>) so the number a secretary is
+/// checked against is the number the round will actually demand.
+/// </summary>
+public static class QuorumRule
+{
+    /// <param name="memberCount">
+    /// The members the round will run with — the committee's active members normally, or the
+    /// meeting roster when it overrides them.
+    /// </param>
+    public static int Required(QuorumType type, int value, int memberCount) =>
+        type switch
+        {
+            QuorumType.Fixed => value,
+            QuorumType.Percentage => (int)Math.Ceiling(memberCount * value / 100.0),
+            _ => memberCount
+        };
+
+    /// <summary>String overload for the engine, which round-trips the type name through JSON.</summary>
+    public static int Required(string type, int value, int memberCount) =>
+        Enum.TryParse<QuorumType>(type, ignoreCase: true, out var parsed)
+            ? Required(parsed, value, memberCount)
+            : memberCount;
+}

--- a/Modules/Workflow/Workflow/Meetings/Activities/MeetingActivity.cs
+++ b/Modules/Workflow/Workflow/Meetings/Activities/MeetingActivity.cs
@@ -177,15 +177,8 @@ public class MeetingActivity : WorkflowActivityBase
         if (resumeInput.TryGetValue("cancelReason", out var reason))
             outputData[$"{normalized}_cancelReason"] = reason;
 
-        // Propagate meeting member user IDs so downstream ApprovalActivity can consume
-        // them as its approver list (released items only).
-        if (resumeInput.TryGetValue("meetingMemberUserIds", out var memberIds))
-        {
-            outputData[$"{normalized}_meetingMemberUserIds"] = memberIds;
-            outputData["meetingMemberUserIds"] = memberIds;
-        }
-
-        // Propagate override member list so downstream ApprovalActivity can replace its committee members.
+        // Propagate this meeting's roster ({ userId, role } pairs) so the downstream
+        // ApprovalActivity replaces its committee-resolved members with it (released items only).
         if (resumeInput.TryGetValue("meetingMemberOverrides", out var memberOverrides))
         {
             outputData[$"{normalized}_meetingMemberOverrides"] = memberOverrides;

--- a/Modules/Workflow/Workflow/Meetings/Domain/Events/MeetingItemReleasedDomainEvent.cs
+++ b/Modules/Workflow/Workflow/Meetings/Domain/Events/MeetingItemReleasedDomainEvent.cs
@@ -8,4 +8,12 @@ public record MeetingItemReleasedDomainEvent(
     Guid WorkflowInstanceId,
     string ActivityId,
     string ReleasedBy,
-    IReadOnlyList<string> MemberUserIds) : IDomainEvent;
+    IReadOnlyList<MeetingApprover> Members) : IDomainEvent;
+
+/// <summary>
+/// A meeting member as the downstream approval sees them: the user who votes and the
+/// meeting position that becomes their approval role. <paramref name="Role"/> is the
+/// <see cref="Workflow.Domain.Committees.CommitteeMemberPosition"/> name, so committee
+/// <c>RoleRequired</c> conditions keep matching once the roster drives the approval.
+/// </summary>
+public record MeetingApprover(string UserId, string Role);

--- a/Modules/Workflow/Workflow/Meetings/Domain/Meeting.cs
+++ b/Modules/Workflow/Workflow/Meetings/Domain/Meeting.cs
@@ -467,10 +467,15 @@ public class Meeting : Aggregate<Guid>
             throw new InvalidOperationException(
                 $"Decision item for appraisal {appraisalId} is missing WorkflowInstanceId or ActivityId");
 
-        var memberUserIds = _members.Select(m => m.UserId).ToList().AsReadOnly();
+        // Carries the position as well as the user id: the approval activity uses this roster
+        // as its member list, and the position becomes each voter's approval role.
+        var approvers = _members
+            .Select(m => new MeetingApprover(m.UserId, m.Position.ToString()))
+            .ToList()
+            .AsReadOnly();
 
         AddDomainEvent(new MeetingItemReleasedDomainEvent(
-            Id, appraisalId, item.WorkflowInstanceId.Value, item.ActivityId, actor, memberUserIds));
+            Id, appraisalId, item.WorkflowInstanceId.Value, item.ActivityId, actor, approvers));
 
         // Auto-transition: if every Decision item has been Released, end the meeting.
         var allDecisionItems = _items.Where(i => i.Kind == MeetingItemKind.Decision).ToList();

--- a/Modules/Workflow/Workflow/Meetings/Domain/MeetingCommittee.cs
+++ b/Modules/Workflow/Workflow/Meetings/Domain/MeetingCommittee.cs
@@ -1,0 +1,13 @@
+namespace Workflow.Meetings.Domain;
+
+/// <summary>
+/// The committee that governs meetings. Only the top appraisal tier routes through a meeting
+/// (<c>approval-tier-switch</c> → <c>pending-meeting</c> in appraisal-workflow.json), so a
+/// meeting is always snapshotted from — and its released items always approved by — this one
+/// committee. Shared by <c>CreateMeeting</c>, <c>BulkCreateMeetings</c> and the release gate so
+/// the roster is checked against the same committee it was copied from.
+/// </summary>
+public static class MeetingCommittee
+{
+    public const string WithMeetingCode = "COMMITTEE_WITH_MEETING";
+}

--- a/Modules/Workflow/Workflow/Meetings/Domain/MeetingRosterEligibility.cs
+++ b/Modules/Workflow/Workflow/Meetings/Domain/MeetingRosterEligibility.cs
@@ -1,0 +1,57 @@
+using Workflow.Domain.Committees;
+
+namespace Workflow.Meetings.Domain;
+
+/// <summary>
+/// Checks that a meeting's roster can actually carry the approval round that follows a release.
+///
+/// Once an item is released the roster REPLACES the committee's members in the approval activity,
+/// but the rules the round is judged by — quorum and the committee's approval conditions — still
+/// come from the committee. A roster that cannot satisfy them produces a round that can never
+/// resolve, with the appraisal stuck in Committee Approval and no error anywhere. The release
+/// endpoint runs this first and refuses instead.
+/// </summary>
+public static class MeetingRosterEligibility
+{
+    /// <summary>
+    /// Returns one message per unsatisfiable rule; empty means the roster can carry the round.
+    /// </summary>
+    public static IReadOnlyList<string> Check(IReadOnlyList<MeetingMember> roster, Committee committee)
+    {
+        ArgumentNullException.ThrowIfNull(roster);
+        ArgumentNullException.ThrowIfNull(committee);
+
+        var failures = new List<string>();
+
+        // Quorum. The same rule the approval round applies, against the same member count it will
+        // run with (the roster), so this check and that round can never disagree. Only a Fixed
+        // quorum can fail here — a Percentage of the roster is satisfiable by construction.
+        var requiredQuorum = QuorumRule.Required(committee.QuorumType, committee.QuorumValue, roster.Count);
+        if (roster.Count < requiredQuorum)
+            failures.Add($"{roster.Count} member(s) but quorum requires {requiredQuorum}");
+
+        foreach (var condition in committee.Conditions.Where(c => c.IsActive).OrderBy(c => c.Priority))
+        {
+            switch (condition.ConditionType)
+            {
+                // The condition is evaluated against the ROLE recorded on each vote, which is the
+                // member's meeting position. If nobody on the roster holds the required position,
+                // no vote can ever carry that role.
+                case ConditionType.RoleRequired
+                    when !string.IsNullOrWhiteSpace(condition.RoleRequired)
+                         && !roster.Any(m => string.Equals(
+                             m.Position.ToString(), condition.RoleRequired, StringComparison.OrdinalIgnoreCase)):
+                    failures.Add($"no member holds the required role {condition.RoleRequired}");
+                    break;
+
+                case ConditionType.MinVotes
+                    when condition.MinVotesRequired > roster.Count:
+                    failures.Add(
+                        $"{condition.MinVotesRequired} approve vote(s) required but the roster has only {roster.Count} member(s)");
+                    break;
+            }
+        }
+
+        return failures;
+    }
+}

--- a/Modules/Workflow/Workflow/Meetings/EventHandlers/MeetingItemReleasedDomainEventHandler.cs
+++ b/Modules/Workflow/Workflow/Meetings/EventHandlers/MeetingItemReleasedDomainEventHandler.cs
@@ -11,8 +11,11 @@ namespace Workflow.Meetings.EventHandlers;
 /// Resume input carries:
 /// - <c>meetingId</c>: the meeting Guid.
 /// - <c>meetingOutcome</c>: "released" (see <see cref="MeetingOutcomes.Released"/>).
-/// - <c>meetingMemberUserIds</c>: user IDs of all meeting members — consumed by the downstream
-///   ApprovalActivity as its approver list.
+/// - <c>meetingMemberOverrides</c>: this meeting's roster as <c>{ userId, role }</c> pairs —
+///   consumed by the downstream ApprovalActivity as its member list, replacing the members it
+///   would otherwise resolve from the committee. Sending the roster (not just user ids) is what
+///   makes per-meeting add/remove/position edits actually govern who votes; the role carries the
+///   meeting position so committee <c>RoleRequired</c> conditions still evaluate.
 /// - <c>completedBy</c>: the secretary who released this item.
 /// </summary>
 public class MeetingItemReleasedDomainEventHandler(
@@ -36,7 +39,9 @@ public class MeetingItemReleasedDomainEventHandler(
             {
                 ["meetingId"] = notification.MeetingId,
                 ["meetingOutcome"] = MeetingOutcomes.Released,
-                ["meetingMemberUserIds"] = notification.MemberUserIds.ToArray(),
+                ["meetingMemberOverrides"] = notification.Members
+                    .Select(m => new { userId = m.UserId, role = m.Role })
+                    .ToArray(),
                 ["completedBy"] = notification.ReleasedBy
             },
             cancellationToken: cancellationToken);

--- a/Modules/Workflow/Workflow/Meetings/Features/BulkCreateMeetings/BulkCreateMeetingsEndpoint.cs
+++ b/Modules/Workflow/Workflow/Meetings/Features/BulkCreateMeetings/BulkCreateMeetingsEndpoint.cs
@@ -40,8 +40,6 @@ public class BulkCreateMeetingsCommandHandler(
     IDateTimeProvider dateTimeProvider)
     : ICommandHandler<BulkCreateMeetingsCommand, BulkCreateMeetingsResponse>
 {
-    private const string COMMITTEE_WITH_MEETING = "COMMITTEE_WITH_MEETING";
-
     public async Task<BulkCreateMeetingsResponse> Handle(
         BulkCreateMeetingsCommand command, CancellationToken ct)
     {
@@ -58,8 +56,8 @@ public class BulkCreateMeetingsCommandHandler(
         }
         else
         {
-            committee = await committeeRepository.GetByCodeAsync(COMMITTEE_WITH_MEETING, ct)
-                ?? throw new NotFoundException($"Committee {COMMITTEE_WITH_MEETING} not found");
+            committee = await committeeRepository.GetByCodeAsync(MeetingCommittee.WithMeetingCode, ct)
+                ?? throw new NotFoundException($"Committee {MeetingCommittee.WithMeetingCode} not found");
         }
 
         var now = dateTimeProvider.ApplicationNow;

--- a/Modules/Workflow/Workflow/Meetings/Features/CreateMeeting/CreateMeetingEndpoint.cs
+++ b/Modules/Workflow/Workflow/Meetings/Features/CreateMeeting/CreateMeetingEndpoint.cs
@@ -41,8 +41,6 @@ public class CreateMeetingCommandHandler(
     IDateTimeProvider dateTimeProvider)
     : ICommandHandler<CreateMeetingCommand, CreateMeetingResponse>
 {
-    private const string COMMITTEE_WITH_MEETING = "COMMITTEE_WITH_MEETING";
-
     public async Task<CreateMeetingResponse> Handle(CreateMeetingCommand command, CancellationToken ct)
     {
         var now = dateTimeProvider.ApplicationNow;
@@ -80,8 +78,8 @@ public class CreateMeetingCommandHandler(
         var title = defaults.TitleTemplate.Replace("{meetingNo}", meetingNo);
         var meeting = Meeting.Create(title, notes: null, meetingNo, seq, beYear);
 
-        var committee = await committeeRepository.GetByCodeAsync(COMMITTEE_WITH_MEETING, ct)
-                        ?? throw new NotFoundException($"Committee {COMMITTEE_WITH_MEETING} not found");
+        var committee = await committeeRepository.GetByCodeAsync(MeetingCommittee.WithMeetingCode, ct)
+                        ?? throw new NotFoundException($"Committee {MeetingCommittee.WithMeetingCode} not found");
 
         meeting.SnapshotCommittee(committee, meeting.MeetingNoSeq!.Value);
 

--- a/Modules/Workflow/Workflow/Meetings/Features/ReleaseMeetingItem/ReleaseMeetingItemEndpoint.cs
+++ b/Modules/Workflow/Workflow/Meetings/Features/ReleaseMeetingItem/ReleaseMeetingItemEndpoint.cs
@@ -1,4 +1,5 @@
 using Shared.Identity;
+using Workflow.Domain.Committees;
 using Workflow.Meetings.Domain;
 
 namespace Workflow.Meetings.Features.ReleaseMeetingItem;
@@ -28,6 +29,7 @@ public record ReleaseMeetingItemCommand(Guid MeetingId, Guid AppraisalId)
 
 public class ReleaseMeetingItemCommandHandler(
     IMeetingRepository meetingRepository,
+    ICommitteeRepository committeeRepository,
     ICurrentUserService currentUserService,
     IDateTimeProvider dateTimeProvider)
     : ICommandHandler<ReleaseMeetingItemCommand>
@@ -39,6 +41,18 @@ public class ReleaseMeetingItemCommandHandler(
 
         var meeting = await meetingRepository.GetByIdForDecisionAsync(command.MeetingId, ct)
             ?? throw new NotFoundException($"Meeting {command.MeetingId} not found");
+
+        // Releasing hands this roster to the approval activity as its voting members. Refuse now if
+        // it cannot satisfy the committee's quorum or approval conditions — otherwise the round
+        // opens and silently never resolves.
+        var committee = await committeeRepository.GetByCodeAsync(MeetingCommittee.WithMeetingCode, ct)
+            ?? throw new NotFoundException($"Committee {MeetingCommittee.WithMeetingCode} not found");
+
+        var failures = MeetingRosterEligibility.Check(meeting.Members, committee);
+        if (failures.Count > 0)
+            throw new ConflictException(
+                $"Meeting roster cannot satisfy committee {committee.Code}: " +
+                $"{string.Join("; ", failures)}. Fix the roster before releasing.");
 
         meeting.ReleaseItem(command.AppraisalId, actor, dateTimeProvider.ApplicationNow);
 

--- a/Modules/Workflow/Workflow/Workflow/Activities/ApprovalActivity.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/ApprovalActivity.cs
@@ -72,8 +72,11 @@ public class ApprovalActivity : WorkflowActivityBase
             var groupInfo = await _memberResolver.ResolveMembersAsync(
                 memberSourceConfig, context.Variables, inlineQuorum, inlineMajority, cancellationToken);
 
-            // Member override: if the pending-meeting step supplied a manual member list, use it
-            // instead of the committee's configured members. Quorum/majority still come from groupInfo.
+            // Member override: the pending-meeting step supplies the roster of the meeting that
+            // released this appraisal, so per-meeting add/remove/position edits govern who votes
+            // here. Used instead of the committee's configured members; quorum/majority/conditions
+            // still come from groupInfo. Each member's meeting position becomes their approval role,
+            // which is what lands on ApprovalVote.MemberRole and what RoleRequired conditions match.
             var overrideMembers = GetVariable<List<MeetingMemberOverride>>(context, "meetingMemberOverrides", []);
             var resolvedMembers = overrideMembers.Count > 0
                 ? overrideMembers.Select(m => new ApprovalMemberInfo(m.UserId, m.Role)).ToList()
@@ -113,6 +116,14 @@ public class ApprovalActivity : WorkflowActivityBase
                 [$"{NormalizeActivityId(context.ActivityId)}_votesReceived"] = 0,
                 ["activityName"] = activityName
             };
+
+            // Consume-once: meetingMemberOverrides is a GLOBAL variable, so clear it now that this
+            // round has snapshotted it into _members. Without this, a route_back from here sends the
+            // appraisal back for rework, and if the revised appraisalValue then falls into a tier
+            // that skips the meeting (approval-tier-switch → pending-approval directly), that round
+            // would silently inherit the old meeting's roster instead of its own committee.
+            if (overrideMembers.Count > 0)
+                outputData["meetingMemberOverrides"] = new List<MeetingMemberOverride>();
 
             // Calculate the SLA deadline via the business-time SLA calculator — the same path
             // TaskActivity uses — so approval activities (a) count in BUSINESS hours (excl.
@@ -800,15 +811,10 @@ public class ApprovalActivity : WorkflowActivityBase
         return true;
     }
 
+    // Delegates to the shared domain rule (single source of truth) so the meeting release gate,
+    // which pre-checks a roster against this same number, cannot drift from it.
     private static int GetRequiredQuorum(QuorumConfig config, int totalMembers)
-    {
-        return config.Type.ToLowerInvariant() switch
-        {
-            "fixed" => config.Value,
-            "percentage" => (int)Math.Ceiling(totalMembers * config.Value / 100.0),
-            _ => totalMembers
-        };
-    }
+        => QuorumRule.Required(config.Type, config.Value, totalMembers);
 
     // Majority is evaluated against the FULL committee (totalMembers), not the votes cast. The string
     // MajorityConfig.Type is the round-tripped MajorityType name, so parse it back to the enum and

--- a/Tests/Unit/Workflow.Tests/Domain/QuorumRuleTests.cs
+++ b/Tests/Unit/Workflow.Tests/Domain/QuorumRuleTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using Workflow.Domain.Committees;
+using Xunit;
+
+namespace Workflow.Tests.Domain;
+
+/// <summary>
+/// The approval engine and the meeting release gate both ask this rule how many votes a round
+/// needs, so a roster accepted at release is one the round can actually resolve with.
+/// </summary>
+public class QuorumRuleTests
+{
+    [Theory]
+    [InlineData(3, 5, 3)]
+    [InlineData(3, 2, 3)]   // a Fixed quorum ignores the member count — this is the case that strands a round
+    [InlineData(1, 0, 1)]
+    public void Required_Fixed_IsTheConfiguredValue(int value, int memberCount, int expected)
+        => QuorumRule.Required(QuorumType.Fixed, value, memberCount).Should().Be(expected);
+
+    [Theory]
+    [InlineData(50, 4, 2)]
+    [InlineData(50, 5, 3)]   // rounds up
+    [InlineData(100, 3, 3)]
+    [InlineData(60, 0, 0)]
+    public void Required_Percentage_RoundsUpAgainstTheMemberCount(int value, int memberCount, int expected)
+        => QuorumRule.Required(QuorumType.Percentage, value, memberCount).Should().Be(expected);
+
+    [Fact]
+    public void Required_Percentage_NeverExceedsTheMemberCount()
+    {
+        // Why only a Fixed quorum can make a roster ineligible at release time.
+        for (var memberCount = 1; memberCount <= 20; memberCount++)
+            QuorumRule.Required(QuorumType.Percentage, 100, memberCount)
+                .Should().BeLessThanOrEqualTo(memberCount);
+    }
+
+    [Theory]
+    [InlineData("Fixed", 2, 5, 2)]
+    [InlineData("fixed", 2, 5, 2)]
+    [InlineData("Percentage", 50, 4, 2)]
+    [InlineData("percentage", 50, 4, 2)]
+    public void Required_StringOverload_ParsesTheRoundTrippedTypeName(
+        string type, int value, int memberCount, int expected)
+        => QuorumRule.Required(type, value, memberCount).Should().Be(expected);
+
+    [Fact]
+    public void Required_UnknownTypeName_FallsBackToRequiringEveryMember()
+        => QuorumRule.Required("nonsense", 2, 4).Should().Be(4);
+}

--- a/Tests/Unit/Workflow.Tests/Meetings/MeetingItemReleasedDomainEventHandlerTests.cs
+++ b/Tests/Unit/Workflow.Tests/Meetings/MeetingItemReleasedDomainEventHandlerTests.cs
@@ -6,6 +6,7 @@ using Workflow.Domain.Committees;
 using Workflow.Meetings.Domain;
 using Workflow.Meetings.Domain.Events;
 using Workflow.Meetings.EventHandlers;
+using Workflow.Workflow.Activities.Core;
 using Workflow.Workflow.Models;
 using Workflow.Workflow.Services;
 using Xunit;

--- a/Tests/Unit/Workflow.Tests/Meetings/MeetingItemReleasedDomainEventHandlerTests.cs
+++ b/Tests/Unit/Workflow.Tests/Meetings/MeetingItemReleasedDomainEventHandlerTests.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Workflow.Domain.Committees;
+using Workflow.Meetings.Domain;
+using Workflow.Meetings.Domain.Events;
+using Workflow.Meetings.EventHandlers;
+using Workflow.Workflow.Models;
+using Workflow.Workflow.Services;
+using Xunit;
+
+namespace Workflow.Tests.Meetings;
+
+/// <summary>
+/// The handler is the hand-off point between the meeting roster and the approval round:
+/// whatever it puts in the resume input is what MeetingActivity propagates and
+/// ApprovalActivity consumes as its member list.
+/// </summary>
+public class MeetingItemReleasedDomainEventHandlerTests
+{
+    private readonly IWorkflowService _workflowService = Substitute.For<IWorkflowService>();
+
+    private MeetingItemReleasedDomainEventHandler BuildHandler() =>
+        new(_workflowService, Substitute.For<ILogger<MeetingItemReleasedDomainEventHandler>>());
+
+    [Fact]
+    public async Task Handle_ResumesWithRosterAsMeetingMemberOverrides()
+    {
+        var handler = BuildHandler();
+        var workflowInstanceId = Guid.NewGuid();
+        var notification = new MeetingItemReleasedDomainEvent(
+            MeetingId: Guid.NewGuid(),
+            AppraisalId: Guid.NewGuid(),
+            WorkflowInstanceId: workflowInstanceId,
+            ActivityId: "pending-meeting",
+            ReleasedBy: "secretary",
+            Members:
+            [
+                new MeetingApprover("alice", nameof(CommitteeMemberPosition.Chairman)),
+                new MeetingApprover("bob", nameof(CommitteeMemberPosition.UW))
+            ]);
+
+        await handler.Handle(notification, CancellationToken.None);
+
+        var input = CapturedInput();
+
+        input.Should().ContainKey("meetingMemberOverrides");
+        input.Should().NotContainKey("meetingMemberUserIds",
+            "the approval activity reads meetingMemberOverrides; a user-id-only payload has no consumer");
+        input["meetingOutcome"].Should().Be(MeetingOutcomes.Released);
+        input["completedBy"].Should().Be("secretary");
+    }
+
+    [Fact]
+    public async Task Handle_OverridesCarryUserIdAndRole_InTheShapeApprovalActivityDeserializes()
+    {
+        var handler = BuildHandler();
+        var notification = new MeetingItemReleasedDomainEvent(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "pending-meeting", "secretary",
+            [
+                new MeetingApprover("alice", nameof(CommitteeMemberPosition.Chairman)),
+                new MeetingApprover("bob", nameof(CommitteeMemberPosition.UW))
+            ]);
+
+        await handler.Handle(notification, CancellationToken.None);
+
+        var input = CapturedInput();
+
+        // Variables round-trip through JSON before ApprovalActivity reads them, so assert on the
+        // serialized shape rather than the CLR type: camelCase userId/role is what the activity's
+        // case-insensitive deserializer binds to MeetingMemberOverride(UserId, Role).
+        var roundTripped = JsonSerializer.Deserialize<List<RoundTrippedOverride>>(
+            JsonSerializer.Serialize(input["meetingMemberOverrides"]),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+        roundTripped.Should().BeEquivalentTo(
+        [
+            new RoundTrippedOverride("alice", nameof(CommitteeMemberPosition.Chairman)),
+            new RoundTrippedOverride("bob", nameof(CommitteeMemberPosition.UW))
+        ]);
+    }
+
+    [Fact]
+    public async Task Handle_ResumesTheReleasedItemsInstanceAndActivity()
+    {
+        var handler = BuildHandler();
+        var workflowInstanceId = Guid.NewGuid();
+        var notification = new MeetingItemReleasedDomainEvent(
+            Guid.NewGuid(), Guid.NewGuid(), workflowInstanceId, "pending-meeting", "secretary",
+            [new MeetingApprover("alice", nameof(CommitteeMemberPosition.Chairman))]);
+
+        await handler.Handle(notification, CancellationToken.None);
+
+        await _workflowService.Received(1).ResumeWorkflowAsync(
+            workflowInstanceId,
+            "pending-meeting",
+            "secretary",
+            Arg.Any<Dictionary<string, object>>(),
+            Arg.Any<Dictionary<string, RuntimeOverride>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private Dictionary<string, object> CapturedInput()
+    {
+        var resume = _workflowService.ReceivedCalls()
+            .Single(c => c.GetMethodInfo().Name == nameof(IWorkflowService.ResumeWorkflowAsync));
+        return (Dictionary<string, object>)resume.GetArguments()[3]!;
+    }
+
+    private record RoundTrippedOverride(string UserId, string Role);
+}

--- a/Tests/Unit/Workflow.Tests/Meetings/MeetingRosterEligibilityTests.cs
+++ b/Tests/Unit/Workflow.Tests/Meetings/MeetingRosterEligibilityTests.cs
@@ -1,0 +1,155 @@
+using FluentAssertions;
+using Workflow.Domain.Committees;
+using Workflow.Meetings.Domain;
+using Xunit;
+
+namespace Workflow.Tests.Meetings;
+
+/// <summary>
+/// The roster replaces the committee's members in the approval round, but quorum and the
+/// committee's approval conditions still govern that round. These tests pin the combinations
+/// that would otherwise open a round that can never resolve.
+/// </summary>
+public class MeetingRosterEligibilityTests
+{
+    [Fact]
+    public void Check_RosterMeetsFixedQuorum_NoFailures()
+    {
+        var committee = BuildCommittee(QuorumType.Fixed, 3);
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Chairman),
+                   ("b", CommitteeMemberPosition.Member),
+                   ("c", CommitteeMemberPosition.Member)),
+            committee);
+
+        failures.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Check_RosterBelowFixedQuorum_Fails()
+    {
+        var committee = BuildCommittee(QuorumType.Fixed, 3);
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Chairman),
+                   ("b", CommitteeMemberPosition.Member)),
+            committee);
+
+        failures.Should().ContainSingle()
+            .Which.Should().Be("2 member(s) but quorum requires 3");
+    }
+
+    [Fact]
+    public void Check_PercentageQuorum_IsAlwaysSatisfiableByTheRosterItself()
+    {
+        // Percentage is taken of the members the round runs with — the roster — so it can never
+        // demand more people than are on it. Only a Fixed quorum can strand a round.
+        var committee = BuildCommittee(QuorumType.Percentage, 100);
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Chairman)), committee);
+
+        failures.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Check_RosterMissingRequiredRole_Fails()
+    {
+        var committee = BuildCommittee(QuorumType.Fixed, 2);
+        committee.AddCondition(ConditionType.RoleRequired, nameof(CommitteeMemberPosition.UW),
+            minVotesRequired: null, priority: 1, description: "UW must approve");
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Chairman),
+                   ("b", CommitteeMemberPosition.Member)),
+            committee);
+
+        failures.Should().ContainSingle()
+            .Which.Should().Be("no member holds the required role UW");
+    }
+
+    [Fact]
+    public void Check_RosterHoldsRequiredRole_NoFailures()
+    {
+        var committee = BuildCommittee(QuorumType.Fixed, 2);
+        committee.AddCondition(ConditionType.RoleRequired, nameof(CommitteeMemberPosition.UW),
+            null, 1, "UW must approve");
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Chairman),
+                   ("b", CommitteeMemberPosition.UW)),
+            committee);
+
+        failures.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Check_InactiveCondition_IsIgnored()
+    {
+        var committee = BuildCommittee(QuorumType.Fixed, 1);
+        var condition = committee.AddCondition(ConditionType.RoleRequired,
+            nameof(CommitteeMemberPosition.UW), null, 1, "UW must approve");
+        condition.Deactivate();
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Chairman)), committee);
+
+        failures.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Check_MinVotesExceedsRosterSize_Fails()
+    {
+        var committee = BuildCommittee(QuorumType.Fixed, 1);
+        committee.AddCondition(ConditionType.MinVotes, roleRequired: null,
+            minVotesRequired: 3, priority: 1, description: "at least 3 approvals");
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Chairman),
+                   ("b", CommitteeMemberPosition.Member)),
+            committee);
+
+        failures.Should().ContainSingle()
+            .Which.Should().Be("3 approve vote(s) required but the roster has only 2 member(s)");
+    }
+
+    [Fact]
+    public void Check_MultipleUnsatisfiableRules_ReportsAllOfThem()
+    {
+        var committee = BuildCommittee(QuorumType.Fixed, 3);
+        committee.AddCondition(ConditionType.RoleRequired, nameof(CommitteeMemberPosition.UW),
+            null, 1, "UW must approve");
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Chairman)), committee);
+
+        failures.Should().BeEquivalentTo(
+        [
+            "1 member(s) but quorum requires 3",
+            "no member holds the required role UW"
+        ]);
+    }
+
+    [Fact]
+    public void Check_EmptyRoster_FailsQuorum()
+    {
+        var committee = BuildCommittee(QuorumType.Fixed, 1);
+
+        var failures = MeetingRosterEligibility.Check([], committee);
+
+        failures.Should().ContainSingle()
+            .Which.Should().Be("0 member(s) but quorum requires 1");
+    }
+
+    // -- Helpers --
+
+    private static Committee BuildCommittee(QuorumType quorumType, int quorumValue)
+        => Committee.Create("Committee With Meeting", MeetingCommittee.WithMeetingCode, null,
+            quorumType, quorumValue, MajorityType.Unanimous, VotingMode.WaitForAll);
+
+    private static List<MeetingMember> Roster(params (string UserId, CommitteeMemberPosition Position)[] members)
+        => members
+            .Select(m => MeetingMember.CreateManual(Guid.NewGuid(), m.UserId, m.UserId, m.Position))
+            .ToList();
+}

--- a/Tests/Unit/Workflow.Tests/Meetings/MeetingTests.cs
+++ b/Tests/Unit/Workflow.Tests/Meetings/MeetingTests.cs
@@ -311,7 +311,7 @@ public class MeetingTests
     }
 
     [Fact]
-    public void ReleaseItem_IncludesMemberUserIds_InEvent()
+    public void ReleaseItem_IncludesMembersWithPositions_InEvent()
     {
         var committee = BuildCommittee();
         committee.AddMember("m1", "Alice", CommitteeMemberPosition.Chairman);
@@ -322,10 +322,74 @@ public class MeetingTests
 
         meeting.ReleaseItem(appraisalId, "secretary", DateTime.UtcNow);
 
-        var evt = (MeetingItemReleasedDomainEvent)meeting.DomainEvents
-            .Single(e => e is MeetingItemReleasedDomainEvent);
-        evt.MemberUserIds.Should().BeEquivalentTo(["m1", "m2"]);
+        // The position travels with the user id: downstream it becomes the approval role that
+        // committee RoleRequired conditions are matched against.
+        ReleasedMembers(meeting).Should().BeEquivalentTo(
+        [
+            new MeetingApprover("m1", nameof(CommitteeMemberPosition.Chairman)),
+            new MeetingApprover("m2", nameof(CommitteeMemberPosition.Member))
+        ]);
     }
+
+    [Fact]
+    public void ReleaseItem_AfterMemberAddedToThisMeeting_IncludesTheAddedMember()
+    {
+        var committee = BuildCommittee();
+        committee.AddMember("m1", "Alice", CommitteeMemberPosition.Chairman);
+
+        var meeting = BuildInvitationSentMeetingWithOneItem(committee);
+        meeting.AddMember(
+            MeetingMember.CreateManual(meeting.Id, "extra", "Dave", CommitteeMemberPosition.UW),
+            DateTime.UtcNow);
+
+        var appraisalId = meeting.Items.Single(i => i.Kind == MeetingItemKind.Decision).AppraisalId;
+        meeting.ReleaseItem(appraisalId, "secretary", DateTime.UtcNow);
+
+        ReleasedMembers(meeting).Should().BeEquivalentTo(
+        [
+            new MeetingApprover("m1", nameof(CommitteeMemberPosition.Chairman)),
+            new MeetingApprover("extra", nameof(CommitteeMemberPosition.UW))
+        ]);
+    }
+
+    [Fact]
+    public void ReleaseItem_AfterMemberRemovedFromThisMeeting_ExcludesTheRemovedMember()
+    {
+        var committee = BuildCommittee();
+        committee.AddMember("m1", "Alice", CommitteeMemberPosition.Chairman);
+        committee.AddMember("m2", "Bob", CommitteeMemberPosition.Member);
+
+        var meeting = BuildInvitationSentMeetingWithOneItem(committee);
+        var bob = meeting.Members.Single(m => m.UserId == "m2");
+        meeting.RemoveMember(bob.Id, DateTime.UtcNow);
+
+        var appraisalId = meeting.Items.Single(i => i.Kind == MeetingItemKind.Decision).AppraisalId;
+        meeting.ReleaseItem(appraisalId, "secretary", DateTime.UtcNow);
+
+        ReleasedMembers(meeting).Should().BeEquivalentTo(
+            [new MeetingApprover("m1", nameof(CommitteeMemberPosition.Chairman))]);
+    }
+
+    [Fact]
+    public void ReleaseItem_AfterPositionChangedOnThisMeeting_CarriesTheNewPosition()
+    {
+        var committee = BuildCommittee();
+        committee.AddMember("m1", "Alice", CommitteeMemberPosition.Member);
+
+        var meeting = BuildInvitationSentMeetingWithOneItem(committee);
+        var alice = meeting.Members.Single(m => m.UserId == "m1");
+        meeting.ChangeMemberPosition(alice.Id, CommitteeMemberPosition.UW, DateTime.UtcNow);
+
+        var appraisalId = meeting.Items.Single(i => i.Kind == MeetingItemKind.Decision).AppraisalId;
+        meeting.ReleaseItem(appraisalId, "secretary", DateTime.UtcNow);
+
+        ReleasedMembers(meeting).Should().BeEquivalentTo(
+            [new MeetingApprover("m1", nameof(CommitteeMemberPosition.UW))]);
+    }
+
+    private static IReadOnlyList<MeetingApprover> ReleasedMembers(Meeting meeting)
+        => ((MeetingItemReleasedDomainEvent)meeting.DomainEvents
+            .Single(e => e is MeetingItemReleasedDomainEvent)).Members;
 
     [Fact]
     public void ReleaseItem_WhenAlreadyReleased_Throws()

--- a/Tests/Unit/Workflow.Tests/Meetings/ReleaseMeetingItemGateTests.cs
+++ b/Tests/Unit/Workflow.Tests/Meetings/ReleaseMeetingItemGateTests.cs
@@ -1,0 +1,144 @@
+using FluentAssertions;
+using NSubstitute;
+using Shared.Exceptions;
+using Shared.Identity;
+using Shared.Time;
+using Workflow.Domain.Committees;
+using Workflow.Meetings.Domain;
+using Workflow.Meetings.Domain.Events;
+using Workflow.Meetings.Features.ReleaseMeetingItem;
+using Xunit;
+
+namespace Workflow.Tests.Meetings;
+
+/// <summary>
+/// Releasing hands the roster to the approval activity as its voting members. The handler must
+/// refuse when that roster cannot satisfy the committee's rules — a round that opens without a
+/// reachable quorum or required role never resolves and never reports anything.
+/// </summary>
+public class ReleaseMeetingItemGateTests
+{
+    private readonly IMeetingRepository _meetingRepository = Substitute.For<IMeetingRepository>();
+    private readonly ICommitteeRepository _committeeRepository = Substitute.For<ICommitteeRepository>();
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly IDateTimeProvider _clock = Substitute.For<IDateTimeProvider>();
+
+    public ReleaseMeetingItemGateTests()
+    {
+        _currentUser.Username.Returns("secretary");
+        _clock.ApplicationNow.Returns(DateTime.UtcNow);
+    }
+
+    private ReleaseMeetingItemCommandHandler BuildHandler() =>
+        new(_meetingRepository, _committeeRepository, _currentUser, _clock);
+
+    [Fact]
+    public async Task Handle_RosterBelowFixedQuorum_ThrowsConflictAndDoesNotRelease()
+    {
+        var committee = BuildCommittee(quorumValue: 3);
+        var meeting = BuildMeetingWithRoster(committee,
+            ("alice", CommitteeMemberPosition.Chairman),
+            ("bob", CommitteeMemberPosition.UW));
+        var appraisalId = DecisionItemId(meeting);
+        Arrange(meeting, committee);
+
+        var act = () => BuildHandler().Handle(
+            new ReleaseMeetingItemCommand(meeting.Id, appraisalId), CancellationToken.None);
+
+        (await act.Should().ThrowAsync<ConflictException>())
+            .WithMessage("*quorum requires 3*");
+
+        meeting.DomainEvents.Should().NotContain(e => e is MeetingItemReleasedDomainEvent,
+            "no workflow resume must be triggered for a roster that cannot vote the round through");
+    }
+
+    [Fact]
+    public async Task Handle_RosterMissingRequiredRole_ThrowsConflict()
+    {
+        var committee = BuildCommittee(quorumValue: 2);
+        committee.AddCondition(ConditionType.RoleRequired, nameof(CommitteeMemberPosition.UW),
+            null, 1, "UW must approve");
+        var meeting = BuildMeetingWithRoster(committee,
+            ("alice", CommitteeMemberPosition.Chairman),
+            ("bob", CommitteeMemberPosition.Member));
+        var appraisalId = DecisionItemId(meeting);
+        Arrange(meeting, committee);
+
+        var act = () => BuildHandler().Handle(
+            new ReleaseMeetingItemCommand(meeting.Id, appraisalId), CancellationToken.None);
+
+        (await act.Should().ThrowAsync<ConflictException>())
+            .WithMessage("*required role UW*");
+    }
+
+    [Fact]
+    public async Task Handle_CompliantRoster_ReleasesAndRaisesTheEventWithTheRoster()
+    {
+        var committee = BuildCommittee(quorumValue: 2);
+        committee.AddCondition(ConditionType.RoleRequired, nameof(CommitteeMemberPosition.UW),
+            null, 1, "UW must approve");
+        var meeting = BuildMeetingWithRoster(committee,
+            ("alice", CommitteeMemberPosition.Chairman),
+            ("bob", CommitteeMemberPosition.UW));
+        var appraisalId = DecisionItemId(meeting);
+        Arrange(meeting, committee);
+
+        await BuildHandler().Handle(
+            new ReleaseMeetingItemCommand(meeting.Id, appraisalId), CancellationToken.None);
+
+        var evt = (MeetingItemReleasedDomainEvent)meeting.DomainEvents
+            .Single(e => e is MeetingItemReleasedDomainEvent);
+        evt.Members.Should().BeEquivalentTo(
+        [
+            new MeetingApprover("alice", nameof(CommitteeMemberPosition.Chairman)),
+            new MeetingApprover("bob", nameof(CommitteeMemberPosition.UW))
+        ]);
+    }
+
+    [Fact]
+    public async Task Handle_UnknownMeeting_ThrowsNotFound()
+    {
+        _meetingRepository.GetByIdForDecisionAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((Meeting?)null);
+
+        var act = () => BuildHandler().Handle(
+            new ReleaseMeetingItemCommand(Guid.NewGuid(), Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    // -- Helpers --
+
+    private void Arrange(Meeting meeting, Committee committee)
+    {
+        _meetingRepository.GetByIdForDecisionAsync(meeting.Id, Arg.Any<CancellationToken>())
+            .Returns(meeting);
+        _committeeRepository.GetByCodeAsync(MeetingCommittee.WithMeetingCode, Arg.Any<CancellationToken>())
+            .Returns(committee);
+    }
+
+    private static Committee BuildCommittee(int quorumValue)
+        => Committee.Create("Committee With Meeting", MeetingCommittee.WithMeetingCode, null,
+            QuorumType.Fixed, quorumValue, MajorityType.Unanimous, VotingMode.WaitForAll);
+
+    /// <summary>InvitationSent meeting (no StartAt, so the roster is still editable) with one Decision item.</summary>
+    private static Meeting BuildMeetingWithRoster(
+        Committee committee,
+        params (string UserId, CommitteeMemberPosition Position)[] roster)
+    {
+        foreach (var (userId, position) in roster)
+            committee.AddMember(userId, userId, position);
+
+        var meeting = Meeting.Create("Test Meeting", null, "1/2568", 1, 2568);
+        meeting.SnapshotCommittee(committee, meetingSeq: 1);
+        meeting.AddItem(Guid.NewGuid(), "APR-001", 50_000_000m, 50_000_000m,
+            Guid.NewGuid(), "pending-meeting", DateTime.UtcNow);
+        meeting.SendInvitation(DateTime.UtcNow.AddDays(-1));
+        meeting.ClearDomainEvents();
+
+        return meeting;
+    }
+
+    private static Guid DecisionItemId(Meeting meeting)
+        => meeting.Items.Single(i => i.Kind == MeetingItemKind.Decision).AppraisalId;
+}

--- a/Tests/Unit/Workflow.Tests/Workflow/Activities/ApprovalActivityMeetingRoleConditionTests.cs
+++ b/Tests/Unit/Workflow.Tests/Workflow/Activities/ApprovalActivityMeetingRoleConditionTests.cs
@@ -1,0 +1,193 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shared.Data.Outbox;
+using Shared.Time;
+using Workflow.Data;
+using Workflow.Data.Repository;
+using Workflow.Domain;
+using Workflow.Domain.Committees;
+using Workflow.Sla.Services;
+using Workflow.Workflow.Activities;
+using Workflow.Workflow.Activities.Approval;
+using Workflow.Workflow.Activities.Core;
+using Workflow.Workflow.Models;
+using Workflow.Workflow.Schema;
+using Xunit;
+
+namespace Workflow.Tests.Workflow.Activities;
+
+/// <summary>
+/// Pins WHERE the role behind a committee RoleRequired condition comes from.
+///
+/// It is NOT re-read from the committee configuration table when a vote is cast. The role is
+/// taken from the members snapshot the round started with — the meeting roster, for an appraisal
+/// that came through a meeting — written onto <see cref="ApprovalVote.MemberRole"/>, and the
+/// condition is then evaluated against those vote rows. So the UW who satisfies
+/// "a UW must approve" is the UW on that meeting, not the UW configured on the committee.
+/// </summary>
+public class ApprovalActivityMeetingRoleConditionTests
+{
+    private readonly IApprovalMemberResolver _memberResolver = Substitute.For<IApprovalMemberResolver>();
+    private readonly IApprovalVoteRepository _voteRepository = Substitute.For<IApprovalVoteRepository>();
+    private readonly IPublisher _publisher = Substitute.For<IPublisher>();
+    private readonly IIntegrationEventOutbox _outbox = Substitute.For<IIntegrationEventOutbox>();
+    private readonly ICommitteeRepository _committeeRepository = Substitute.For<ICommitteeRepository>();
+    private readonly WorkflowDbContext _dbContext = new(
+        new DbContextOptionsBuilder<WorkflowDbContext>()
+            .UseInMemoryDatabase($"approval-role-condition-{Guid.NewGuid()}")
+            .Options);
+    private readonly IDateTimeProvider _clock = Substitute.For<IDateTimeProvider>();
+
+    private const string ActivityId = "pending-approval";
+
+    /// <summary>
+    /// The roster of the meeting that released the appraisal. Deliberately NOT the committee's
+    /// configured membership — "meeting-uw" is the only member holding UW.
+    /// </summary>
+    private static readonly (string Voter, string Role)[] MeetingRoster =
+    [
+        ("meeting-chair", nameof(CommitteeMemberPosition.Chairman)),
+        ("meeting-member", nameof(CommitteeMemberPosition.Member)),
+        ("meeting-uw", nameof(CommitteeMemberPosition.UW))
+    ];
+
+    public ApprovalActivityMeetingRoleConditionTests()
+        => _clock.ApplicationNow.Returns(DateTime.UtcNow);
+
+    private ApprovalActivity BuildActivity() =>
+        new(_memberResolver, _voteRepository, _publisher, _outbox, _committeeRepository,
+            _dbContext, _clock, Substitute.For<ISlaCalculator>(),
+            Substitute.For<ILogger<ApprovalActivity>>());
+
+    [Fact]
+    public async Task Resume_QuorumAndMajorityMetButNoUwVote_DoesNotResolve()
+    {
+        // Two of three approve: quorum (2) and Simple majority (2 > 3/2) are both satisfied.
+        // Only the committee's RoleRequired UW condition is outstanding.
+        var result = await Resume(
+            currentVoter: "meeting-member",
+            votesThisRound: [("meeting-chair", "approve"), ("meeting-member", "approve")]);
+
+        result.Status.Should().Be(ActivityResultStatus.Pending);
+        result.OutputData.Should().NotContainKey("decision");
+    }
+
+    [Fact]
+    public async Task Resume_OnceTheMeetingsUwApproves_Resolves()
+    {
+        var result = await Resume(
+            currentVoter: "meeting-uw",
+            votesThisRound:
+            [
+                ("meeting-chair", "approve"),
+                ("meeting-member", "approve"),
+                ("meeting-uw", "approve")
+            ]);
+
+        result.Status.Should().Be(ActivityResultStatus.Completed);
+        result.OutputData["decision"].Should().Be("approve");
+    }
+
+    [Fact]
+    public async Task Resume_WritesTheMeetingPositionOntoTheVote()
+    {
+        // This is the value the condition is later matched on, and the value the approval-history
+        // and approval-status views display as the approver's role.
+        await Resume(
+            currentVoter: "meeting-uw",
+            votesThisRound: [("meeting-uw", "approve")]);
+
+        var written = _voteRepository.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(IApprovalVoteRepository.AddVoteAsync))
+            .Select(c => (ApprovalVote)c.GetArguments()[0]!)
+            .Single();
+
+        written.Member.Should().Be("meeting-uw");
+        written.MemberRole.Should().Be(nameof(CommitteeMemberPosition.UW));
+    }
+
+    [Fact]
+    public async Task Resume_VoterOutsideTheMeetingRoster_IsRejected()
+    {
+        // A committee member who was removed from this meeting can no longer vote on it.
+        var result = await Resume(
+            currentVoter: "committee-only-member",
+            votesThisRound: []);
+
+        result.Status.Should().Be(ActivityResultStatus.Failed);
+        result.ErrorMessage.Should().Contain("not a member of this approval group");
+    }
+
+    // -- Harness --
+
+    private async Task<ActivityResult> Resume(
+        string currentVoter,
+        (string Voter, string Vote)[] votesThisRound)
+    {
+        var normalizedId = ActivityId.Replace("-", "_").Replace(" ", "_").Replace(".", "_").ToLowerInvariant();
+        var appraisalId = Guid.NewGuid();
+
+        var instance = WorkflowInstance.Create(Guid.NewGuid(), "Test Workflow", null, "system");
+        instance.UpdateVariables(new Dictionary<string, object>
+        {
+            ["appraisalId"] = appraisalId,
+            // The snapshot ApprovalActivity took at Execute — the meeting roster, with each
+            // member's meeting position as their approval role.
+            [$"{normalizedId}_members"] = MeetingRoster
+                .Select(m => new ApprovalMemberInfo(m.Voter, m.Role))
+                .ToList(),
+            [$"{normalizedId}_quorum"] = new QuorumConfig("Fixed", 2),
+            [$"{normalizedId}_majority"] = new MajorityConfig("Simple", "approve"),
+            [$"{normalizedId}_votingMode"] = "Quorum",
+            // Straight from the committee configuration — the seeded COMMITTEE_WITH_MEETING rule.
+            [$"{normalizedId}_conditions"] = new List<ApprovalConditionInfo>
+            {
+                new(nameof(ConditionType.RoleRequired), nameof(CommitteeMemberPosition.UW), null)
+            },
+            [$"{normalizedId}_voteOptions"] = new List<string> { "approve", "reject", "route_back" },
+            [$"{normalizedId}_committeeCode"] = "COMMITTEE_WITH_MEETING",
+            [$"{normalizedId}_totalMembers"] = MeetingRoster.Length,
+            ["activityName"] = "PendingApproval"
+        });
+
+        var execution = WorkflowActivityExecution.Create(
+            instance.Id, ActivityId, "Approval Activity", ActivityTypes.ApprovalActivity);
+        execution.Start();
+        instance.AddActivityExecution(execution);
+
+        _voteRepository.HasMemberVotedAsync(execution.Id, currentVoter, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        // Vote rows carry the role the activity itself would have stamped — the roster position.
+        _voteRepository.GetVotesForExecutionAsync(execution.Id, Arg.Any<CancellationToken>())
+            .Returns(votesThisRound
+                .Select(v => ApprovalVote.Create(
+                    appraisalId, instance.Id, ActivityId, execution.Id,
+                    v.Voter, RoleOf(v.Voter), v.Vote, null))
+                .ToList());
+
+        var context = new ActivityContext
+        {
+            WorkflowInstanceId = instance.Id,
+            ActivityId = ActivityId,
+            ActivityName = "Committee Approval",
+            WorkflowInstance = instance,
+            Variables = new Dictionary<string, object>(instance.Variables),
+            Properties = new Dictionary<string, object>()
+        };
+
+        return await BuildActivity().ResumeAsync(context,
+            new Dictionary<string, object>
+            {
+                ["completedBy"] = currentVoter,
+                ["decisionTaken"] = "approve"
+            },
+            CancellationToken.None);
+    }
+
+    private static string? RoleOf(string voter) =>
+        MeetingRoster.FirstOrDefault(m => m.Voter == voter).Role;
+}

--- a/Tests/Unit/Workflow.Tests/Workflow/Activities/ApprovalActivityMemberOverrideTests.cs
+++ b/Tests/Unit/Workflow.Tests/Workflow/Activities/ApprovalActivityMemberOverrideTests.cs
@@ -1,0 +1,186 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shared.Data.Outbox;
+using Shared.Time;
+using Workflow.Data;
+using Workflow.Data.Repository;
+using Workflow.Domain.Committees;
+using Workflow.Sla.Services;
+using Workflow.Workflow.Activities;
+using Workflow.Workflow.Activities.Approval;
+using Workflow.Workflow.Activities.Core;
+using Workflow.Workflow.Events;
+using Workflow.Workflow.Models;
+using Workflow.Workflow.Schema;
+using Xunit;
+
+namespace Workflow.Tests.Workflow.Activities;
+
+/// <summary>
+/// When an appraisal reaches approval through a meeting, the members are the meeting's roster —
+/// not the committee's configured members — so per-meeting add/remove/position edits decide who
+/// votes. Quorum, majority and conditions still come from the committee.
+/// </summary>
+public class ApprovalActivityMemberOverrideTests
+{
+    private readonly IApprovalMemberResolver _memberResolver = Substitute.For<IApprovalMemberResolver>();
+    private readonly IApprovalVoteRepository _voteRepository = Substitute.For<IApprovalVoteRepository>();
+    private readonly IPublisher _publisher = Substitute.For<IPublisher>();
+    private readonly IIntegrationEventOutbox _outbox = Substitute.For<IIntegrationEventOutbox>();
+    private readonly ICommitteeRepository _committeeRepository = Substitute.For<ICommitteeRepository>();
+    private readonly WorkflowDbContext _dbContext = new(
+        new DbContextOptionsBuilder<WorkflowDbContext>()
+            .UseInMemoryDatabase($"approval-override-{Guid.NewGuid()}")
+            .Options);
+    private readonly IDateTimeProvider _clock = Substitute.For<IDateTimeProvider>();
+
+    private const string ActivityId = "pending-approval";
+
+    public ApprovalActivityMemberOverrideTests()
+    {
+        _clock.ApplicationNow.Returns(DateTime.UtcNow);
+
+        // The committee the workflow would otherwise approve with.
+        _memberResolver.ResolveMembersAsync(
+                Arg.Any<MemberSourceConfig>(), Arg.Any<Dictionary<string, object>>(),
+                Arg.Any<QuorumConfig?>(), Arg.Any<MajorityConfig?>(), Arg.Any<CancellationToken>())
+            .Returns(new ApprovalGroupInfo(
+                Members:
+                [
+                    new ApprovalMemberInfo("committee-1", nameof(CommitteeMemberPosition.Chairman)),
+                    new ApprovalMemberInfo("committee-2", nameof(CommitteeMemberPosition.Member))
+                ],
+                Quorum: new QuorumConfig("Fixed", 2),
+                Majority: new MajorityConfig("Unanimous", "approve"),
+                Conditions: [],
+                CommitteeName: "Committee With Meeting",
+                CommitteeCode: "COMMITTEE_WITH_MEETING"));
+    }
+
+    private ApprovalActivity BuildActivity() =>
+        new(_memberResolver, _voteRepository, _publisher, _outbox, _committeeRepository,
+            _dbContext, _clock, Substitute.For<ISlaCalculator>(),
+            Substitute.For<ILogger<ApprovalActivity>>());
+
+    [Fact]
+    public async Task Execute_WithMeetingRoster_AssignsTasksToTheRosterInsteadOfTheCommittee()
+    {
+        var context = BuildContext(WithOverride(
+            ("meeting-1", nameof(CommitteeMemberPosition.Chairman)),
+            ("meeting-2", nameof(CommitteeMemberPosition.UW)),
+            ("meeting-3", nameof(CommitteeMemberPosition.Member))));
+
+        await BuildActivity().ExecuteAsync(context, CancellationToken.None);
+
+        var assigned = CapturedAssignment();
+        assigned.Members.Select(m => m.Username).Should()
+            .BeEquivalentTo(["meeting-1", "meeting-2", "meeting-3"]);
+    }
+
+    [Fact]
+    public async Task Execute_WithMeetingRoster_SnapshotsMeetingPositionsAsApprovalRoles()
+    {
+        var context = BuildContext(WithOverride(
+            ("meeting-1", nameof(CommitteeMemberPosition.Chairman)),
+            ("meeting-2", nameof(CommitteeMemberPosition.UW))));
+
+        var result = await BuildActivity().ExecuteAsync(context, CancellationToken.None);
+
+        // The snapshot is what each vote's MemberRole is taken from, and what committee
+        // RoleRequired conditions are matched against.
+        var members = (List<ApprovalMemberInfo>)result.OutputData[$"{Normalized}_members"];
+        members.Should().BeEquivalentTo(
+        [
+            new ApprovalMemberInfo("meeting-1", nameof(CommitteeMemberPosition.Chairman)),
+            new ApprovalMemberInfo("meeting-2", nameof(CommitteeMemberPosition.UW))
+        ]);
+        result.OutputData[$"{Normalized}_totalMembers"].Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Execute_WithMeetingRoster_KeepsQuorumAndMajorityFromTheCommittee()
+    {
+        var context = BuildContext(WithOverride(
+            ("meeting-1", nameof(CommitteeMemberPosition.Chairman)),
+            ("meeting-2", nameof(CommitteeMemberPosition.UW))));
+
+        var result = await BuildActivity().ExecuteAsync(context, CancellationToken.None);
+
+        result.OutputData[$"{Normalized}_quorum"].Should().BeEquivalentTo(new QuorumConfig("Fixed", 2));
+        result.OutputData[$"{Normalized}_majority"].Should()
+            .BeEquivalentTo(new MajorityConfig("Unanimous", "approve"));
+    }
+
+    [Fact]
+    public async Task Execute_WithMeetingRoster_ClearsTheOverrideSoALaterNonMeetingRoundCannotInheritIt()
+    {
+        var context = BuildContext(WithOverride(("meeting-1", nameof(CommitteeMemberPosition.Chairman))));
+
+        var result = await BuildActivity().ExecuteAsync(context, CancellationToken.None);
+
+        // meetingMemberOverrides is a global variable: a route_back here can send the appraisal
+        // back for rework and return it to approval through a tier that has no meeting.
+        result.OutputData.Should().ContainKey("meetingMemberOverrides");
+        ((List<ApprovalActivity.MeetingMemberOverride>)result.OutputData["meetingMemberOverrides"])
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Execute_WithoutMeetingRoster_UsesTheCommitteeAndWritesNoOverride()
+    {
+        var context = BuildContext(new Dictionary<string, object>());
+
+        var result = await BuildActivity().ExecuteAsync(context, CancellationToken.None);
+
+        CapturedAssignment().Members.Select(m => m.Username).Should()
+            .BeEquivalentTo(["committee-1", "committee-2"]);
+        result.OutputData.Should().NotContainKey("meetingMemberOverrides");
+    }
+
+    // -- Helpers --
+
+    private static string Normalized =>
+        ActivityId.Replace("-", "_").Replace(" ", "_").Replace(".", "_").ToLowerInvariant();
+
+    private static Dictionary<string, object> WithOverride(
+        params (string UserId, string Role)[] roster) =>
+        new()
+        {
+            ["meetingMemberOverrides"] = roster
+                .Select(m => new ApprovalActivity.MeetingMemberOverride(m.UserId, m.Role))
+                .ToList()
+        };
+
+    private static ActivityContext BuildContext(Dictionary<string, object> variables)
+    {
+        var instance = WorkflowInstance.Create(Guid.NewGuid(), "Test Workflow", null, "system");
+        instance.UpdateVariables(new Dictionary<string, object>(variables)
+        {
+            ["appraisalId"] = Guid.NewGuid(),
+            ["appraisalValue"] = 50_000_000m
+        });
+
+        return new ActivityContext
+        {
+            WorkflowInstanceId = instance.Id,
+            ActivityId = ActivityId,
+            ActivityName = "Committee Approval",
+            WorkflowInstance = instance,
+            Variables = new Dictionary<string, object>(instance.Variables),
+            Properties = new Dictionary<string, object>
+            {
+                ["memberSource"] = new MemberSourceConfig("committee", null, "COMMITTEE_WITH_MEETING", null, null, null),
+                ["activityName"] = "PendingApproval"
+            }
+        };
+    }
+
+    private ApprovalTasksAssignedEvent CapturedAssignment() =>
+        _publisher.ReceivedCalls()
+            .Select(c => c.GetArguments()[0])
+            .OfType<ApprovalTasksAssignedEvent>()
+            .Single();
+}


### PR DESCRIPTION
## Summary

When an appraisal is released from a meeting, the meeting's roster now replaces the committee's configured members as the voting group in the approval activity. Per-meeting member edits (add/remove/position changes) now govern who votes and in what role, while quorum, majority, and approval conditions still come from the committee configuration.

## Key Changes

- **Meeting roster as approval members**: Added `MeetingMemberOverride` support to `ApprovalActivity` to use the meeting roster instead of committee members when present. Each member's meeting position becomes their approval role (used for `RoleRequired` conditions and recorded on votes).

- **Roster eligibility validation**: Introduced `MeetingRosterEligibility` class to validate that a meeting roster can satisfy the committee's quorum and approval conditions before release. The release endpoint now refuses to release items when the roster cannot carry the approval round (e.g., missing a required role or below fixed quorum).

- **Quorum rule extraction**: Created `QuorumRule` static class as a single source of truth for quorum calculations, used by both the approval engine and the meeting release gate to ensure consistency.

- **Event payload update**: Changed `MeetingItemReleasedDomainEvent` to carry `IReadOnlyList<MeetingApprover>` (user ID + role pairs) instead of just user IDs, enabling downstream activities to know each member's meeting position.

- **Comprehensive test coverage**: Added four new test classes:
  - `ApprovalActivityMeetingRoleConditionTests`: Verifies that `RoleRequired` conditions are evaluated against meeting positions, not committee configuration
  - `ApprovalActivityMemberOverrideTests`: Confirms meeting roster replaces committee members while preserving quorum/majority/conditions
  - `MeetingRosterEligibilityTests`: Tests all combinations of quorum types and approval conditions
  - `ReleaseMeetingItemGateTests`: Validates the release endpoint rejects ineligible rosters
  - `MeetingItemReleasedDomainEventHandlerTests`: Ensures the event handler correctly propagates roster data
  - `MeetingTests`: Updated existing tests to verify position data travels with member IDs

## Implementation Details

- Meeting position snapshots are taken at release time and persist through the approval round, ensuring conditions are evaluated against the roster that was actually present when the item was released, not against later committee configuration changes.
- The `meetingMemberOverrides` variable is cleared after the approval activity executes, preventing later non-meeting approval rounds from inheriting the override.
- Percentage-based quorum is always satisfiable by the roster itself (cannot exceed roster size), so only fixed quorum can make a roster ineligible at release time.

https://claude.ai/code/session_01YcKGCqiApDsjLatkterdwK