### PR TITLE
feat(integration): report each collateral's own deed address in the legacy result

### DIFF
--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQueryHandler.cs
@@ -78,15 +78,13 @@ internal static class GetAppraisalResultSql
                                             ORDER BY a.CreatedAt DESC, a.AppraisalNumber
                                             """;
 
-    // Legacy (AS400) header: adds AppraisalType, the request-level selling price (MarketValue) and the
-    // request-detail DOPA address resolved to Thai names (RequestDetails geocodes → parameter.Dopa*).
-    // COALESCE falls back to the raw code if a geocode is absent from the reference tables.
+    // Legacy (AS400) header: adds AppraisalType and the request-level selling price (MarketValue).
+    // The Province/District/SubDistrict returned to AS400 is the TITLE address, sourced per collateral
+    // (land/condo detail, or the project for a block) — not the request-level DOPA address — so it is
+    // resolved in the collateral/project queries below, not here.
     public const string LegacyByAppraisalNumber = """
                                             SELECT a.Id, a.AppraisalNumber, a.AppraisalType, a.Status, a.CompletedAt, a.RequestId,
                                                    rd.TotalSellingPrice AS MarketValue,
-                                                   COALESCE(dprov.NameTh, rd.Province)    AS Province,
-                                                   COALESCE(ddist.NameTh, rd.District)    AS District,
-                                                   COALESCE(dsub.NameTh,  rd.SubDistrict) AS SubDistrict,
                                                    -- SequenceOfApprove = the committee meeting number the appraisal was reviewed in (latest).
                                                    (SELECT TOP 1 m.MeetingNo
                                                     FROM appraisal.AppraisalReviews ar
@@ -95,9 +93,6 @@ internal static class GetAppraisalResultSql
                                                     ORDER BY ar.ReviewedAt DESC) AS SequenceOfApprove
                                             FROM appraisal.Appraisals a
                                             LEFT JOIN request.RequestDetails rd ON rd.RequestId = a.RequestId
-                                            LEFT JOIN parameter.DopaProvinces    dprov ON dprov.Code = rd.Province
-                                            LEFT JOIN parameter.DopaDistricts    ddist ON ddist.Code = rd.District
-                                            LEFT JOIN parameter.DopaSubDistricts dsub  ON dsub.Code  = rd.SubDistrict
                                             WHERE a.AppraisalNumber = @AppraisalNumber AND a.IsDeleted = 0
                                             """;
 
@@ -191,6 +186,13 @@ internal static class GetAppraisalResultSql
                                                    -- LandOffice code resolved to its Thai description (legacy variant only)
                                                    COALESCE(pLandOffice.[description],    lad.LandOffice) AS LandOfficeName,
                                                    COALESCE(pCadLandOffice.[description], cad.LandOffice) AS CadLandOfficeName,
+                                                   -- Title-address geocodes resolved to Thai names (Title masters, NOT DOPA — legacy variant only)
+                                                   COALESCE(ltProv.NameTh, lad.Province)    AS ProvinceName,
+                                                   COALESCE(ltDist.NameTh, lad.District)    AS DistrictName,
+                                                   COALESCE(ltSub.NameTh,  lad.SubDistrict) AS SubDistrictName,
+                                                   COALESCE(ctProv.NameTh, cad.Province)    AS CadProvinceName,
+                                                   COALESCE(ctDist.NameTh, cad.District)    AS CadDistrictName,
+                                                   COALESCE(ctSub.NameTh,  cad.SubDistrict) AS CadSubDistrictName,
                                                    -- PMA / pre-completion prices stored directly on the property (no ValuationAnalyses yet)
                                                    ap.SellingPrice           AS PropSellingPrice,
                                                    ap.ForcedSalePrice        AS PropForcedSalePrice,
@@ -233,6 +235,13 @@ internal static class GetAppraisalResultSql
                                                LEFT JOIN parameter.Parameters pCadLandOffice
                                                    ON pCadLandOffice.[group] = 'LandOffice' AND pCadLandOffice.[language] = 'TH'
                                                   AND pCadLandOffice.[isactive] = 1 AND pCadLandOffice.[code] = cad.LandOffice
+                                               -- Title-address masters (land + condo detail geocodes → Thai names)
+                                               LEFT JOIN parameter.TitleProvinces    ltProv ON ltProv.Code = lad.Province
+                                               LEFT JOIN parameter.TitleDistricts    ltDist ON ltDist.Code = lad.District
+                                               LEFT JOIN parameter.TitleSubDistricts ltSub  ON ltSub.Code  = lad.SubDistrict
+                                               LEFT JOIN parameter.TitleProvinces    ctProv ON ctProv.Code = cad.Province
+                                               LEFT JOIN parameter.TitleDistricts    ctDist ON ctDist.Code = cad.District
+                                               LEFT JOIN parameter.TitleSubDistricts ctSub  ON ctSub.Code  = cad.SubDistrict
                                                WHERE ap.AppraisalId = @AppraisalId
                                                ORDER BY pg.GroupNumber, pgi.SequenceInGroup, ap.Id
                                                """;
