### PR TITLE
feat(workflow): scope pool tasks to their team, override assignment rules, enforce segregation of duties

### DIFF
--- a/Modules/Workflow/Workflow/AssigneeSelection/Core/AssignmentContext.cs
+++ b/Modules/Workflow/Workflow/AssigneeSelection/Core/AssignmentContext.cs
@@ -28,4 +28,12 @@ public class AssignmentContext
     /// Workflow instance variables (runtime state). Used by VariableAssignee strategy.
     /// </summary>
     public Dictionary<string, object>? Variables { get; set; }
+
+    /// <summary>
+    /// The team the pipeline actually resolved for this assignment (Stage 1), or null when the
+    /// assignment is not scoped to a team. Selectors must use this rather than inferring a team
+    /// from <see cref="CandidatePool"/> — the pool holds every group member (each carrying their
+    /// own team) whenever no team constraint applied or no team could be derived.
+    /// </summary>
+    public string? TeamId { get; set; }
 }

--- a/Modules/Workflow/Workflow/AssigneeSelection/Pipeline/AssignmentContextBuilder.cs
+++ b/Modules/Workflow/Workflow/AssigneeSelection/Pipeline/AssignmentContextBuilder.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Workflow.AssigneeSelection.Teams;
 using Workflow.Services.Configuration;
+using Workflow.Services.Configuration.Models;
 using Workflow.Workflow;
 using Workflow.Workflow.Activities.Core;
 using Workflow.Workflow.Models;
@@ -27,10 +28,21 @@ public class AssignmentContextBuilder : IAssignmentContextBuilder
     {
         var activityCtx = context.ActivityContext;
 
-        // 1. Parse assignmentRules from workflow definition JSON
-        context.Rules = ParseAssignmentRules(activityCtx);
+        // 1. Resolve the DB-backed assignment override (scoped by activity + workflow + banking segment).
+        //    The service returns null on miss/error, in which case the JSON definition stays the baseline.
+        //    This MUST run before the rules are built: the team derivation in step 3 reads
+        //    Rules.TeamConstrained, and the override is allowed to flip it.
+        var bankingSegment = GetJsonString(activityCtx.Variables, "bankingSegment");
+        context.ExternalConfig = await _configurationService.GetConfigurationAsync(
+            activityCtx.ActivityId,
+            activityCtx.WorkflowInstance.WorkflowDefinitionId.ToString(),
+            bankingSegment,
+            cancellationToken);
 
-        // 2a. Read TeamId — check activity-specific teamIdVariable first
+        // 2. Build assignmentRules: JSON definition is the baseline, the DB override wins per field.
+        context.Rules = MergeAssignmentRules(ParseAssignmentRules(activityCtx), context.ExternalConfig);
+
+        // 3a. Read TeamId — check activity-specific teamIdVariable first
         var teamVarName = GetJsonString(activityCtx.Properties, "teamIdVariable");
         if (!string.IsNullOrEmpty(teamVarName))
         {
@@ -39,7 +51,7 @@ public class AssignmentContextBuilder : IAssignmentContextBuilder
                 context.TeamId = activityTeamId;
         }
 
-        // 2b. If team-constrained but no explicit variable, derive from previous assignee's team.
+        // 3b. If team-constrained but no explicit variable, derive from previous assignee's team.
         //     Fan-out-aware path runs first: when we are inside a fan-out stage transition,
         //     the activity execution is still InProgress so GetMostRecentPriorAssignee (which only
         //     scans Completed executions) would miss the maker. We read CompletedBy from the
@@ -81,7 +93,7 @@ public class AssignmentContextBuilder : IAssignmentContextBuilder
             }
         }
 
-        // 2c. Fall back to global TeamId variable
+        // 3c. Fall back to global TeamId variable
         if (string.IsNullOrEmpty(context.TeamId))
         {
             var globalTeamId = GetJsonString(activityCtx.Variables, "TeamId");
@@ -89,26 +101,17 @@ public class AssignmentContextBuilder : IAssignmentContextBuilder
                 context.TeamId = globalTeamId;
         }
 
-        // 3. Extract RuntimeOverride for this activity
+        // 4. Extract RuntimeOverride for this activity
         context.RuntimeOverride = activityCtx.RuntimeOverrides;
 
-        // 3b. Resolve the DB-backed assignment override (scoped by activity + workflow + banking segment).
-        //     The service returns null on miss/error, in which case the JSON definition stays the baseline.
-        var bankingSegment = GetJsonString(activityCtx.Variables, "bankingSegment");
-        context.ExternalConfig = await _configurationService.GetConfigurationAsync(
-            activityCtx.ActivityId,
-            activityCtx.WorkflowInstance.WorkflowDefinitionId.ToString(),
-            bankingSegment,
-            cancellationToken);
-
-        // 3c. Resolve the assignee group ONCE with precedence RuntimeOverride > DB config > JSON definition.
+        // 4b. Resolve the assignee group ONCE with precedence RuntimeOverride > DB config > JSON definition.
         //     Stage 2 (TeamFilter) and Stage 3 (engine) both read this so they cannot drift apart.
         context.ResolvedAssigneeGroup =
             JsonPropertyReader.NullIfEmpty(context.RuntimeOverride?.RuntimeAssigneeGroup)
             ?? JsonPropertyReader.NullIfEmpty(context.ExternalConfig?.AssigneeGroup)
             ?? GetJsonString(activityCtx.Properties, "assigneeGroup");
 
-        // 4. Build PriorAssignees map from completed activity executions.
+        // 5. Build PriorAssignees map from completed activity executions.
         //    When FanOutKey is set on the ActivityContext, also include per-item stage history
         //    entries keyed as "<activityId>:<stageName>" so excludeAssigneesFrom can reference
         //    prior stages on the same fan-out item.
@@ -168,50 +171,27 @@ public class AssignmentContextBuilder : IAssignmentContextBuilder
             .FirstOrDefault();
     }
 
