### PR TITLE
feat(workflow): approve a committee round on a fixed number of approvals

### DIFF
--- a/Modules/Workflow/Workflow/Data/Configurations/CommitteeConfiguration.cs
+++ b/Modules/Workflow/Workflow/Data/Configurations/CommitteeConfiguration.cs
@@ -15,6 +15,8 @@ public class CommitteeConfiguration : IEntityTypeConfiguration<Committee>
         builder.Property(c => c.Description).HasMaxLength(500);
         builder.Property(c => c.QuorumType).HasConversion<string>().HasMaxLength(20);
         builder.Property(c => c.MajorityType).HasConversion<string>().HasMaxLength(20);
+        // 0 for the proportional majority types, which ignore it; only FixedCount reads it.
+        builder.Property(c => c.MajorityValue).HasDefaultValue(0);
         builder.Property(c => c.VotingMode).HasConversion<string>().HasMaxLength(20)
             .HasDefaultValue(VotingMode.WaitForAll);
 

--- a/Modules/Workflow/Workflow/Domain/Committees/Committee.cs
+++ b/Modules/Workflow/Workflow/Domain/Committees/Committee.cs
@@ -11,6 +11,13 @@ public class Committee : Aggregate<Guid>
     public MajorityType MajorityType { get; private set; }
 
     /// <summary>
+    /// The approval count that resolves the round when <see cref="MajorityType"/> is
+    /// <see cref="MajorityType.FixedCount"/> — e.g. 3, meaning three approvals are enough
+    /// regardless of how many members the committee has. Unused (0) for the proportional types.
+    /// </summary>
+    public int MajorityValue { get; private set; }
+
+    /// <summary>
     /// Controls when the approval round resolves:
     ///   <see cref="VotingMode.WaitForAll"/> — every member must vote before the approve rule is
     ///   evaluated (consensus); quorum is ignored.
@@ -37,9 +44,13 @@ public class Committee : Aggregate<Guid>
         QuorumType quorumType,
         int quorumValue,
         MajorityType majorityType,
-        VotingMode votingMode = VotingMode.WaitForAll)
+        VotingMode votingMode = VotingMode.WaitForAll,
+        int majorityValue = 0)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(quorumValue, 0, nameof(quorumValue));
+        // No members exist yet at creation, so only the lower bound is checkable here; Update and
+        // the round-start guard in ApprovalActivity cover "more approvals than there are members".
+        RequirePositiveWhenFixedCount(majorityType, majorityValue);
 
         var committee = new Committee
         {
@@ -51,22 +62,44 @@ public class Committee : Aggregate<Guid>
             QuorumType = quorumType,
             QuorumValue = quorumValue,
             MajorityType = majorityType,
+            MajorityValue = majorityValue,
             VotingMode = votingMode
         };
         return committee;
     }
 
     public void Update(string name, string? description, QuorumType quorumType, int quorumValue,
-        MajorityType majorityType, bool isActive, VotingMode votingMode = VotingMode.WaitForAll)
+        MajorityType majorityType, bool isActive, VotingMode votingMode = VotingMode.WaitForAll,
+        int majorityValue = 0)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        RequirePositiveWhenFixedCount(majorityType, majorityValue);
+
+        // Members are known by now, so a threshold nobody could ever reach is rejected outright —
+        // it would otherwise open a round that can never resolve and stalls with no error.
+        var activeMembers = GetActiveMembers().Count;
+        if (majorityType == MajorityType.FixedCount && activeMembers > 0 && majorityValue > activeMembers)
+            throw new ArgumentException(
+                $"MajorityValue {majorityValue} exceeds the committee's {activeMembers} active member(s); " +
+                "the approval round could never reach it",
+                nameof(majorityValue));
+
         Name = name;
         Description = description;
         QuorumType = quorumType;
         QuorumValue = quorumValue;
         MajorityType = majorityType;
+        MajorityValue = majorityValue;
         IsActive = isActive;
         VotingMode = votingMode;