@@ -264,11 +273,18 @@ internal static class GetAppraisalResultSql
     public const string ProjectByAppraisalId = """
                                                SELECT TOP 1 p.Id AS ProjectId, p.ProjectType,
                                                       p.ProjectName, p.Developer, p.BuiltOnTitleDeedNumber,
-                                                      COALESCE(pLandOffice.[description], p.LandOffice) AS LandOfficeName
+                                                      COALESCE(pLandOffice.[description], p.LandOffice) AS LandOfficeName,
+                                                      -- Block title address (project geocodes → Title masters, NOT DOPA)
+                                                      COALESCE(ltProv.NameTh, p.Province)    AS ProvinceName,
+                                                      COALESCE(ltDist.NameTh, p.District)    AS DistrictName,
+                                                      COALESCE(ltSub.NameTh,  p.SubDistrict) AS SubDistrictName
                                                FROM appraisal.Projects p
                                                LEFT JOIN parameter.Parameters pLandOffice
                                                    ON pLandOffice.[group] = 'LandOffice' AND pLandOffice.[language] = 'TH'
                                                   AND pLandOffice.[isactive] = 1 AND pLandOffice.[code] = p.LandOffice
+                                               LEFT JOIN parameter.TitleProvinces    ltProv ON ltProv.Code = p.Province
+                                               LEFT JOIN parameter.TitleDistricts    ltDist ON ltDist.Code = p.District
+                                               LEFT JOIN parameter.TitleSubDistricts ltSub  ON ltSub.Code  = p.SubDistrict
                                                WHERE p.AppraisalId = @AppraisalId
                                                """;
 
@@ -404,13 +420,20 @@ internal sealed record CollateralRow(
     decimal? TotalBuildingArea,
     string? LandOfficeName,
     string? CadLandOfficeName,
+    // Title-address geocodes resolved to Thai names (land detail / condo detail)
+    string? ProvinceName,
+    string? DistrictName,
+    string? SubDistrictName,
+    string? CadProvinceName,
+    string? CadDistrictName,
+    string? CadSubDistrictName,
     // PMA / pre-completion prices stored on the property (used when ValuationAnalyses is absent)
     decimal? PropSellingPrice,
     decimal? PropForcedSalePrice,
     decimal? PropBuildingInsurancePrice);
 