-    private ActivityAssignmentRules ParseAssignmentRules(ActivityContext activityCtx)
+    /// <summary>
+    /// Applies the DB override on top of the JSON-derived rules, per field. A null column means
+    /// "inherit the definition JSON", which is what every pre-existing row has — so untouched
+    /// overrides keep behaving exactly as before.
+    /// </summary>
+    private static ActivityAssignmentRules MergeAssignmentRules(
+        ActivityAssignmentRules fromJson,
+        TaskAssignmentConfigurationDto? config)
     {
-        // Try to get assignmentRules from activity properties (parsed from JSON definition)
-        if (activityCtx.Properties.TryGetValue("assignmentRules", out var rulesObj))
-            try
-            {
-                if (rulesObj is JsonElement jsonElement)
-                {
-                    var teamConstrained = false;
-                    var excludeFrom = new List<string>();
+        if (config is null)
+            return fromJson;
 
-                    if (jsonElement.TryGetProperty("teamConstrained", out var tc))
-                        teamConstrained = tc.GetBoolean();
-
-                    if (jsonElement.TryGetProperty("excludeAssigneesFrom", out var ea) &&
-                        ea.ValueKind == JsonValueKind.Array)
-                        foreach (var item in ea.EnumerateArray())
-                        {
-                            var val = item.GetString();
-                            if (!string.IsNullOrEmpty(val))
-                                excludeFrom.Add(val);
-                        }
-
-                    return new ActivityAssignmentRules(teamConstrained, excludeFrom);
-                }
-
-                if (rulesObj is Dictionary<string, object> dict)
-                {
-                    var teamConstrained = dict.TryGetValue("teamConstrained", out var tc) && tc is true;
-                    var excludeFrom = new List<string>();
-
-                    if (dict.TryGetValue("excludeAssigneesFrom", out var ea) && ea is List<string> list)
-                        excludeFrom = list;
-
-                    return new ActivityAssignmentRules(teamConstrained, excludeFrom);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to parse assignmentRules for {ActivityId}", activityCtx.ActivityId);
-            }
-
-        return ActivityAssignmentRules.Default;
+        return fromJson with
+        {
+            TeamConstrained = config.TeamConstrained ?? fromJson.TeamConstrained,
+            ExcludeAssigneesFrom = config.ExcludeAssigneesFrom ?? fromJson.ExcludeAssigneesFrom
+        };
     }
+
+    private ActivityAssignmentRules ParseAssignmentRules(ActivityContext activityCtx)
+        => ActivityAssignmentRules.Parse(activityCtx.Properties, _logger, activityCtx.ActivityId);
 
     /// <summary>
     /// Builds the prior-assignees map used by <see cref="ExclusionFilter"/>.

--- a/Modules/Workflow/Workflow/AssigneeSelection/Pipeline/AssignmentPipeline.cs
+++ b/Modules/Workflow/Workflow/AssigneeSelection/Pipeline/AssignmentPipeline.cs
@@ -257,7 +257,8 @@ public class AssignmentPipeline : IAssignmentPipeline
             Properties = activityCtx.Properties,
             StartedBy = activityCtx.WorkflowInstance.StartedBy,
             CandidatePool = pipelineCtx.CandidatePool,
-            Variables = activityCtx.Variables
+            Variables = activityCtx.Variables,
+            TeamId = pipelineCtx.TeamId
         };
 
         var engineResult = await _engine.ExecuteAsync(assignmentContext, cancellationToken);

--- a/Modules/Workflow/Workflow/AssigneeSelection/Strategies/PoolAssigneeSelector.cs
+++ b/Modules/Workflow/Workflow/AssigneeSelection/Strategies/PoolAssigneeSelector.cs
@@ -21,23 +21,21 @@ public class PoolAssigneeSelector : IAssigneeSelector
         AssignmentContext context,
         CancellationToken cancellationToken = default)
     {
-        // Build pool group identifier from UserGroups or CandidatePool
+        // Build pool group identifier from UserGroups, scoped to the team only when the pipeline
+        // actually resolved one.
         string poolGroups;
 
-        if (context.CandidatePool is { Count: > 0 })
+        if (context.UserGroups.Count > 0)
         {
-            // Team-constrained: use team ID from candidate pool for scoped group
-            var teamId = context.CandidatePool.First().TeamId;
-            var groups = context.UserGroups.Count > 0
-                ? string.Join(",", context.UserGroups)
-                : "Default";
-            poolGroups = !string.IsNullOrEmpty(teamId)
-                ? $"{groups}:Team_{teamId}"
+            var groups = string.Join(",", context.UserGroups);
+
+            // Scope to a team ONLY when Stage 1 resolved one. Deriving it from CandidatePool would be
+            // wrong whenever the pool holds the whole group (no team constraint, or a constraint whose
+            // team could not be derived) — the pool is unordered, so an arbitrary member's team would
+            // win and hide the task from every other team in the group.
+            poolGroups = !string.IsNullOrEmpty(context.TeamId)
+                ? $"{groups}:Team_{context.TeamId}"
                 : groups;
-        }
-        else if (context.UserGroups.Count > 0)
-        {
-            poolGroups = string.Join(",", context.UserGroups);
         }
         else
         {

--- a/Modules/Workflow/Workflow/Data/Configurations/TaskAssignmentConfigurationConfiguration.cs
+++ b/Modules/Workflow/Workflow/Data/Configurations/TaskAssignmentConfigurationConfiguration.cs
@@ -43,6 +43,12 @@ public class TaskAssignmentConfigurationConfiguration : IEntityTypeConfiguration
         builder.Property(x => x.BankingSegment)
             .HasMaxLength(20);
 
+        // Nullable on purpose: null means "inherit the workflow definition JSON".
+        builder.Property(x => x.TeamConstrained);
+
+        builder.Property(x => x.ExcludeAssigneesFrom)
+            .HasColumnType("nvarchar(max)");
+
         // NOTE: SupervisorId and ReplacementUserId properties removed - now handled by UserManagement mock data
 
         builder.Property(x => x.AdditionalConfiguration)

--- a/Modules/Workflow/Workflow/Data/Entities/TaskAssignmentConfiguration.cs
+++ b/Modules/Workflow/Workflow/Data/Entities/TaskAssignmentConfiguration.cs
@@ -53,6 +53,18 @@ public class TaskAssignmentConfiguration : Entity<Guid>
     /// </summary>
     public string? BankingSegment { get; private set; }
 
+    /// <summary>
+    /// Overrides <c>assignmentRules.teamConstrained</c> from the workflow definition JSON.
+    /// Null = inherit the JSON value; true = force team scoping on; false = force it off.
+    /// </summary>
+    public bool? TeamConstrained { get; private set; }
+
+    /// <summary>
+    /// Overrides <c>assignmentRules.excludeAssigneesFrom</c> from the workflow definition JSON
+    /// (JSON array of activity ids). Null = inherit the JSON value.
+    /// </summary>
+    public string? ExcludeAssigneesFrom { get; private set; }
+
     // NOTE: SupervisorId and ReplacementUserId removed - now handled by UserManagement mock data
 
     /// <summary>
@@ -102,7 +114,9 @@ public class TaskAssignmentConfiguration : Entity<Guid>
         string? adminPoolId = null,
         bool escalateToAdminPool = true,
         string? additionalConfiguration = null,
-        bool isActive = true)
+        bool isActive = true,
+        bool? teamConstrained = null,
+        string? excludeAssigneesFrom = null)
     {
         return new TaskAssignmentConfiguration
         {
@@ -115,6 +129,8 @@ public class TaskAssignmentConfiguration : Entity<Guid>
             SpecificAssignee = specificAssignee,
             AssigneeGroup = assigneeGroup,
             BankingSegment = bankingSegment,
+            TeamConstrained = teamConstrained,
+            ExcludeAssigneesFrom = excludeAssigneesFrom,
             AdditionalConfiguration = additionalConfiguration,
             IsActive = isActive,
             CreatedAt = DateTime.Now,
@@ -134,13 +150,17 @@ public class TaskAssignmentConfiguration : Entity<Guid>
         string? adminPoolId = null,
         bool? escalateToAdminPool = null,
         string? additionalConfiguration = null,
-        bool isActive = true)
+        bool isActive = true,
+        bool? teamConstrained = null,
+        string? excludeAssigneesFrom = null)
     {
         PrimaryStrategies = primaryStrategies;
         RouteBackStrategies = routeBackStrategies;
         SpecificAssignee = specificAssignee;
         AssigneeGroup = assigneeGroup;
         BankingSegment = bankingSegment;
+        TeamConstrained = teamConstrained;
+        ExcludeAssigneesFrom = excludeAssigneesFrom;
         IsActive = isActive;
 
         if (adminPoolId != null)

--- a/Modules/Workflow/Workflow/Infrastructure/Migrations/20260803025615_AddTeamConstrainedToTaskAssignmentConfig.Designer.cs
+++ b/Modules/Workflow/Workflow/Infrastructure/Migrations/20260803025615_AddTeamConstrainedToTaskAssignmentConfig.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Workflow.Data;
 
@@ -11,9 +12,11 @@ using Workflow.Data;
 namespace Workflow.Infrastructure.Migrations
 {
     [DbContext(typeof(WorkflowDbContext))]
-    partial class WorkflowDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260803025615_AddTeamConstrainedToTaskAssignmentConfig")]
+    partial class AddTeamConstrainedToTaskAssignmentConfig
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modules/Workflow/Workflow/Infrastructure/Migrations/20260803025615_AddTeamConstrainedToTaskAssignmentConfig.cs
+++ b/Modules/Workflow/Workflow/Infrastructure/Migrations/20260803025615_AddTeamConstrainedToTaskAssignmentConfig.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Workflow.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTeamConstrainedToTaskAssignmentConfig : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExcludeAssigneesFrom",
+                schema: "workflow",
+                table: "TaskAssignmentConfigurations",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "TeamConstrained",
+                schema: "workflow",
+                table: "TaskAssignmentConfigurations",
+                type: "bit",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExcludeAssigneesFrom",
+                schema: "workflow",
+                table: "TaskAssignmentConfigurations");
+
+            migrationBuilder.DropColumn(
+                name: "TeamConstrained",
+                schema: "workflow",
+                table: "TaskAssignmentConfigurations");
+        }
+    }
+}