+    }
+
+    private static void RequirePositiveWhenFixedCount(MajorityType majorityType, int majorityValue)
+    {
+        if (majorityType == MajorityType.FixedCount && majorityValue <= 0)
+            throw new ArgumentException(
+                $"MajorityType {nameof(MajorityType.FixedCount)} requires a MajorityValue greater than 0",
+                nameof(majorityValue));
     }
 
     public CommitteeMember AddMember(string userId, string memberName, CommitteeMemberPosition position,
@@ -182,7 +215,7 @@ public class Committee : Aggregate<Guid>
     /// the domain share one implementation.
     /// </summary>
     public bool HasMajority(int targetVoteCount, int totalVotes, int totalMembers)
-        => MajorityRule.IsMet(MajorityType, targetVoteCount, totalMembers);
+        => MajorityRule.IsMet(MajorityType, targetVoteCount, totalMembers, MajorityValue);
 }
 
 public enum QuorumType
@@ -193,9 +226,21 @@ public enum QuorumType
 
 public enum MajorityType
 {
+    /// <summary>More than half of ALL members approve.</summary>
     Simple,
+
+    /// <summary>At least two-thirds of ALL members approve.</summary>
     TwoThirds,
-    Unanimous
+
+    /// <summary>Every member approves.</summary>
+    Unanimous,
+
+    /// <summary>
+    /// An absolute number of approvals — <see cref="Committee.MajorityValue"/> — regardless of
+    /// member count. Note this replaces the majority bar only; whether the round resolves on the
+    /// Nth approval or after everyone has voted is still governed by <see cref="VotingMode"/>.
+    /// </summary>
+    FixedCount
 }
 
 public enum VotingMode

--- a/Modules/Workflow/Workflow/Domain/Committees/MajorityRule.cs
+++ b/Modules/Workflow/Workflow/Domain/Committees/MajorityRule.cs
@@ -1,20 +1,29 @@
 namespace Workflow.Domain.Committees;
 
 /// <summary>
-/// Single source of truth for the committee majority rule. The approve count is always evaluated
-/// against the FULL committee (<paramref name="totalMembers"/>), not the votes cast — so "Simple"
-/// means a majority of all members and "TwoThirds" two-thirds of all members.
+/// Single source of truth for the committee majority rule. The proportional types evaluate the
+/// approve count against the FULL committee (<paramref name="totalMembers"/>), not the votes cast
+/// — so "Simple" means a majority of all members and "TwoThirds" two-thirds of all members.
 /// Used by both <see cref="Committee.HasMajority"/> (domain) and the approval engine
-/// (<c>ApprovalActivity.CheckMajority</c>) so the two cannot drift.
+/// (<c>ApprovalActivity.CheckMajority</c>, <c>ApprovalListProjection.CheckMajority</c>) so they
+/// cannot drift.
 /// </summary>
 public static class MajorityRule
 {
-    public static bool IsMet(MajorityType type, int approveCount, int totalMembers) =>
+    /// <param name="value">
+    /// Only read for <see cref="MajorityType.FixedCount"/>: the absolute number of approvals that
+    /// resolves the round, independent of how many members there are. Ignored by the proportional
+    /// types, which is why it is optional — existing call sites keep compiling unchanged.
+    /// </param>
+    public static bool IsMet(MajorityType type, int approveCount, int totalMembers, int value = 0) =>
         type switch
         {
             MajorityType.Simple => approveCount > totalMembers / 2.0,
             MajorityType.TwoThirds => approveCount >= Math.Ceiling(totalMembers * 2.0 / 3.0),
             MajorityType.Unanimous => approveCount == totalMembers,
+            // A non-positive threshold would make every round approve on zero votes, so it is
+            // treated as unmet rather than trusted. Committee.Create/Update reject it up front.
+            MajorityType.FixedCount => value > 0 && approveCount >= value,
             _ => false
         };
 }

--- a/Modules/Workflow/Workflow/Infrastructure/Migrations/20260802142111_AddCommitteeMajorityValue.Designer.cs
+++ b/Modules/Workflow/Workflow/Infrastructure/Migrations/20260802142111_AddCommitteeMajorityValue.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Workflow.Data;
 