-// Legacy (AS400) appraisal header row: appraisal identity + type, request-level MarketValue and the
-// DOPA address already resolved to Thai names.
+// Legacy (AS400) appraisal header row: appraisal identity + type and the request-level MarketValue.
+// The title address is resolved per collateral (see CollateralRow / ProjectRow), not here.
 internal sealed record LegacyAppraisalRow(
     Guid Id,
     string AppraisalNumber,
@@ -419,9 +442,6 @@ internal sealed record LegacyAppraisalRow(
     DateTime? CompletedAt,
     Guid RequestId,
     decimal? MarketValue,
-    string? Province,
-    string? District,
-    string? SubDistrict,
     string? SequenceOfApprove);
 
 internal sealed record DocumentRow(string? DocumentType, Guid DocumentId);
@@ -435,7 +455,11 @@ internal sealed record ProjectRow(
     string? ProjectName = null,
     string? Developer = null,
     string? BuiltOnTitleDeedNumber = null,
-    string? LandOfficeName = null);
+    string? LandOfficeName = null,
+    // Block title address resolved to Thai names
+    string? ProvinceName = null,
+    string? DistrictName = null,
+    string? SubDistrictName = null);
 
 internal sealed record BlockUnitRow(
     string? RoomNumber,

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetLegacyAppraisalResultQueryHandler.cs
@@ -174,6 +174,10 @@ internal static class LegacyResultMapper
             MarketValue = completed ? (header.MarketValue ?? 0m) : (row.PropSellingPrice ?? header.MarketValue ?? 0m),
             MethodOfAppraisal = MapMethod(row.AppraisalMethod),
             AppraisalValueWaOrM = row.GroupValuePerUnit ?? 0m,  // selected method's per-Wa/Sqm rate (usually cost only)
+            // Title address from the condo detail (falls back to the land detail on the same property).
+            Province = Str(row.CadProvinceName ?? row.ProvinceName),
+            District = Str(row.CadDistrictName ?? row.DistrictName),
+            SubDistrict = Str(row.CadSubDistrictName ?? row.SubDistrictName),
             LandOffice = Str(row.LandOfficeName ?? row.CadLandOfficeName),
             LandValue = row.GroupLandValue ?? 0m,
             LandNo = Str(row.LandNo),
@@ -221,6 +225,10 @@ internal static class LegacyResultMapper
             MarketValue = completed ? (header.MarketValue ?? 0m) : (propSelling ?? header.MarketValue ?? 0m),
             MethodOfAppraisal = MapMethod(land?.AppraisalMethod ?? building?.AppraisalMethod),
             AppraisalValueWaOrM = (land?.GroupValuePerUnit ?? building?.GroupValuePerUnit) ?? 0m,
+            // Title address from the land detail (the building detail carries no address).
+            Province = Str(land?.ProvinceName ?? building?.ProvinceName),
+            District = Str(land?.DistrictName ?? building?.DistrictName),
+            SubDistrict = Str(land?.SubDistrictName ?? building?.SubDistrictName),
             LandOffice = Str(land?.LandOfficeName ?? building?.LandOfficeName),
             LandValue = groupLandValue ?? 0m,
             // Land row
@@ -270,6 +278,10 @@ internal static class LegacyResultMapper
             Developer = Str(project.Developer),
             TitleNo = Str(project.BuiltOnTitleDeedNumber),
             LandOffice = Str(project.LandOfficeName),
+            // Title address from the project (block has no per-property detail address).
+            Province = Str(project.ProvinceName),
+            District = Str(project.DistrictName),
+            SubDistrict = Str(project.SubDistrictName),
             // Per-unit identity.
             LandNo = isCondo ? "" : Str(unit.PlotNumber),
             HouseNo = isCondo ? "" : Str(unit.HouseNumber),
@@ -323,9 +335,8 @@ internal static class LegacyResultMapper
             // MethodOfAppraisal + AppraisalValueWaOrM are set per selected collateral by the callers.
             MarketValue = header.MarketValue ?? 0m,
             BuildingValue = valuation?.InsuranceValue ?? 0m, // legacy BuildingValue = fire-insurance value
-            Province = Str(header.Province),
-            District = Str(header.District),
-            SubDistrict = Str(header.SubDistrict),
+            // Province/District/SubDistrict = the TITLE address, set per collateral by each caller below
+            // (land/condo detail, or the project for a block) — never the request-level DOPA address.
             AppraisalDate = appraisalDate,
             InternalValuerCode = valuer.InternalCode,
             InternalValuerName = valuer.InternalName,


### PR DESCRIPTION
## What

The legacy AS400 appraisal result reported **one address for the whole appraisal**. It came from the
request-level DOPA address, resolved on the header query by joining `RequestDetails.Province/District/
SubDistrict` against `parameter.DopaProvinces/DopaDistricts/DopaSubDistricts`, and `LegacyResultMapper`
stamped that single header address onto every collateral row.

It now reports **each collateral's own deed (title) address**, resolved against the Title masters.

- Header query (`LegacyByAppraisalNumber`) drops the three DOPA joins and the three address columns;
  `LegacyAppraisalRow` loses `Province`/`District`/`SubDistrict`.
- Collateral query gains six columns via new Title joins — `ProvinceName`/`DistrictName`/`SubDistrictName`
  (land detail, alias `lad`) and `CadProvinceName`/`CadDistrictName`/`CadSubDistrictName` (condo detail,
  alias `cad`).
- Project query gains `ProvinceName`/`DistrictName`/`SubDistrictName` from `appraisal.Projects` joined
  to the Title masters.
- Mapper fallback chains, one per collateral shape:
  - condo → `CadXName ?? XName`
  - land/building group → `land?.XName ?? building?.XName`
  - block unit → `project.XName`

## Why

A multi-collateral appraisal can span several provinces. Reporting the request-level address for every
collateral was simply wrong for those cases.

## Risks worth a careful look

1. **The coding system changes from DOPA geocodes to Title geocodes.** The Title and DOPA masters
   **diverged on 2026-07-29** (Title now tracks the Land Department extract: 93 provinces / 1,640
   districts / 11,144 sub-districts, nullable postcode, non-numeric codes). The same underlying location
   can therefore produce a different Thai name, or fall back to the raw code where the two masters
   disagree.
2. **The header no longer emits an address at all.** Any AS400 consumer that read the top-level address
   now depends on all three mapper paths being reached. Worth confirming against the interface spec
   before this goes to UAT.

## Test

- [ ] Regenerate a legacy result for a multi-collateral, multi-province appraisal and diff against the
      previous output.
- [ ] Confirm each collateral carries its own deed address.
- [ ] Confirm no row falls back to a raw geocode unexpectedly.

## Notes

Split out of a large combined working tree; this branch is self-contained and touches only the two
Integration query handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhV2jVwAfwgBu3JboaNnCC