--- a/Modules/Workflow/Workflow/Services/Configuration/Models/TaskAssignmentConfigurationDto.cs
+++ b/Modules/Workflow/Workflow/Services/Configuration/Models/TaskAssignmentConfigurationDto.cs
@@ -15,6 +15,13 @@ public class TaskAssignmentConfigurationDto
     public string? SpecificAssignee { get; set; }
     public string? AssigneeGroup { get; set; }
     public string? BankingSegment { get; set; }
+
+    /// <summary>Null = inherit <c>assignmentRules.teamConstrained</c> from the definition JSON.</summary>
+    public bool? TeamConstrained { get; set; }
+
+    /// <summary>Null = inherit <c>assignmentRules.excludeAssigneesFrom</c> from the definition JSON.</summary>
+    public List<string>? ExcludeAssigneesFrom { get; set; }
+
     public Dictionary<string, object>? AdditionalConfiguration { get; set; }
     public bool IsActive { get; set; }
     public DateTime CreatedAt { get; set; }
@@ -40,6 +47,12 @@ public class CreateTaskAssignmentConfigurationRequest
 
     public string? BankingSegment { get; set; }
 
+    /// <summary>Null = inherit <c>assignmentRules.teamConstrained</c> from the definition JSON.</summary>
+    public bool? TeamConstrained { get; set; }
+
+    /// <summary>Null = inherit <c>assignmentRules.excludeAssigneesFrom</c> from the definition JSON.</summary>
+    public List<string>? ExcludeAssigneesFrom { get; set; }
+
     /// <summary>Whether the override is active. Defaults to true on create.</summary>
     public bool IsActive { get; set; } = true;
 
@@ -62,6 +75,12 @@ public class UpdateTaskAssignmentConfigurationRequest
     public string? AssigneeGroup { get; set; }
 
     public string? BankingSegment { get; set; }
+
+    /// <summary>Null = inherit <c>assignmentRules.teamConstrained</c> from the definition JSON.</summary>
+    public bool? TeamConstrained { get; set; }
+
+    /// <summary>Null = inherit <c>assignmentRules.excludeAssigneesFrom</c> from the definition JSON.</summary>
+    public List<string>? ExcludeAssigneesFrom { get; set; }
 
     /// <summary>Whether the override is active. Lets the admin enable/disable without deleting.</summary>
     public bool IsActive { get; set; } = true;

--- a/Modules/Workflow/Workflow/Services/Configuration/TaskAssignmentConfigAdminEndpoints.cs
+++ b/Modules/Workflow/Workflow/Services/Configuration/TaskAssignmentConfigAdminEndpoints.cs
@@ -10,7 +10,8 @@ using Workflow.AssigneeSelection.Core;
 using Workflow.Services.Configuration.Models;
 using Workflow.Workflow;
 using Workflow.Workflow.Features.GetVersions;
-using Workflow.Workflow.Features.GetWorkflowDefinitions;
+using Workflow.Workflow.Infrastructure.Seed;
+using Workflow.Workflow.Repositories;
 using Workflow.Workflow.Schema;
 
 namespace Workflow.Services.Configuration;