@@ -11,9 +12,11 @@ using Workflow.Data;
 namespace Workflow.Infrastructure.Migrations
 {
     [DbContext(typeof(WorkflowDbContext))]
-    partial class WorkflowDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260802142111_AddCommitteeMajorityValue")]
+    partial class AddCommitteeMajorityValue
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modules/Workflow/Workflow/Infrastructure/Migrations/20260802142111_AddCommitteeMajorityValue.cs
+++ b/Modules/Workflow/Workflow/Infrastructure/Migrations/20260802142111_AddCommitteeMajorityValue.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Workflow.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommitteeMajorityValue : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MajorityValue",
+                schema: "workflow",
+                table: "Committees",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MajorityValue",
+                schema: "workflow",
+                table: "Committees");
+        }
+    }
+}

--- a/Modules/Workflow/Workflow/Meetings/Domain/MeetingRosterEligibility.cs
+++ b/Modules/Workflow/Workflow/Meetings/Domain/MeetingRosterEligibility.cs
@@ -63,6 +63,12 @@ public static class MeetingRosterEligibility
         if (roster.Count < requiredQuorum)
             failures.Add($"{roster.Count} member(s) but quorum requires {requiredQuorum}");
 
+        // Majority. Only FixedCount can be unreachable — the proportional types are taken of the
+        // roster itself and so are satisfiable by construction, exactly like a Percentage quorum.
+        if (committee.MajorityType == MajorityType.FixedCount && committee.MajorityValue > roster.Count)
+            failures.Add(
+                $"{committee.MajorityValue} approve vote(s) required but the roster has only {roster.Count} member(s)");
+
         foreach (var condition in committee.Conditions.Where(c => c.IsActive).OrderBy(c => c.Priority))
         {
             switch (condition.ConditionType)

--- a/Modules/Workflow/Workflow/Workflow/Activities/Approval/ApprovalMemberResolver.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/Approval/ApprovalMemberResolver.cs
@@ -40,10 +40,40 @@ public class ApprovalMemberResolver(
         return new ApprovalGroupInfo(
             members,
             quorum ?? new QuorumConfig("Fixed", members.Count),
-            majority ?? new MajorityConfig("Simple", "approve"),
+            NormalizeInlineMajority(majority),
             new List<ApprovalConditionInfo>(),
             null,
             null);
+    }
+
+    /// <summary>
+    /// The Workflow Builder writes <c>majority: { type: 'count' | 'percent', value: N }</c>, a
+    /// different vocabulary from <see cref="MajorityType"/>. Unmapped, <c>'count'</c> fails
+    /// <c>Enum.TryParse</c> in CheckMajority, which returns false — so the round could never
+    /// approve, silently. Map what we can and reject the rest loudly at Execute instead.
+    /// </summary>
+    private static MajorityConfig NormalizeInlineMajority(MajorityConfig? majority)
+    {
+        if (majority is null)
+            return new MajorityConfig("Simple", "approve");
+
+        if (Enum.GetNames<MajorityType>().Contains(majority.Type, StringComparer.OrdinalIgnoreCase))
+            return majority;
+
+        if (string.Equals(majority.Type, "count", StringComparison.OrdinalIgnoreCase))
+        {
+            if (majority.Value <= 0)
+                throw new InvalidOperationException(
+                    "Inline majority type 'count' requires a value greater than 0");
+
+            return majority with { Type = nameof(MajorityType.FixedCount) };
+        }
+
+        // 'percent' has no backend equivalent — Simple/TwoThirds are hardcoded fractions, there is
+        // no general percentage rule. Fail here rather than approve-never at vote time.
+        throw new InvalidOperationException(
+            $"Unsupported inline majority type '{majority.Type}'. Supported: " +
+            $"{string.Join(", ", Enum.GetNames<MajorityType>())}, count");
     }
 
     private async Task<ApprovalGroupInfo> ResolveFromCommittee(MemberSourceConfig config, CancellationToken ct)
@@ -160,7 +190,8 @@ public class ApprovalMemberResolver(
             .ToList();
 
         var quorum = new QuorumConfig(committee.QuorumType.ToString(), committee.QuorumValue);
-        var majority = new MajorityConfig(committee.MajorityType.ToString(), "approve");
+        var majority = new MajorityConfig(
+            committee.MajorityType.ToString(), "approve", committee.MajorityValue);
 
         var conditions = committee.Conditions
             .Where(c => c.IsActive)

--- a/Modules/Workflow/Workflow/Workflow/Activities/Approval/ApprovalModels.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/Approval/ApprovalModels.cs
@@ -12,7 +12,12 @@ public record ThresholdConfig(decimal? MaxValue, string CommitteeCode);
 
 public record QuorumConfig(string Type, int Value);
 
-public record MajorityConfig(string Type, string TargetVote);
+/// <param name="Value">
+/// Only meaningful for <see cref="Workflow.Domain.Committees.MajorityType.FixedCount"/>. Defaults
+/// to 0 so every existing call site and every already-persisted <c>{activityId}_majority</c>
+/// workflow variable (these round-trip through JSON) keeps deserializing unchanged.
+/// </param>
+public record MajorityConfig(string Type, string TargetVote, int Value = 0);
 
 public record ApprovalGroupInfo(
     List<ApprovalMemberInfo> Members,

--- a/Modules/Workflow/Workflow/Workflow/Activities/ApprovalActivity.cs
+++ b/Modules/Workflow/Workflow/Workflow/Activities/ApprovalActivity.cs
@@ -102,6 +102,19 @@ public class ApprovalActivity : WorkflowActivityBase
                     context.ActivityId, groupInfo.CommitteeCode ?? "inline");
             }
 
+            // A FixedCount threshold above the member count can never be reached, so the round
+            // would open and then sit Pending forever. Checked against resolvedMembers — a
+            // released meeting roster replaces the committee's members, so that is the count the
+            // round actually runs with.
+            if (string.Equals(groupInfo.Majority.Type, nameof(MajorityType.FixedCount),
+                    StringComparison.OrdinalIgnoreCase)
+                && groupInfo.Majority.Value > resolvedMembers.Count)
+            {
+                return ActivityResult.Failed(
+                    $"Approval requires {groupInfo.Majority.Value} approve vote(s) but the group has only " +
+                    $"{resolvedMembers.Count} member(s); the round could never resolve");
+            }
+
             var activityName = GetProperty(context, "activityName", context.ActivityId);
             var voteOptions = GetProperty<List<string>>(context, "voteOptions",
                 new List<string> { "approve", "reject", "route_back" });
@@ -834,7 +847,7 @@ public class ApprovalActivity : WorkflowActivityBase
     private static bool CheckMajority(MajorityConfig config, int targetCount, int totalVotes, int totalMembers)
     {
         return Enum.TryParse<MajorityType>(config.Type, ignoreCase: true, out var majorityType)
-            && MajorityRule.IsMet(majorityType, targetCount, totalMembers);
+            && MajorityRule.IsMet(majorityType, targetCount, totalMembers, config.Value);
     }
 
     private static Dictionary<string, object> BuildOutputData(

--- a/Modules/Workflow/Workflow/Workflow/Features/Committees/CreateCommittee/CreateCommitteeEndpoint.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/Committees/CreateCommittee/CreateCommitteeEndpoint.cs
@@ -32,7 +32,8 @@ public record CreateCommitteeRequest(
     string? VotingMode,
     List<CreateCommitteeMemberRequest>? Members,
     List<CreateCommitteeThresholdRequest>? Thresholds,
-    List<CreateCommitteeConditionRequest>? Conditions);
+    List<CreateCommitteeConditionRequest>? Conditions,
+    int MajorityValue = 0);
 
 public record CreateCommitteeMemberRequest(string UserId, string MemberName, string Role, string? Attendance = null);
 public record CreateCommitteeThresholdRequest(decimal? MinValue, decimal? MaxValue, int Priority);
@@ -65,7 +66,8 @@ public class CreateCommitteeCommandHandler(
             && !Enum.TryParse(req.VotingMode, ignoreCase: true, out votingMode))
             throw new ArgumentException($"Invalid VotingMode '{req.VotingMode}'. Allowed values: {string.Join(", ", Enum.GetNames<VotingMode>())}");
 
-        var committee = Committee.Create(req.Name, req.Code, req.Description, quorumType, req.QuorumValue, majorityType, votingMode);
+        var committee = Committee.Create(req.Name, req.Code, req.Description, quorumType,
+            req.QuorumValue, majorityType, votingMode, req.MajorityValue);
 
         if (req.Members is not null)
         {

--- a/Modules/Workflow/Workflow/Workflow/Features/Committees/GetCommitteeById/GetCommitteeByIdEndpoint.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/Committees/GetCommitteeById/GetCommitteeByIdEndpoint.cs
@@ -30,7 +30,8 @@ public record GetCommitteeByIdResponse(
     bool IsActive, string QuorumType, int QuorumValue, string MajorityType,
     List<CommitteeMemberDto> Members,
     List<CommitteeThresholdDto> Thresholds,
-    List<CommitteeConditionDto> Conditions);
+    List<CommitteeConditionDto> Conditions,
+    int MajorityValue = 0);
 
 public record CommitteeMemberDto(Guid Id, string UserId, string MemberName, string Role, bool IsActive, string Attendance);
 public record CommitteeThresholdDto(Guid Id, decimal? MinValue, decimal? MaxValue, int Priority, bool IsActive);
@@ -55,6 +56,7 @@ public class GetCommitteeByIdQueryHandler(
                 t.Id, t.MinValue, t.MaxValue, t.Priority, t.IsActive)).ToList(),
             committee.Conditions.Select(c => new CommitteeConditionDto(
                 c.Id, c.ConditionType.ToString(), c.RoleRequired, c.MinVotesRequired,
-                c.Priority, c.IsActive, c.Description)).ToList());
+                c.Priority, c.IsActive, c.Description)).ToList(),
+            committee.MajorityValue);
     }
 }

