### PR TITLE
fix(workflow): stop approval rounds that can never resolve

### DIFF
--- a/Modules/Workflow/Workflow/Domain/Committees/Committee.cs
+++ b/Modules/Workflow/Workflow/Domain/Committees/Committee.cs
@@ -111,10 +111,31 @@ public class Committee : Aggregate<Guid>
         return threshold;
     }
 
+    /// <param name="roleRequired">
+    /// For <see cref="ConditionType.RoleRequired"/>, the <see cref="CommitteeMemberPosition"/> that
+    /// must cast an approving vote. It is matched — case-insensitively, as a plain string — against
+    /// the role stamped on each <c>ApprovalVote</c>, which is the voter's
+    /// <see cref="CommitteeMember.Position"/>. A value outside the enum therefore matches nothing:
+    /// the condition can never be satisfied, and the approval round sits Pending forever with no
+    /// error raised anywhere. Validated here rather than at the endpoint so every caller is covered.
+    /// </param>
     public CommitteeApprovalCondition AddCondition(
         ConditionType conditionType, string? roleRequired, int? minVotesRequired,
         int priority, string? description)
     {
+        // Name comparison, not Enum.TryParse: TryParse also accepts the numeric form ("3" -> UW),
+        // and roleRequired is persisted as the raw string, so "3" would pass validation and then
+        // match no vote's role at runtime — the exact failure this guard exists to prevent.
+        if (conditionType == ConditionType.RoleRequired
+            && !Enum.GetNames<CommitteeMemberPosition>()
+                .Contains(roleRequired, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                $"Invalid RoleRequired '{roleRequired}'. Allowed values: " +
+                $"{string.Join(", ", Enum.GetNames<CommitteeMemberPosition>())}",
+                nameof(roleRequired));
+        }
+
         var condition = CommitteeApprovalCondition.Create(
             Id, conditionType, roleRequired, minVotesRequired, priority, description);
         _conditions.Add(condition);

--- a/Modules/Workflow/Workflow/GlobalUsing.cs
+++ b/Modules/Workflow/Workflow/GlobalUsing.cs
@@ -34,6 +34,7 @@ global using Workflow.Data.Repository;
 global using Workflow.Services.Groups;
 global using Workflow.Services.Hashing;
 global using Workflow.Services.TaskMonitor;
+global using Workflow.Services.Users;
 global using Workflow.Tasks.Models;
 global using Workflow.Workflow.Resilience;
 

--- a/Modules/Workflow/Workflow/Meetings/Domain/MeetingRosterEligibility.cs
+++ b/Modules/Workflow/Workflow/Meetings/Domain/MeetingRosterEligibility.cs
@@ -16,12 +16,45 @@ public static class MeetingRosterEligibility
     /// <summary>
     /// Returns one message per unsatisfiable rule; empty means the roster can carry the round.
     /// </summary>
-    public static IReadOnlyList<string> Check(IReadOnlyList<MeetingMember> roster, Committee committee)
+    /// <param name="knownUsernames">
+    /// Usernames that resolve to a real user. When supplied, roster members outside this set are
+    /// reported as failures — they would be counted into the round's member total but could never
+    /// cast a vote. Pass null to skip the check (the domain has no way to resolve users itself).
+    /// </param>
+    public static IReadOnlyList<string> Check(
+        IReadOnlyList<MeetingMember> roster,
+        Committee committee,
+        IReadOnlySet<string>? knownUsernames = null)
     {
         ArgumentNullException.ThrowIfNull(roster);
         ArgumentNullException.ThrowIfNull(committee);
 
         var failures = new List<string>();
+
+        // Empty roster. Checked before quorum because a Percentage quorum of zero members is zero,
+        // so the quorum rule below would pass it. An empty roster is never releasable: it cannot be
+        // told apart from "no roster supplied" downstream — ApprovalActivity switches on
+        // `overrideMembers.Count > 0`, so an empty one silently falls back to the committee's own
+        // members, which is the exact substitution this whole path exists to prevent.
+        if (roster.Count == 0)
+        {
+            failures.Add("the meeting has no members");
+            return failures;
+        }
+
+        // Members who do not resolve to a real user. They still count toward the round's member
+        // total — and therefore raise the majority denominator (MajorityRule evaluates against ALL
+        // members, not votes cast) — while never being able to vote.
+        if (knownUsernames is not null)
+        {
+            var unresolved = roster
+                .Where(m => !knownUsernames.Contains(m.UserId))
+                .Select(m => m.UserId)
+                .ToList();
+
+            if (unresolved.Count > 0)
+                failures.Add($"no such user: {string.Join(", ", unresolved)}");
+        }
 
         // Quorum. The same rule the approval round applies, against the same member count it will
         // run with (the roster), so this check and that round can never disagree. Only a Fixed

--- a/Modules/Workflow/Workflow/Meetings/Features/ReleaseMeetingItem/ReleaseMeetingItemEndpoint.cs
+++ b/Modules/Workflow/Workflow/Meetings/Features/ReleaseMeetingItem/ReleaseMeetingItemEndpoint.cs
@@ -30,6 +30,7 @@ public record ReleaseMeetingItemCommand(Guid MeetingId, Guid AppraisalId)
 public class ReleaseMeetingItemCommandHandler(
     IMeetingRepository meetingRepository,
     ICommitteeRepository committeeRepository,
+    IUserDirectory userDirectory,
     ICurrentUserService currentUserService,
     IDateTimeProvider dateTimeProvider)
     : ICommandHandler<ReleaseMeetingItemCommand>
@@ -48,7 +49,12 @@ public class ReleaseMeetingItemCommandHandler(
         var committee = await committeeRepository.GetByCodeAsync(MeetingCommittee.WithMeetingCode, ct)
             ?? throw new NotFoundException($"Committee {MeetingCommittee.WithMeetingCode} not found");
 
-        var failures = MeetingRosterEligibility.Check(meeting.Members, committee);
+        // Resolved here rather than inside the domain check: the roster stores usernames, and only
+        // infrastructure can say which of them are real users.
+        var knownUsernames = await userDirectory.GetExistingAsync(
+            meeting.Members.Select(m => m.UserId), ct);
+
+        var failures = MeetingRosterEligibility.Check(meeting.Members, committee, knownUsernames);
         if (failures.Count > 0)
             throw new ConflictException(
                 $"Meeting roster cannot satisfy committee {committee.Code}: " +

--- a/Modules/Workflow/Workflow/Meetings/Features/UpdateMeetingMembers/UpdateMeetingMembersEndpoint.cs
+++ b/Modules/Workflow/Workflow/Meetings/Features/UpdateMeetingMembers/UpdateMeetingMembersEndpoint.cs
@@ -62,6 +62,7 @@ public record AddMeetingMemberCommand(Guid MeetingId, AddMeetingMemberRequest Re
 
 public class AddMeetingMemberCommandHandler(
     IMeetingRepository meetingRepository,
+    IUserDirectory userDirectory,
     IDateTimeProvider dateTimeProvider)
     : ICommandHandler<AddMeetingMemberCommand>
 {
@@ -69,6 +70,13 @@ public class AddMeetingMemberCommandHandler(
     {
         var meeting = await meetingRepository.GetByIdForDecisionAsync(command.MeetingId, ct)
             ?? throw new NotFoundException($"Meeting {command.MeetingId} not found");
+
+        // The roster is the approval round's voting group once the item is released, so a member
+        // who is not a real user would inflate the majority denominator while never being able to
+        // vote. Reject at the point of entry rather than at release.
+        if (!await userDirectory.ExistsAsync(command.Request.UserId, ct))
+            throw new BadRequestException(
+                $"No user '{command.Request.UserId}' exists; a meeting member must be an existing user");
 
         var member = MeetingMember.CreateManual(
             command.MeetingId,

--- a/Modules/Workflow/Workflow/Services/Users/UserDirectory.cs
+++ b/Modules/Workflow/Workflow/Services/Users/UserDirectory.cs
@@ -1,0 +1,60 @@
+using Dapper;
+using Shared.Data;
+
+namespace Workflow.Services.Users;
+
+/// <summary>
+/// Resolves whether a username actually exists in <c>auth.AspNetUsers</c>.
+///
+/// Committee and meeting members are stored as usernames (<c>CommitteeMember.UserId</c> /
+/// <c>MeetingMember.UserId</c>), and those usernames become the approval round's voters: they are
+/// counted into the majority denominator and fanned out as PendingTasks. A member who does not
+/// resolve to a real user can never vote, so the round's quorum/majority can become unreachable —
+/// the appraisal then sits in Committee Approval with no error. Callers that accept a username
+/// from the client check it here first.
+/// </summary>
+public interface IUserDirectory
+{
+    Task<bool> ExistsAsync(string username, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the subset of <paramref name="usernames"/> that exist, compared case-insensitively
+    /// (matching how member usernames are compared everywhere else in the approval path).
+    /// </summary>
+    Task<IReadOnlySet<string>> GetExistingAsync(IEnumerable<string> usernames, CancellationToken ct = default);
+}
+
+public class UserDirectory(ISqlConnectionFactory connectionFactory) : IUserDirectory
+{
+    public async Task<bool> ExistsAsync(string username, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(username)) return false;
+
+        var existing = await GetExistingAsync([username], ct);
+        return existing.Count > 0;
+    }
+
+    public async Task<IReadOnlySet<string>> GetExistingAsync(
+        IEnumerable<string> usernames, CancellationToken ct = default)
+    {
+        var candidates = usernames
+            .Where(u => !string.IsNullOrWhiteSpace(u))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (candidates.Count == 0)
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        const string sql = """
+                           SELECT UserName
+                           FROM auth.AspNetUsers
+                           WHERE UserName IN @Usernames
+                           """;
+
+        var connection = connectionFactory.GetOpenConnection();
+        var found = await connection.QueryAsync<string>(
+            new CommandDefinition(sql, new { Usernames = candidates }, cancellationToken: ct));
+
+        return found.ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/Modules/Workflow/Workflow/Workflow/Activities/ApprovalActivity.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/ApprovalActivity.cs
@@ -90,6 +90,17 @@ public class ApprovalActivity : WorkflowActivityBase
                         "ApprovalActivity {ActivityId}: override member count ({OverrideCount}) is below required quorum ({Quorum}); approval may never reach quorum",
                         context.ActivityId, overrideMembers.Count, requiredQuorum);
             }
+            else if (context.Variables.ContainsKey("meetingMemberOverrides"))
+            {
+                // The variable exists but carries no members, so the ternary above silently fell
+                // back to the committee's own members — the substitution this path exists to
+                // prevent. MeetingRosterEligibility refuses to release an empty roster, so reaching
+                // here means either that gate was bypassed or the roster was emptied after release.
+                _logger.LogWarning(
+                    "ApprovalActivity {ActivityId}: meetingMemberOverrides was present but empty; " +
+                    "falling back to committee {CommitteeCode} members instead of the meeting roster",
+                    context.ActivityId, groupInfo.CommitteeCode ?? "inline");
+            }
 
             var activityName = GetProperty(context, "activityName", context.ActivityId);
             var voteOptions = GetProperty<List<string>>(context, "voteOptions",

--- a/Modules/Workflow/Workflow/Workflow/Features/Committees/AddCommitteeMember/AddCommitteeMemberEndpoint.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/Committees/AddCommitteeMember/AddCommitteeMemberEndpoint.cs
@@ -43,7 +43,8 @@ public record AddCommitteeMemberResponse(
     bool IsActive);
 
 public class AddCommitteeMemberCommandHandler(
-    ICommitteeRepository committeeRepository)
+    ICommitteeRepository committeeRepository,
+    IUserDirectory userDirectory)
     : ICommandHandler<AddCommitteeMemberCommand, AddCommitteeMemberResponse>
 {
     public async Task<AddCommitteeMemberResponse> Handle(AddCommitteeMemberCommand command, CancellationToken ct)
@@ -56,6 +57,12 @@ public class AddCommitteeMemberCommandHandler(
         if (!Enum.TryParse<CommitteeMemberPosition>(req.Role, ignoreCase: true, out var position))
             throw new ArgumentException(
                 $"Invalid Role '{req.Role}'. Allowed values: {string.Join(", ", Enum.GetNames<CommitteeMemberPosition>())}");
+
+        // UserId is a username and becomes an approval voter — counted into the round's member
+        // total whether or not anyone can actually sign in as it. Validated alongside Role.
+        if (!await userDirectory.ExistsAsync(req.UserId, ct))
+            throw new BadRequestException(
+                $"No user '{req.UserId}' exists; a committee member must be an existing user");
 
         var attendance = string.IsNullOrWhiteSpace(req.Attendance)
             ? CommitteeAttendance.Always

--- a/Modules/Workflow/Workflow/Workflow/Features/Committees/CreateCommittee/CreateCommitteeEndpoint.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/Committees/CreateCommittee/CreateCommitteeEndpoint.cs
@@ -43,7 +43,8 @@ public record CreateCommitteeCommand(CreateCommitteeRequest Request) : ICommand<
 public record CreateCommitteeResponse(Guid Id, string Name, string Code);
 
 public class CreateCommitteeCommandHandler(
-    ICommitteeRepository committeeRepository
+    ICommitteeRepository committeeRepository,
+    IUserDirectory userDirectory
 ) : ICommandHandler<CreateCommitteeCommand, CreateCommitteeResponse>
 {
     public async Task<CreateCommitteeResponse> Handle(CreateCommitteeCommand command, CancellationToken ct)
@@ -68,6 +69,13 @@ public class CreateCommitteeCommandHandler(
 
         if (req.Members is not null)
         {
+            // Members are usernames and become approval voters — see AddCommitteeMember.
+            var known = await userDirectory.GetExistingAsync(req.Members.Select(m => m.UserId), ct);
+            var unknown = req.Members.Select(m => m.UserId).Where(u => !known.Contains(u)).ToList();
+            if (unknown.Count > 0)
+                throw new BadRequestException(
+                    $"No such user(s): {string.Join(", ", unknown)}. Committee members must be existing users");
+
             foreach (var m in req.Members)
             {
                 var position = Enum.Parse<CommitteeMemberPosition>(m.Role, ignoreCase: true);

--- a/Modules/Workflow/Workflow/WorkflowModule.cs
+++ b/Modules/Workflow/Workflow/WorkflowModule.cs
@@ -166,6 +166,7 @@ public static class WorkflowModule
         services.AddScoped<IApprovalMemberResolver, ApprovalMemberResolver>();
         services.AddScoped<IApprovalVoteRepository, ApprovalVoteRepository>();
         services.AddScoped<ICommitteeRepository, CommitteeRepository>();
+        services.AddScoped<IUserDirectory, UserDirectory>();
 
         // Company routing
         services.AddScoped<ICompanyRoundRobinService, CompanyRoundRobinService>();

--- a/Tests/Unit/Workflow.Tests/Domain/CommitteeAddConditionTests.cs
+++ b/Tests/Unit/Workflow.Tests/Domain/CommitteeAddConditionTests.cs
@@ -1,0 +1,91 @@
+using FluentAssertions;
+using Workflow.Domain.Committees;
+using Xunit;
+
+namespace Workflow.Tests.Domain;
+
+/// <summary>
+/// A RoleRequired condition is satisfied by a plain case-insensitive string comparison against the
+/// role stamped on each vote (ApprovalActivity.CheckApprovalConditions), and that role is a
+/// CommitteeMemberPosition name. A RoleRequired value outside the enum therefore matches no vote
+/// ever cast: the round's conditionsMet stays false, it never resolves, and nothing surfaces an
+/// error. These tests pin the guard that stops such a value being stored in the first place.
+/// </summary>
+public class CommitteeAddConditionTests
+{
+    [Theory]
+    [InlineData("UW")]
+    [InlineData("uw")]
+    [InlineData("Chairman")]
+    [InlineData("Member")]
+    public void AddCondition_RoleRequired_AcceptsAPositionName(string role)
+    {
+        var committee = BuildCommittee();
+
+        var condition = committee.AddCondition(
+            ConditionType.RoleRequired, role, minVotesRequired: null, priority: 1, description: null);
+
+        condition.RoleRequired.Should().Be(role);
+        committee.Conditions.Should().ContainSingle();
+    }
+
+    [Theory]
+    [InlineData("COMMITTEE")]          // a committee CODE, not a position — the original bug
+    [InlineData("COMMITTEE_WITH_MEETING")]
+    [InlineData("Underwriter")]        // plausible synonym for UW
+    [InlineData("")]
+    [InlineData(null)]
+    public void AddCondition_RoleRequired_RejectsAnythingThatIsNotAPositionName(string? role)
+    {
+        var committee = BuildCommittee();
+
+        var act = () => committee.AddCondition(
+            ConditionType.RoleRequired, role, minVotesRequired: null, priority: 1, description: null);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Allowed values*");
+        committee.Conditions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddCondition_RoleRequired_RejectsTheNumericFormOfAPosition()
+    {
+        // Enum.TryParse would accept "3" and map it to UW, but RoleRequired is persisted as the raw
+        // string — so "3" would be stored and then match no vote's role at runtime.
+        var committee = BuildCommittee();
+
+        var act = () => committee.AddCondition(
+            ConditionType.RoleRequired, "3", minVotesRequired: null, priority: 1, description: null);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AddCondition_MinVotes_IsUnaffectedByTheRoleGuard()
+    {
+        var committee = BuildCommittee();
+
+        var condition = committee.AddCondition(
+            ConditionType.MinVotes, roleRequired: null, minVotesRequired: 3, priority: 1, description: null);
+
+        condition.MinVotesRequired.Should().Be(3);
+    }
+
+    [Fact]
+    public void AddCondition_RoleRequired_AcceptsEveryDefinedPosition()
+    {
+        // The guard must not drift from the enum the vote role is produced from.
+        foreach (var name in Enum.GetNames<CommitteeMemberPosition>())
+        {
+            var committee = BuildCommittee();
+            var act = () => committee.AddCondition(
+                ConditionType.RoleRequired, name, null, 1, null);
+
+            act.Should().NotThrow($"{name} is a valid CommitteeMemberPosition");
+        }
+    }
+
+    private static Committee BuildCommittee()
+        => Committee.Create("Committee", "COMMITTEE", null,
+            QuorumType.Fixed, 3, MajorityType.Simple, VotingMode.WaitForAll);
+}

--- a/Tests/Unit/Workflow.Tests/Meetings/MeetingRosterEligibilityTests.cs
+++ b/Tests/Unit/Workflow.Tests/Meetings/MeetingRosterEligibilityTests.cs
@@ -132,17 +132,93 @@ public class MeetingRosterEligibilityTests
     }
 
     [Fact]
-    public void Check_EmptyRoster_FailsQuorum()
+    public void Check_EmptyRoster_Fails()
     {
         var committee = BuildCommittee(QuorumType.Fixed, 1);
 
         var failures = MeetingRosterEligibility.Check([], committee);
 
         failures.Should().ContainSingle()
-            .Which.Should().Be("0 member(s) but quorum requires 1");
+            .Which.Should().Be("the meeting has no members");
+    }
+
+    [Fact]
+    public void Check_EmptyRoster_FailsEvenWhenQuorumWouldAcceptIt()
+    {
+        // The case a quorum check alone cannot catch: a Percentage of zero members is zero, so
+        // `roster.Count < requiredQuorum` is 0 < 0 = false. Released with an empty roster,
+        // ApprovalActivity's `overrideMembers.Count > 0` switch reads it as "no override" and
+        // silently runs the round with the COMMITTEE's members instead.
+        var committee = BuildCommittee(QuorumType.Percentage, 100);
+
+        var failures = MeetingRosterEligibility.Check([], committee);
+
+        failures.Should().ContainSingle()
+            .Which.Should().Be("the meeting has no members");
+    }
+
+    [Fact]
+    public void Check_MemberWithNoMatchingUser_Fails()
+    {
+        var committee = BuildCommittee(QuorumType.Fixed, 2);
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("alice", CommitteeMemberPosition.Chairman),
+                   ("ghost", CommitteeMemberPosition.UW)),
+            committee,
+            knownUsernames: Known("alice"));
+
+        failures.Should().ContainSingle()
+            .Which.Should().Be("no such user: ghost");
+    }
+
+    [Fact]
+    public void Check_UnresolvedMembers_AreReportedTogether()
+    {
+        var committee = BuildCommittee(QuorumType.Fixed, 1);
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("alice", CommitteeMemberPosition.Chairman),
+                   ("ghost", CommitteeMemberPosition.UW),
+                   ("phantom", CommitteeMemberPosition.Member)),
+            committee,
+            knownUsernames: Known("alice"));
+
+        failures.Should().ContainSingle()
+            .Which.Should().Be("no such user: ghost, phantom");
+    }
+
+    [Fact]
+    public void Check_KnownUsernamesMatchCaseInsensitively()
+    {
+        // Member usernames are compared case-insensitively everywhere else in the approval path
+        // (ApprovalActivity's voter lookup, RoleRequired matching), so this must agree.
+        var committee = BuildCommittee(QuorumType.Fixed, 1);
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("Alice", CommitteeMemberPosition.Chairman)),
+            committee,
+            knownUsernames: Known("alice"));
+
+        failures.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Check_WithoutKnownUsernames_SkipsTheUserCheck()
+    {
+        // The domain cannot resolve users itself; callers that do not supply the set opt out.
+        var committee = BuildCommittee(QuorumType.Fixed, 1);
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("ghost", CommitteeMemberPosition.Chairman)), committee);
+
+        failures.Should().BeEmpty();
     }
 
     // -- Helpers --
+
+    private static IReadOnlySet<string> Known(params string[] usernames)
+        => usernames.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
     private static Committee BuildCommittee(QuorumType quorumType, int quorumValue)
         => Committee.Create("Committee With Meeting", MeetingCommittee.WithMeetingCode, null,

--- a/Tests/Unit/Workflow.Tests/Meetings/ReleaseMeetingItemGateTests.cs
+++ b/Tests/Unit/Workflow.Tests/Meetings/ReleaseMeetingItemGateTests.cs
@@ -7,6 +7,7 @@ using Workflow.Domain.Committees;
 using Workflow.Meetings.Domain;
 using Workflow.Meetings.Domain.Events;
 using Workflow.Meetings.Features.ReleaseMeetingItem;
+using Workflow.Services.Users;
 using Xunit;
 
 namespace Workflow.Tests.Meetings;
@@ -20,6 +21,7 @@ public class ReleaseMeetingItemGateTests
 {
     private readonly IMeetingRepository _meetingRepository = Substitute.For<IMeetingRepository>();
     private readonly ICommitteeRepository _committeeRepository = Substitute.For<ICommitteeRepository>();
+    private readonly IUserDirectory _userDirectory = Substitute.For<IUserDirectory>();
     private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
     private readonly IDateTimeProvider _clock = Substitute.For<IDateTimeProvider>();
 
@@ -27,10 +29,17 @@ public class ReleaseMeetingItemGateTests
     {
         _currentUser.Username.Returns("secretary");
         _clock.ApplicationNow.Returns(DateTime.UtcNow);
+
+        // Default: every username asked about resolves to a real user, so these tests exercise the
+        // quorum/condition rules in isolation. Overridden by the unresolved-member test below.
+        _userDirectory
+            .GetExistingAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult<IReadOnlySet<string>>(
+                ci.Arg<IEnumerable<string>>().ToHashSet(StringComparer.OrdinalIgnoreCase)));
     }
 
     private ReleaseMeetingItemCommandHandler BuildHandler() =>
-        new(_meetingRepository, _committeeRepository, _currentUser, _clock);
+        new(_meetingRepository, _committeeRepository, _userDirectory, _currentUser, _clock);
 
     [Fact]
     public async Task Handle_RosterBelowFixedQuorum_ThrowsConflictAndDoesNotRelease()
@@ -93,6 +102,32 @@ public class ReleaseMeetingItemGateTests
             new MeetingApprover("alice", nameof(CommitteeMemberPosition.Chairman)),
             new MeetingApprover("bob", nameof(CommitteeMemberPosition.UW))
         ]);
+    }
+
+    [Fact]
+    public async Task Handle_RosterMemberIsNotARealUser_ThrowsConflictAndDoesNotRelease()
+    {
+        // A member who cannot sign in still counts toward the round's member total, so it raises
+        // the majority denominator while never being able to vote.
+        var committee = BuildCommittee(quorumValue: 2);
+        var meeting = BuildMeetingWithRoster(committee,
+            ("alice", CommitteeMemberPosition.Chairman),
+            ("ghost", CommitteeMemberPosition.UW));
+        var appraisalId = DecisionItemId(meeting);
+        Arrange(meeting, committee);
+
+        _userDirectory
+            .GetExistingAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlySet<string>>(
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "alice" }));
+
+        var act = () => BuildHandler().Handle(
+            new ReleaseMeetingItemCommand(meeting.Id, appraisalId), CancellationToken.None);
+
+        (await act.Should().ThrowAsync<ConflictException>())
+            .WithMessage("*no such user: ghost*");
+
+        meeting.DomainEvents.Should().NotContain(e => e is MeetingItemReleasedDomainEvent);
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #349. Three ways a committee approval round could open and then sit `Pending` forever with no error surfaced anywhere.

## 1. `RoleRequired` was written unvalidated

`CreateCommitteeEndpoint` parsed `ConditionType` through `Enum.Parse` but passed `RoleRequired` straight through as a free string — while member roles nineteen lines earlier *were* parsed. A committee code (`"COMMITTEE"`) or a plausible synonym (`"Underwriter"`) persisted silently.

It is matched as a plain case-insensitive string against `ApprovalVote.MemberRole`, which is a `CommitteeMemberPosition` name — so an out-of-enum value matches no vote ever cast, `conditionsMet` never goes true, and the round never resolves.

Validated in `Committee.AddCondition` rather than at the endpoint, so the seed and any future caller are covered. Name comparison rather than `Enum.TryParse`, because `TryParse` also accepts the numeric form (`"3"` → `UW`) and the value is persisted raw — `"3"` would pass validation and then match nothing.

Tiers 1 and 2 never reach a meeting, so #349's release gate did not protect them at all.

## 2. Members were not verified to be real users

`MeetingMember.CreateManual` and `Committee.AddMember` both take `UserId` as free-form client input. Since #349 the meeting roster *is* the voting group, so that string now becomes an approval member: counted into `totalMembers` — the majority denominator, since `MajorityRule` evaluates against all members rather than votes cast — and fanned out a `PendingTask` nobody can action.

A two-person roster with one unreachable member can never satisfy Simple majority: `approveCount > 2/2.0` needs 2 approvals from 1 reachable person.

Checked on the way in (`AddMeetingMember`, `AddCommitteeMember`, `CreateCommittee`), with the release gate re-checking the whole roster so rows predating this change cannot strand a round either.

**Behaviour change worth knowing:** if UAT already holds a committee or meeting member whose username does not resolve, release will now 409 until the roster is fixed. That is deliberate — a refusal at release beats a round that hangs silently — but it may surface existing bad data.

## 3. An empty roster silently fell back to the committee

`ApprovalActivity` switches on `overrideMembers.Count > 0`, so an empty roster is indistinguishable from *no* roster and the round quietly ran with the committee's own members — the exact substitution the meeting-roster path exists to prevent, with no signal anywhere.

`MeetingRosterEligibility` now refuses an empty roster outright. A quorum check alone cannot catch this: `QuorumRule.Required(Percentage, v, 0)` is `ceil(0 * v/100)` = 0, so `0 < 0` passed. `ApprovalActivity` also warns if it ever sees the variable present but empty.

## Not addressed

The release gate resolves its committee by the `COMMITTEE_WITH_MEETING` constant while `ApprovalMemberResolver` resolves by threshold on `appraisalValue`. They agree only because `approval-tier-switch` routes `> 30000000` to `pending-meeting`. Structurally decoupled but not currently reachable — left alone deliberately.

## Verification

`dotnet build` clean across all 39 projects. `Workflow.Tests`: 940 passed, 31 of them in the new/changed classes (`CommitteeAddConditionTests`, `MeetingRosterEligibilityTests`, `ReleaseMeetingItemGateTests`).

The 8 remaining failures are a pre-existing local-environment baseline — byte-identical on `main`, on #349's branch, and here — and CI's own test step passes on `main`.

One existing test changed meaning rather than being added to: `Check_EmptyRoster_FailsQuorum` asserted the empty roster produced a quorum message; it is now `Check_EmptyRoster_Fails` and asserts the new refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183ybF4aVjz8VuHyQQJ58ko