@@ -131,20 +132,28 @@ public class TaskAssignmentConfigAdminEndpoints : ICarterModule
     private static async Task<IResult> ListActivities(
         Guid? workflowDefinitionId,
         ISender sender,
+        IWorkflowDefinitionRepository definitionRepository,
         CancellationToken ct)
     {
         var definitionId = workflowDefinitionId;
 
-        // Default to the single active definition when not specified.
+        // Default to the appraisal workflow, resolved exactly the way the engine resolves it:
+        // by name, highest version (see RequestSubmittedIntegrationEventConsumer). Counting active
+        // definitions does not work here — every environment has several (Quotation, Document
+        // Followup, Fee Appointment Approval), plus any renamed "_bk*" backups, all left IsActive.
+        // The name lookup is what excludes those backups, which is why they are renamed.
         if (definitionId is null)
         {
-            var definitions = await sender.Send(new GetWorkflowDefinitionsQuery { ActiveOnly = true }, ct);
-            if (definitions.Definitions.Count == 1)
-                definitionId = definitions.Definitions[0].Id;
-            else
+            var definition = await definitionRepository.GetLatestVersion(
+                AppraisalWorkflowDefinitionSeeder.WorkflowName, ct);
+
+            if (definition is null)
                 return Results.Problem(
-                    detail: "workflowDefinitionId is required (multiple or no active workflow definitions exist).",
+                    detail: $"Workflow definition '{AppraisalWorkflowDefinitionSeeder.WorkflowName}' not found. " +
+                            "Pass workflowDefinitionId to target a different workflow.",
                     statusCode: StatusCodes.Status400BadRequest);
+
+            definitionId = definition.Id;
         }
 
         var version = await sender.Send(new GetLatestVersionQuery { DefinitionId = definitionId.Value }, ct);
@@ -154,9 +163,12 @@ public class TaskAssignmentConfigAdminEndpoints : ICarterModule
         WorkflowSchema? schema;
         try
         {
+            // Must use the engine's options, not bare PropertyNameCaseInsensitive: TransitionDefinition.Type
+            // is an enum stored as the string "Conditional", so without the JsonStringEnumConverter this
+            // throws and the picker silently degrades to "activity list unavailable".
             schema = JsonSerializer.Deserialize<WorkflowSchema>(
                 version.JsonSchema,
-                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                WorkflowDefinitionSeedHelper.EngineJsonOptions);
         }
         catch (JsonException)
         {

--- a/Modules/Workflow/Workflow/Services/Configuration/TaskConfigurationService.cs
+++ b/Modules/Workflow/Workflow/Services/Configuration/TaskConfigurationService.cs
@@ -113,7 +113,9 @@ public class TaskConfigurationService : ITaskConfigurationService
                 request.AdminPoolId,
                 request.EscalateToAdminPool,
                 request.AdditionalConfiguration != null ? JsonSerializer.Serialize(request.AdditionalConfiguration) : null,
-                request.IsActive);
+                request.IsActive,
+                request.TeamConstrained,
+                request.ExcludeAssigneesFrom != null ? JsonSerializer.Serialize(request.ExcludeAssigneesFrom) : null);
 
             _context.TaskAssignmentConfigurations.Add(entity);
             await _context.SaveChangesAsync(cancellationToken);
@@ -155,7 +157,9 @@ public class TaskConfigurationService : ITaskConfigurationService
                 request.AdminPoolId,
                 request.EscalateToAdminPool,
                 request.AdditionalConfiguration != null ? JsonSerializer.Serialize(request.AdditionalConfiguration) : null,
-                request.IsActive);
+                request.IsActive,
+                request.TeamConstrained,
+                request.ExcludeAssigneesFrom != null ? JsonSerializer.Serialize(request.ExcludeAssigneesFrom) : null);
 
             await _context.SaveChangesAsync(cancellationToken);
 
@@ -227,6 +231,8 @@ public class TaskConfigurationService : ITaskConfigurationService
             SpecificAssignee = entity.SpecificAssignee,
             AssigneeGroup = entity.AssigneeGroup,
             BankingSegment = entity.BankingSegment,
+            TeamConstrained = entity.TeamConstrained,
+            ExcludeAssigneesFrom = DeserializeOptionalList(entity.ExcludeAssigneesFrom),
             // NOTE: SupervisorId and ReplacementUserId removed - now handled by UserManagement mock data
             AdditionalConfiguration = DeserializeAdditionalConfiguration(entity.AdditionalConfiguration),
             IsActive = entity.IsActive,
@@ -247,6 +253,27 @@ public class TaskConfigurationService : ITaskConfigurationService
         {
             _logger.LogWarning("Failed to deserialize strategies JSON: {Json}", strategiesJson);
             return new List<string>();
+        }
+    }
+
+    /// <summary>
+    /// Nullable counterpart of <see cref="DeserializeStrategies"/>. Null is preserved (rather than
+    /// collapsed to an empty list) because null means "inherit the definition JSON" while an empty
+    /// array means "explicitly no exclusions".
+    /// </summary>
+    private List<string>? DeserializeOptionalList(string? json)
+    {
+        if (string.IsNullOrEmpty(json))
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<string>>(json);
+        }
+        catch (JsonException)
+        {
+            _logger.LogWarning("Failed to deserialize activity id list JSON: {Json}", json);
+            return null;
         }
     }
 