--- a/Modules/Workflow/Workflow/Workflow/Features/Committees/GetCommittees/GetCommitteesEndpoint.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/Committees/GetCommittees/GetCommitteesEndpoint.cs
@@ -28,7 +28,7 @@ public record GetCommitteesResponse(List<CommitteeListItem> Committees);
 public record CommitteeListItem(
     Guid Id, string Name, string Code, string? Description,
     bool IsActive, string QuorumType, int QuorumValue, string MajorityType,
-    int MemberCount);
+    int MemberCount, int MajorityValue = 0);
 
 public class GetCommitteesQueryHandler(
     ICommitteeRepository committeeRepository
@@ -41,7 +41,7 @@ public class GetCommitteesQueryHandler(
         var items = committees.Select(c => new CommitteeListItem(
             c.Id, c.Name, c.Code, c.Description, c.IsActive,
             c.QuorumType.ToString(), c.QuorumValue, c.MajorityType.ToString(),
-            c.GetActiveMembers().Count)).ToList();
+            c.GetActiveMembers().Count, c.MajorityValue)).ToList();
 
         return new GetCommitteesResponse(items);
     }

--- a/Modules/Workflow/Workflow/Workflow/Features/Committees/UpdateCommittee/UpdateCommitteeEndpoint.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/Committees/UpdateCommittee/UpdateCommitteeEndpoint.cs
@@ -31,7 +31,8 @@ public record UpdateCommitteeRequest(
     int QuorumValue,
     string MajorityType,
     bool IsActive,
-    string? VotingMode = null);
+    string? VotingMode = null,
+    int MajorityValue = 0);
 
 public record UpdateCommitteeCommand(Guid Id, UpdateCommitteeRequest Request) : ICommand<UpdateCommitteeResponse>, ITransactionalCommand<IWorkflowUnitOfWork>;
 
@@ -58,7 +59,8 @@ public class UpdateCommitteeCommandHandler(
             && !Enum.TryParse(req.VotingMode, ignoreCase: true, out votingMode))
             throw new ArgumentException($"Invalid VotingMode '{req.VotingMode}'. Allowed values: {string.Join(", ", Enum.GetNames<VotingMode>())}");
 
-        committee.Update(req.Name, req.Description, quorumType, req.QuorumValue, majorityType, req.IsActive, votingMode);
+        committee.Update(req.Name, req.Description, quorumType, req.QuorumValue, majorityType,
+            req.IsActive, votingMode, req.MajorityValue);
 
         await committeeRepository.UpdateAsync(committee, ct);
 

--- a/Modules/Workflow/Workflow/Workflow/Features/GetApprovalList/ApprovalListProjection.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/GetApprovalList/ApprovalListProjection.cs
@@ -90,7 +90,7 @@ internal static class ApprovalListProjection
     internal static bool CheckMajority(MajorityConfig config, int targetCount, int totalVotes, int totalMembers)
     {
         return Enum.TryParse<MajorityType>(config.Type, ignoreCase: true, out var majorityType)
-            && MajorityRule.IsMet(majorityType, targetCount, totalMembers);
+            && MajorityRule.IsMet(majorityType, targetCount, totalMembers, config.Value);
     }
 
     /// <summary>