--- a/Modules/Workflow/Workflow/Tasks/Authorization/SegregationOfDutiesGuard.cs
+++ b/Modules/Workflow/Workflow/Tasks/Authorization/SegregationOfDutiesGuard.cs
@@ -1,0 +1,107 @@
+using Microsoft.EntityFrameworkCore;
+using Workflow.AssigneeSelection.Pipeline;
+using Workflow.Data;
+using Workflow.Services.Configuration;
+using Workflow.Workflow.Models;
+
+namespace Workflow.Tasks.Authorization;
+
+/// <summary>
+/// Enforces <c>excludeAssigneesFrom</c> for individuals taking a task, which the assignment pipeline
+/// cannot do for pool tasks.
+///
+/// <para>
+/// <see cref="AssigneeSelection.Pipeline.ExclusionFilter"/> removes excluded users from the candidate
+/// pool, which works when a specific person is selected. It has no effect on a <c>pool</c> assignment:
+/// <see cref="AssigneeSelection.Strategies.PoolAssigneeSelector"/> emits a <em>group</em> name and never
+/// consults the filtered candidate list, so every group member can still reach the task. This guard
+/// re-applies the rule at the moment an individual claims or opens it.
+/// </para>
+/// </summary>
+public interface ISegregationOfDutiesGuard
+{
+    /// <summary>
+    /// Returns the id of the activity that disqualifies <paramref name="username"/> from working
+    /// <paramref name="activityId"/>, or <c>null</c> when they are allowed.
+    /// </summary>
+    Task<string?> GetBlockingActivityAsync(
+        Guid workflowInstanceId,
+        string activityId,
+        string username,
+        CancellationToken cancellationToken = default);
+}
+
+public class SegregationOfDutiesGuard(
+    WorkflowDbContext dbContext,
+    ITaskConfigurationService configurationService,
+    ILogger<SegregationOfDutiesGuard> logger) : ISegregationOfDutiesGuard
+{
+    public async Task<string?> GetBlockingActivityAsync(
+        Guid workflowInstanceId,
+        string activityId,
+        string username,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(activityId))
+            return null;
+
+        var instance = await dbContext.WorkflowInstances
+            .Include(i => i.WorkflowDefinition)
+            .Include(i => i.ActivityExecutions)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(i => i.Id == workflowInstanceId, cancellationToken);
+
+        if (instance is null)
+            return null;
+
+        var excludeFrom = await ResolveExcludeAssigneesFromAsync(instance, activityId, cancellationToken);
+        if (excludeFrom.Count == 0)
+            return null;
+
+        // CompletedBy is the individual who actually finished the activity — the same identifier shape
+        // PreviousOwnerAssigneeSelector compares against. AssignedTo is not used: for a pool task it
+        // holds a group name, not a person.
+        var blocking = instance.ActivityExecutions
+            .Where(e => e.Status == ActivityExecutionStatus.Completed
+                        && !string.IsNullOrEmpty(e.CompletedBy)
+                        && excludeFrom.Contains(e.ActivityId)
+                        && string.Equals(e.CompletedBy, username, StringComparison.OrdinalIgnoreCase))
+            .Select(e => e.ActivityId)
+            .FirstOrDefault();
+
+        if (blocking is not null)
+            logger.LogInformation(
+                "Segregation of duties: {Username} completed {BlockingActivity} on instance {InstanceId} and cannot work {ActivityId}",
+                username, blocking, workflowInstanceId, activityId);
+
+        return blocking;
+    }
+
+    /// <summary>
+    /// Effective exclusion list, using the same precedence as the assignment pipeline: the DB override
+    /// wins when its column is set, otherwise the workflow definition JSON is the baseline.
+    /// </summary>
+    private async Task<HashSet<string>> ResolveExcludeAssigneesFromAsync(
+        WorkflowInstance instance,
+        string activityId,
+        CancellationToken cancellationToken)
+    {
+        var bankingSegment = instance.Variables.TryGetValue("bankingSegment", out var seg)
+            ? seg?.ToString()
+            : null;
+
+        var config = await configurationService.GetConfigurationAsync(
+            activityId,
+            instance.WorkflowDefinitionId.ToString(),
+            bankingSegment,
+            cancellationToken);
+
+        if (config?.ExcludeAssigneesFrom is { } fromDb)
+            return new HashSet<string>(fromDb, StringComparer.OrdinalIgnoreCase);
+
+        var properties = ActivityPropertiesExtractor.Extract(instance, activityId, logger);
+        var rules = ActivityAssignmentRules.Parse(properties, logger, activityId);
+
+        return new HashSet<string>(rules.ExcludeAssigneesFrom, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/Modules/Workflow/Workflow/Tasks/Features/ClaimTask/ClaimTaskCommandHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/ClaimTask/ClaimTaskCommandHandler.cs
@@ -17,7 +17,8 @@ public class ClaimTaskCommandHandler(
     IPublishEndpoint publishEndpoint,
     ILogger<ClaimTaskCommandHandler> logger,
     IUserGroupService userGroupService,
-    ITeamService teamService
+    ITeamService teamService,
+    ISegregationOfDutiesGuard segregationOfDutiesGuard
 ) : ICommandHandler<ClaimTaskCommand, ClaimTaskResult>
 {
     public async Task<ClaimTaskResult> Handle(ClaimTaskCommand command, CancellationToken cancellationToken)
@@ -43,6 +44,14 @@ public class ClaimTaskCommandHandler(
             currentUserService.CompanyId);
         if (!isPoolMember)
             return new ClaimTaskResult(false, ErrorMessage: "You are not a member of this pool");
+
+        // Segregation of duties: pool membership alone is not enough — a user who already completed an
+        // excluded upstream activity on this instance (e.g. checked the appraisal) cannot also take this one.
+        var blockingActivity = await segregationOfDutiesGuard.GetBlockingActivityAsync(
+            task.WorkflowInstanceId, task.ActivityId, username, cancellationToken);
+        if (blockingActivity is not null)
+            return new ClaimTaskResult(false,
+                ErrorMessage: "You already completed an earlier step on this appraisal and cannot take this task.");
 
         // Capture pool group before reassignment for notification
         var poolGroup = task.AssignedTo;

--- a/Modules/Workflow/Workflow/Tasks/Features/OpenTask/OpenTaskCommandHandler.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/OpenTask/OpenTaskCommandHandler.cs
@@ -16,7 +16,8 @@ public class OpenTaskCommandHandler(
     ISqlConnectionFactory connectionFactory,
     ILogger<OpenTaskCommandHandler> logger,
     IUserGroupService userGroupService,
-    ITeamService teamService
+    ITeamService teamService,
+    ISegregationOfDutiesGuard segregationOfDutiesGuard
 ) : ICommandHandler<OpenTaskCommand, OpenTaskResult>
 {
     public async Task<OpenTaskResult> Handle(OpenTaskCommand command, CancellationToken cancellationToken)
@@ -51,6 +52,19 @@ public class OpenTaskCommandHandler(
 
         if (!isOwner && !isPoolMember)
             return new OpenTaskResult(false, "You are not assigned to this task");
+
+        // Segregation of duties: a pool task is reachable by the whole group, so the exclusion the
+        // assignment pipeline could not apply (PoolAssigneeSelector emits a group, not a person) is
+        // enforced here. Claiming is not a prerequisite for opening, so guarding ClaimTask alone
+        // would be bypassable.
+        if (isPoolMember)
+        {
+            var blockingActivity = await segregationOfDutiesGuard.GetBlockingActivityAsync(
+                task.WorkflowInstanceId, task.ActivityId, username, cancellationToken);
+            if (blockingActivity is not null)
+                return new OpenTaskResult(false,
+                    "You already completed an earlier step on this appraisal and cannot work this task.");
+        }
 
         // For personal tasks: transition to InProgress on first open
         if (isOwner && task.TaskStatus != TaskStatus.InProgress)

--- a/Modules/Workflow/Workflow/Workflow/Infrastructure/Seed/WorkflowDefinitionSeedHelper.cs
+++ b/Modules/Workflow/Workflow/Workflow/Infrastructure/Seed/WorkflowDefinitionSeedHelper.cs
@@ -30,8 +30,14 @@ public static class WorkflowDefinitionSeedHelper
     /// The deserialization options the engine uses in
     /// <c>WorkflowPersistenceService.DeserializeWorkflowSchemaSecurely</c>. Kept identical here so the
     /// seeder validates the JSON exactly the way the runtime will read it.
+    /// <para>
+    /// Public so read-only consumers (e.g. the task-assignment admin activity picker) parse a stored
+    /// schema the same way. The <see cref="JsonStringEnumConverter"/> is load-bearing:
+    /// <c>TransitionDefinition.Type</c> is an enum and the stored JSON carries it as a string
+    /// (<c>"Conditional"</c>), so deserializing without it throws.
+    /// </para>
     /// </summary>
-    private static readonly JsonSerializerOptions EngineJsonOptions = new()
+    public static readonly JsonSerializerOptions EngineJsonOptions = new()
     {
         PropertyNameCaseInsensitive = true,
         MaxDepth = WorkflowEngineConstants.MaxJsonDeserializationDepth,

--- a/Modules/Workflow/Workflow/Workflow/Models/ActivityAssignmentRules.cs
+++ b/Modules/Workflow/Workflow/Workflow/Models/ActivityAssignmentRules.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Workflow.Workflow.Models;
 
 public record ActivityAssignmentRules(
@@ -5,4 +7,59 @@ public record ActivityAssignmentRules(
     List<string> ExcludeAssigneesFrom)
 {
     public static ActivityAssignmentRules Default => new(false, []);
+
+    /// <summary>
+    /// Reads the <c>assignmentRules</c> entry out of an activity's properties as parsed from the
+    /// workflow definition JSON. Returns <see cref="Default"/> when the entry is absent or malformed.
+    /// Shared by the assignment pipeline and the segregation-of-duties guard so the two cannot
+    /// disagree about what a definition says.
+    /// </summary>
+    public static ActivityAssignmentRules Parse(
+        IReadOnlyDictionary<string, object> properties,
+        ILogger? logger = null,
+        string? activityId = null)
+    {
+        if (!properties.TryGetValue("assignmentRules", out var rulesObj))
+            return Default;
+
+        try
+        {
+            if (rulesObj is JsonElement jsonElement)
+            {
+                var teamConstrained = false;
+                var excludeFrom = new List<string>();
+
+                if (jsonElement.TryGetProperty("teamConstrained", out var tc))
+                    teamConstrained = tc.GetBoolean();
+
+                if (jsonElement.TryGetProperty("excludeAssigneesFrom", out var ea) &&
+                    ea.ValueKind == JsonValueKind.Array)
+                    foreach (var item in ea.EnumerateArray())
+                    {
+                        var val = item.GetString();
+                        if (!string.IsNullOrEmpty(val))
+                            excludeFrom.Add(val);
+                    }
+
+                return new ActivityAssignmentRules(teamConstrained, excludeFrom);
+            }
+
+            if (rulesObj is Dictionary<string, object> dict)
+            {
+                var teamConstrained = dict.TryGetValue("teamConstrained", out var tc) && tc is true;
+                var excludeFrom = new List<string>();
+
+                if (dict.TryGetValue("excludeAssigneesFrom", out var ea) && ea is List<string> list)
+                    excludeFrom = list;
+
+                return new ActivityAssignmentRules(teamConstrained, excludeFrom);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "Failed to parse assignmentRules for {ActivityId}", activityId);
+        }
+
+        return Default;
+    }
 }

--- a/Modules/Workflow/Workflow/WorkflowModule.cs
+++ b/Modules/Workflow/Workflow/WorkflowModule.cs
@@ -28,6 +28,7 @@ using Workflow.FeeAppointmentApprovals.Infrastructure;
 using Workflow.Meetings.Application;
 using Workflow.Meetings.Configuration;
 using Appraisal.Contracts.Services;
+using Workflow.Tasks.Authorization;
 using Workflow.Tasks.Services;
 using WfIUserGroupService = global::Workflow.Services.Groups.IUserGroupService;
 using WfITeamService = global::Workflow.AssigneeSelection.Teams.ITeamService;
@@ -132,6 +133,7 @@ public static class WorkflowModule
         services.AddScoped<IWorkflowAuditService, WorkflowAuditService>();
         services.AddScoped<IWorkflowResilienceService, WorkflowResilienceService>();
         services.AddScoped<ITaskConfigurationService, TaskConfigurationService>();
+        services.AddScoped<ISegregationOfDutiesGuard, SegregationOfDutiesGuard>();
         services.AddScoped<ICompanyRoundRobinConfigService, CompanyRoundRobinConfigService>();
         services.AddScoped<IAutoAssignmentRuleService, AutoAssignmentRuleService>();
 

--- a/Tests/Unit/Workflow.Tests/AssigneeSelection/Pipeline/AssignmentContextBuilderTests.cs
+++ b/Tests/Unit/Workflow.Tests/AssigneeSelection/Pipeline/AssignmentContextBuilderTests.cs
@@ -58,6 +58,81 @@ public class AssignmentContextBuilderTests
         context.ExternalConfig.Should().BeNull();
     }
 
+    // ── assignmentRules precedence: DB override > JSON definition, per field ──
+
+    [Fact]
+    public async Task BuildAsync_DbTeamConstrainedFalse_OverridesJsonTrue()
+    {
+        // Arrange — JSON says team-constrained, the override forces it off (the whole-group pool case).
+        _configurationService
+            .GetConfigurationAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new TaskAssignmentConfigurationDto { TeamConstrained = false });
+
+        var context = CreatePipelineContext(
+            properties: new Dictionary<string, object>
+            {
+                ["assignmentRules"] = new Dictionary<string, object> { ["teamConstrained"] = true }
+            },
+            priorAssigneeId: "somchai");
+
+        // Act
+        await _sut.BuildAsync(context);
+
+        // Assert — constraint is off, so no team is derived from the previous assignee at all.
+        context.Rules.TeamConstrained.Should().BeFalse();
+        context.TeamId.Should().BeNullOrEmpty();
+        await _teamService.DidNotReceive().GetTeamForUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BuildAsync_DbTeamConstrainedNull_InheritsJsonValue()
+    {
+        // Arrange — an override row that does not touch TeamConstrained (every pre-existing row).
+        // Regression guard for the ordering: the config is loaded before the rules are built.
+        _configurationService
+            .GetConfigurationAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new TaskAssignmentConfigurationDto { TeamConstrained = null });
+
+        var context = CreatePipelineContext(
+            properties: new Dictionary<string, object>
+            {
+                ["assignmentRules"] = new Dictionary<string, object> { ["teamConstrained"] = true }
+            });
+
+        // Act
+        await _sut.BuildAsync(context);
+
+        // Assert — the JSON baseline survives.
+        context.Rules.TeamConstrained.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task BuildAsync_DbExcludeAssigneesFrom_OverridesJsonList()
+    {
+        // Arrange
+        _configurationService
+            .GetConfigurationAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new TaskAssignmentConfigurationDto
+            {
+                ExcludeAssigneesFrom = ["int-appraisal-check"]
+            });
+
+        var context = CreatePipelineContext(
+            properties: new Dictionary<string, object>
+            {
+                ["assignmentRules"] = new Dictionary<string, object>
+                {
+                    ["excludeAssigneesFrom"] = new List<string> { "some-other-activity" }
+                }
+            });
+
+        // Act
+        await _sut.BuildAsync(context);
+
+        // Assert
+        context.Rules.ExcludeAssigneesFrom.Should().BeEquivalentTo(["int-appraisal-check"]);
+    }
+
     [Fact]
     public async Task BuildAsync_TeamConstrainedWithTeamIdVariable_UsesExplicitVariable()
     {

--- a/Tests/Unit/Workflow.Tests/AssigneeSelection/PoolAssigneeSelectorTests.cs
+++ b/Tests/Unit/Workflow.Tests/AssigneeSelection/PoolAssigneeSelectorTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Workflow.AssigneeSelection.Core;
+using Workflow.AssigneeSelection.Strategies;
+using Workflow.AssigneeSelection.Teams;
+using Xunit;
+
+namespace Workflow.Tests.AssigneeSelection;
+
+public class PoolAssigneeSelectorTests
+{
+    private readonly PoolAssigneeSelector _sut =
+        new(Substitute.For<ILogger<PoolAssigneeSelector>>());
+
+    private static AssignmentContext CreateContext(
+        List<string>? userGroups = null,
+        string? teamId = null,
+        List<TeamMemberInfo>? candidatePool = null) => new()
+    {
+        WorkflowInstanceId = Guid.NewGuid(),
+        ActivityName = "int-appraisal-verification",
+        UserGroups = userGroups ?? ["IntAppraisalVerifier"],
+        TeamId = teamId,
+        CandidatePool = candidatePool
+    };
+
+    [Fact]
+    public async Task SelectAssignee_NoResolvedTeam_EmitsBareGroup()
+    {
+        // Arrange — the pool holds the whole group (no team constraint, or none derivable), each
+        // member carrying their own team. Nothing here identifies "the" team for the assignment.
+        var context = CreateContext(
+            teamId: null,
+            candidatePool:
+            [
+                new TeamMemberInfo("praset", "Praset", "BBBB-2222", ["IntAppraisalVerifier"]),
+                new TeamMemberInfo("somchai", "Somchai", "AAAA-1111", ["IntAppraisalVerifier"])
+            ]);
+
+        // Act
+        var result = await _sut.SelectAssigneeAsync(context);
+
+        // Assert — must NOT inherit the first candidate's team, which would hide the task from
+        // every other team in the group.
+        result.IsSuccess.Should().BeTrue();
+        result.AssigneeId.Should().Be("IntAppraisalVerifier");
+        result.Metadata!["AssignedType"].Should().Be("2");
+    }
+
+    [Fact]
+    public async Task SelectAssignee_ResolvedTeam_ScopesGroupToThatTeam()
+    {
+        // Arrange — the pipeline genuinely resolved a team (team-constrained activity).
+        var context = CreateContext(
+            teamId: "AAAA-1111",
+            candidatePool:
+            [
+                new TeamMemberInfo("somchai", "Somchai", "AAAA-1111", ["IntAppraisalVerifier"])
+            ]);
+
+        // Act
+        var result = await _sut.SelectAssigneeAsync(context);
+
+        // Assert — matches the "<group>:Team_<id>" shape PoolTaskAccess builds for callers.
+        result.IsSuccess.Should().BeTrue();
+        result.AssigneeId.Should().Be("IntAppraisalVerifier:Team_AAAA-1111");
+    }
+
+    [Fact]
+    public async Task SelectAssignee_NoUserGroups_Fails()
+    {
+        // Arrange — a pool assignment with no group is a misconfiguration; cascade to the next strategy.
+        var context = CreateContext(userGroups: []);
+
+        // Act
+        var result = await _sut.SelectAssigneeAsync(context);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("UserGroup");
+    }
+}

--- a/Tests/Unit/Workflow.Tests/Services/Configuration/ActivityPickerSchemaParsingTests.cs
+++ b/Tests/Unit/Workflow.Tests/Services/Configuration/ActivityPickerSchemaParsingTests.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+using FluentAssertions;
+using Workflow.Workflow.Infrastructure.Seed;
+using Workflow.Workflow.Schema;
+using Xunit;
+
+namespace Workflow.Tests.Services.Configuration;
+
+/// <summary>
+/// Pins the deserialization contract the task-assignment activity picker
+/// (<c>TaskAssignmentConfigAdminEndpoints.ListActivities</c>) depends on.
+///
+/// <para>
+/// The picker used to parse the stored schema with bare
+/// <c>new JsonSerializerOptions { PropertyNameCaseInsensitive = true }</c>. That throws on the real
+/// appraisal schema because <see cref="TransitionDefinition.Type"/> is an enum stored as the string
+/// <c>"Conditional"</c>, and the endpoint swallowed the exception into a 500 — which the admin page
+/// rendered as "Activity list unavailable".
+/// </para>
+/// </summary>
+public class ActivityPickerSchemaParsingTests
+{
+    private static string LoadAppraisalSchemaJson()
+    {
+        var fileJson = WorkflowDefinitionSeedHelper.LoadEmbeddedResource(
+            typeof(AppraisalWorkflowDefinitionSeeder).Assembly,
+            "Workflow.Workflow.Config.appraisal-workflow.json");
+
+        fileJson.Should().NotBeNull("the appraisal workflow JSON must be embedded in the Workflow assembly");
+
+        // Stored column holds the unwrapped schema, not the API envelope.
+        return WorkflowDefinitionSeedHelper.ExtractSchemaJson(fileJson!);
+    }
+
+    [Fact]
+    public void BareCaseInsensitiveOptions_Throw_OnStringBackedTransitionTypeEnum()
+    {
+        var schemaJson = LoadAppraisalSchemaJson();
+
+        var act = () => JsonSerializer.Deserialize<WorkflowSchema>(
+            schemaJson,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        // Documents exactly why the picker must not use these options.
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void EngineJsonOptions_ParseSchema_AndYieldTaskActivities()
+    {
+        var schemaJson = LoadAppraisalSchemaJson();
+
+        var schema = JsonSerializer.Deserialize<WorkflowSchema>(
+            schemaJson,
+            WorkflowDefinitionSeedHelper.EngineJsonOptions);
+
+        schema.Should().NotBeNull();
+
+        var pickerOptions = schema!.Activities
+            .Where(a => a.Type is ActivityTypes.TaskActivity or ActivityTypes.FanOutTaskActivity)
+            .Select(a => a.Id)
+            .ToList();
+
+        pickerOptions.Should().NotBeEmpty("the picker is empty otherwise and the admin page shows 'unavailable'");
+        pickerOptions.Should().Contain("int-appraisal-check");
+        pickerOptions.Should().Contain("int-appraisal-verification");
+    }
+}


### PR DESCRIPTION
> **Frontend counterpart:** immortalgky/collateral-appraisal-system-app#298
> **This PR must merge first** — the FE silently loses data otherwise. See below.

## What

Four related changes to *who can receive and claim a task*. They share `AssignmentContextBuilder`,
`ActivityAssignmentRules` and the `TaskAssignmentConfiguration` DTO, so they ship together.

### 1. Pool tasks stopped inheriting an arbitrary member's team

`PoolAssigneeSelector` branched on `CandidatePool` first and took `CandidatePool.First().TeamId` as
"the" team, emitting `<groups>:Team_<id>`. The pool is **unordered** and holds the whole group whenever
no team constraint applied — so an arbitrary member's team won, and the task became invisible to every
other team in the group.

It now branches on `UserGroups` first and appends `:Team_<id>` only when Stage 1 actually resolved a
team, carried on the new `AssignmentContext.TeamId` (populated in `AssignmentPipeline` from
`pipelineCtx.TeamId`). The literal `"Default"` group fallback is gone — no groups now yields a failure
result that cascades to the next strategy, rather than inventing a group name.

### 2. `assignmentRules` can be overridden per activity from the DB

Two nullable columns on `workflow.TaskAssignmentConfigurations`:

| Column | Type | Meaning |
|---|---|---|
| `TeamConstrained` | `bit` | `null` = inherit the definition JSON |
| `ExcludeAssigneesFrom` | `nvarchar(max)` | JSON array of activity ids; `null` = inherit |

`null` means inherit, so **every pre-existing row is behaviour-identical**. `MergeAssignmentRules`
applies the override per field via a `with` expression, and `DeserializeOptionalList` deliberately
preserves `null` (inherit) vs `[]` (explicitly none).

One ordering change worth noting in review: the DB-config load **moves ahead of** rules construction in
`AssignmentContextBuilder`, because team derivation reads `Rules.TeamConstrained` and the override may
flip it.

### 3. Segregation of duties is actually enforced

`ExclusionFilter` (pipeline Stage 2) only prunes the candidate list. For a `pool` assignment
`PoolAssigneeSelector` emits a *group name* and never reads that list — so anyone in the group,
**including the person who completed the excluded upstream activity**, could claim and open the task.

The new `SegregationOfDutiesGuard` resolves the effective `excludeAssigneesFrom` (DB override wins,
else definition JSON via `ActivityAssignmentRules.Parse`), then scans the instance's `Completed`
activity executions for `CompletedBy == username` (case-insensitive) and returns the blocking activity
id.

- `ClaimTask` rejects unconditionally.
- `OpenTask` rejects only for `isPoolMember` — **deliberate**: opening doesn't require claiming, so
  guarding claim alone was bypassable.

### 4. The admin activity picker was broken in every environment

`ListActivities` 400'd whenever `workflowDefinitionId` was omitted: it counted `ActiveOnly` definitions
and only worked when exactly one existed, which is never true — every environment has Quotation,
Document Followup, Fee Appointment Approval plus renamed `_bk*` backups, all left active. Now resolves
by name + highest version via `IWorkflowDefinitionRepository.GetLatestVersion`, the same path the
engine uses.

It also deserialized the schema with a bare `PropertyNameCaseInsensitive`, which throws on the real
appraisal schema because `TransitionDefinition.Type` is the enum stored as the string `"Conditional"` —
and the `catch (JsonException)` swallowed it, so the admin page just rendered "activity list
unavailable". Now uses `WorkflowDefinitionSeedHelper.EngineJsonOptions`, which required widening that
field from `private static readonly` to `public static readonly`.

## ⚠ Merge before the frontend PR

If the FE lands first, `POST`/`PUT` with `teamConstrained` / `excludeAssigneesFrom` against the old
DTOs **succeeds with 200 and silently drops both fields** — System.Text.Json ignores unknown members.
The admin sets a constraint, gets a success toast, reopens the row, and it's gone. Worse than a 400.

## Migration

`20260803025615_AddTeamConstrainedToTaskAssignmentConfig` — both columns nullable, non-breaking, `Down`
drops both.

This was **re-scaffolded** during the split. The original was generated at `20260802123825`, before
`main` was pulled, so it sorted *ahead* of the already-merged `20260802142111_AddCommitteeMajorityValue`
and left an inconsistent Designer chain. Regenerated against current `main`.

## Test

- [x] `dotnet build Modules/Workflow/Workflow` — 0 errors.
- [x] `dotnet test Tests/Unit/Workflow.Tests` — **964 passed**, 8 failed, 1 skipped. The 8 failures are
      **pre-existing on `main`** (verified: identical set and count on a baseline worktree —
      `PoolTaskAccessTests` ×2, `AppraisalCreatedIntegrationEventConsumerTests` ×4,
      `SubmitDocumentFollowupCommandHandlerTests`, `MeetingTests`). This branch adds 8 passing tests
      (956 → 964).
- [ ] `dotnet run --project Database/Database.csproj migrate`, then confirm both columns exist and the
      migration sorts after `20260802142111` in `__EFMigrationsHistory`.
- [ ] Set Team Constraint on one activity; confirm a pool task is visible only to the resolved team.
- [ ] Add an exclude activity; confirm the user who completed it is rejected on **both** claim and open.
- [ ] Call `ListActivities` with no `workflowDefinitionId` — should return activities, not 400.

## Notes

Split out of a large combined working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhV2jVwAfwgBu3JboaNnCC