--- a/Tests/Unit/Workflow.Tests/Domain/CommitteeMajorityTests.cs
+++ b/Tests/Unit/Workflow.Tests/Domain/CommitteeMajorityTests.cs
@@ -43,4 +43,53 @@ public class CommitteeMajorityTests
             .HasMajority(approveCount, totalVotes: approveCount, totalMembers: 5)
             .Should().Be(expected);
     }
+
+    [Theory]
+    [InlineData(2, false)]
+    [InlineData(3, true)]
+    public void FixedCount_UsesTheCommitteesConfiguredValue(int approveCount, bool expected)
+    {
+        // 3 approvals is enough on a 7-member committee — where Simple would demand 4.
+        Committee.Create("C", "C", null, QuorumType.Fixed, 1,
+                MajorityType.FixedCount, VotingMode.WaitForAll, majorityValue: 3)
+            .HasMajority(approveCount, totalVotes: approveCount, totalMembers: 7)
+            .Should().Be(expected);
+    }
+
+    [Fact]
+    public void Create_FixedCountWithoutAValue_IsRejected()
+    {
+        // Would otherwise persist a committee whose every round approves on zero votes.
+        var act = () => Committee.Create("C", "C", null, QuorumType.Fixed, 1,
+            MajorityType.FixedCount, VotingMode.WaitForAll, majorityValue: 0);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*MajorityValue*");
+    }
+
+    [Fact]
+    public void Update_FixedCountAboveActiveMemberCount_IsRejected()
+    {
+        var committee = Committee.Create("C", "C", null, QuorumType.Fixed, 1, MajorityType.Simple);
+        committee.AddMember("alice", "Alice", CommitteeMemberPosition.Chairman);
+        committee.AddMember("bob", "Bob", CommitteeMemberPosition.UW);
+
+        var act = () => committee.Update("C", null, QuorumType.Fixed, 1,
+            MajorityType.FixedCount, isActive: true, VotingMode.WaitForAll, majorityValue: 3);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*exceeds*2 active member(s)*");
+    }
+
+    [Fact]
+    public void Update_FixedCountAtTheMemberCount_IsAllowed()
+    {
+        var committee = Committee.Create("C", "C", null, QuorumType.Fixed, 1, MajorityType.Simple);
+        committee.AddMember("alice", "Alice", CommitteeMemberPosition.Chairman);
+        committee.AddMember("bob", "Bob", CommitteeMemberPosition.UW);
+
+        committee.Update("C", null, QuorumType.Fixed, 1,
+            MajorityType.FixedCount, isActive: true, VotingMode.WaitForAll, majorityValue: 2);
+
+        committee.MajorityValue.Should().Be(2);
+        committee.MajorityType.Should().Be(MajorityType.FixedCount);
+    }
 }

--- a/Tests/Unit/Workflow.Tests/Domain/MajorityRuleTests.cs
+++ b/Tests/Unit/Workflow.Tests/Domain/MajorityRuleTests.cs
@@ -32,4 +32,48 @@ public class MajorityRuleTests
     public void EvenCommittee_SimpleRequiresStrictMajority() =>
         // 2 of 4 is exactly half — not a majority.
         MajorityRule.IsMet(MajorityType.Simple, 2, 4).Should().BeFalse();
+
+    // -- FixedCount: an absolute threshold, independent of member count --
+
+    [Theory]
+    [InlineData(2, 3, false)]
+    [InlineData(3, 3, true)]  // the business case: 3 approvals out of 7 members is enough
+    [InlineData(4, 3, true)]  // above the threshold still passes
+    public void FixedCount_IsMetAtOrAboveTheThreshold(int approve, int value, bool expected) =>
+        MajorityRule.IsMet(MajorityType.FixedCount, approve, totalMembers: 7, value).Should().Be(expected);
+
+    [Fact]
+    public void FixedCount_IgnoresMemberCount()
+    {
+        // Same 3 approvals, wildly different committee sizes — all met. This is exactly what
+        // distinguishes it from every proportional rule above, where 3 of 20 would fail.
+        foreach (var members in new[] { 3, 7, 20, 100 })
+            MajorityRule.IsMet(MajorityType.FixedCount, 3, members, 3).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void FixedCount_NonPositiveThreshold_IsNeverMet(int value)
+    {
+        // Without the value > 0 guard, `approveCount >= 0` would approve on zero votes.
+        // Committee.Create/Update reject this up front; this is the defence behind that.
+        MajorityRule.IsMet(MajorityType.FixedCount, 0, 5, value).Should().BeFalse();
+        MajorityRule.IsMet(MajorityType.FixedCount, 5, 5, value).Should().BeFalse();
+    }
+
+    [Fact]
+    public void FixedCount_ThresholdAboveMemberCount_CanNeverBeMet() =>
+        // Unreachable by construction — every member approving still falls short. Committee.Update
+        // and the ApprovalActivity round-start guard stop a round ever opening on this.
+        MajorityRule.IsMet(MajorityType.FixedCount, approveCount: 4, totalMembers: 4, value: 5)
+            .Should().BeFalse();
+
+    [Fact]
+    public void ProportionalTypes_IgnoreTheValue()
+    {
+        // The value exists only for FixedCount; supplying one must not perturb the others.
+        MajorityRule.IsMet(MajorityType.Simple, 2, 5, value: 2).Should().BeFalse();
+        MajorityRule.IsMet(MajorityType.Unanimous, 5, 5, value: 99).Should().BeTrue();
+    }
 }

--- a/Tests/Unit/Workflow.Tests/Meetings/MeetingRosterEligibilityTests.cs
+++ b/Tests/Unit/Workflow.Tests/Meetings/MeetingRosterEligibilityTests.cs
@@ -215,6 +215,50 @@ public class MeetingRosterEligibilityTests
         failures.Should().BeEmpty();
     }
 
+    [Fact]
+    public void Check_RosterSmallerThanFixedCountMajority_Fails()
+    {
+        // The roster replaces the committee's members but the majority rule still comes from the
+        // committee, so a fixed threshold larger than the roster can never be reached.
+        var committee = Committee.Create("Committee With Meeting", MeetingCommittee.WithMeetingCode,
+            null, QuorumType.Fixed, 1, MajorityType.FixedCount, VotingMode.Quorum, majorityValue: 3);
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Chairman),
+                   ("b", CommitteeMemberPosition.UW)),
+            committee);
+
+        failures.Should().ContainSingle()
+            .Which.Should().Be("3 approve vote(s) required but the roster has only 2 member(s)");
+    }
+
+    [Fact]
+    public void Check_RosterMeetsFixedCountMajority_NoFailures()
+    {
+        var committee = Committee.Create("Committee With Meeting", MeetingCommittee.WithMeetingCode,
+            null, QuorumType.Fixed, 1, MajorityType.FixedCount, VotingMode.Quorum, majorityValue: 2);
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Chairman),
+                   ("b", CommitteeMemberPosition.UW)),
+            committee);
+
+        failures.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Check_ProportionalMajority_IsAlwaysSatisfiableByTheRosterItself()
+    {
+        // Unanimous of a 1-member roster is 1 — proportional rules are taken of the roster, so
+        // only FixedCount can be unreachable. Same reasoning as a Percentage quorum.
+        var committee = BuildCommittee(QuorumType.Fixed, 1);
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Chairman)), committee);
+
+        failures.Should().BeEmpty();
+    }
+
     // -- Helpers --
 
     private static IReadOnlySet<string> Known(params string[] usernames)


### PR DESCRIPTION
Committees could only resolve on a proportional rule — `Simple`, `TwoThirds`, `Unanimous`, all measured against the full member count. The business needs an absolute alternative: **7 members, 3 approvals is enough**.

## Why not `ConditionType.MinVotes`

It looks like it already does this — it means "at least N approve votes" — but it cannot, because the decision ANDs it with the majority rule:

```csharp
var decided = requireAllVotes ? allVoted && conditionsMet && majorityMet
                              : conditionsMet && quorumMet && majorityMet;
```

On 7 members with `Simple`, `majorityMet` needs `approveCount > 3.5` → 4. A `MinVotes = 3` condition is subsumed. Conditions can only *tighten* the bar, never lower it — so the switch has to be on the majority rule itself.

## The change

`MajorityType.FixedCount` + `Committee.MajorityValue`. `MajorityRule.IsMet` is the one place the three callers share (`Committee.HasMajority`, `ApprovalActivity.CheckMajority`, `ApprovalListProjection.CheckMajority`), so the rule itself changes once and the engine and the read side cannot drift.

`VotingMode` stays independent — a committee still chooses whether it resolves on the Nth approval or after everyone votes:

| `VotingMode` | "7 members, FixedCount 3" means |
|---|---|
| `Quorum` | Resolves the moment the 3rd approval lands; the other 4 members' tasks close. Also needs `QuorumValue <= 3` — `quorumMet` counts **all** votes cast, not approvals. |
| `WaitForAll` (current seed) | Waits for all 7 to vote, then approves if ≥3 approved. |

## Unreachable thresholds

A fixed threshold can be impossible in ways a proportional one cannot — 5 approvals on a 4-member committee approves nothing, ever. Guarded in three places:

- `Committee.Create` — rejects a non-positive value (otherwise `approveCount >= 0` approves on zero votes).
- `Committee.Update` — rejects a value above the active member count, where that count is finally known.
- `ApprovalActivity.ExecuteActivityAsync` — fails the round at open, checked against **`resolvedMembers`** rather than the committee, so a released meeting roster is measured rather than the committee behind it.
- `MeetingRosterEligibility` — the matching pre-release check, so a too-small roster is refused at release instead of stalling later.

## Latent bug fixed on the way

The Workflow Builder has always emitted `majority: { type: 'count' | 'percent', value: N }` (`ApprovalForm.tsx:42-43`). `MajorityConfig` had no `Value`, and `CheckMajority` ran `Enum.TryParse<MajorityType>('count')` — which fails, returns `false`, and means **an inline-majority approval activity could never approve**. Dormant only because the seeded `appraisal-workflow.json` takes its majority from the committee row.

`'count'` now maps to `FixedCount`. `'percent'` has no backend equivalent (`Simple`/`TwoThirds` are hardcoded fractions) and now throws at Execute rather than failing silently at vote time.

## Migration

One column, generated not hand-authored: `workflow.Committees.MajorityValue int NOT NULL DEFAULT 0`. Existing rows get 0, correct for every proportional type. **Not applied** — run `dotnet run --project Database/Database.csproj migrate`.

## Verification

`dotnet build` clean across 39 projects. `Workflow.Tests`: 956 passed, 16 new (`MajorityRuleTests`, `CommitteeMajorityTests`, `MeetingRosterEligibilityTests`). The 8 failures are the known pre-existing local-environment baseline — byte-identical on `main` — and CI's own test step passes there.

Not yet exercised end-to-end: committee approval cannot currently run on the dev database at any tier, because 13 `CommitteeMembers.Position` rows hold Thai HR job titles instead of `CommitteeMemberPosition` names and EF cannot materialise them. Unrelated to this PR, tracked separately.

## Frontend

`CommitteeAdminPage.tsx` does not render or edit quorum/majority today — it manages members only. So there is no form to extend here; setting this per committee through the UI is a separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183ybF4aVjz8VuHyQQJ58ko