### PR TITLE
feat(admin): manage job schedules and Thai address masters from the UI

### DIFF
--- a/Bootstrapper/Api/Program.cs
+++ b/Bootstrapper/Api/Program.cs
@@ -17,6 +17,7 @@ using Shared.Data;
 using Shared.Data.Dapper;
 using Shared.Data.Outbox;
 using Shared.Logging;
+using Shared.Scheduling;
 using Shared.Security;
 using Integration.Application.EventHandlers.Outbound;
 using Appraisal.Application.EventHandlers;
@@ -63,6 +64,10 @@ var appraisalAssembly = typeof(AppraisalModule).Assembly;
 var integrationAssembly = typeof(IntegrationModule).Assembly;
 var commonAssembly = typeof(CommonModule).Assembly;
 var reportingAssembly = typeof(ReportingModule).Assembly;
+
+// Cross-module catalog of recurring jobs, populated by each UseModuleRecurringJobs<T>() below and
+// read by the job-schedule admin endpoints. Must be registered before those Use* calls run.
+builder.Services.AddJobScheduleRegistry();
 
 builder.Services.AddCarterWithAssemblies(apiAssembly, requestAssembly, authAssembly, notificationAssembly,
     parameterAssembly, documentAssembly, workflowAssembly, collateralAssembly, appraisalAssembly, integrationAssembly,

--- a/Database/Migration/Scripts/20260802120100_SeedData_JobScheduleAdmin.sql
+++ b/Database/Migration/Scripts/20260802120100_SeedData_JobScheduleAdmin.sql
@@ -1,0 +1,94 @@
+-- ============================================================
+-- JOB_SCHEDULE_MANAGE permission + Scheduled Jobs menu entry
+-- Schema: auth
+--
+-- The per-module {schema}.JobSchedules tables (cron / timezone / enabled for every
+-- Hangfire recurring job) had no API and no screen; changing a schedule meant
+-- hand-editing SQL and restarting. /admin/job-schedules now covers them.
+--
+-- AuthDataSeed.SeedPermissionsAsync IS additive, so the permission row itself
+-- appears on the next boot without help. Two things are NOT covered by the seeder:
+--
+--   1. SeedAdminRoleAsync is CREATE-ONLY -- it grants every permission only when
+--      the Admin role is first created. On an existing database a newly added
+--      permission never reaches Admin. Step 2 below does that.
+--   2. AuthDataSeed.UpsertTreeAsync is INSERT-ONLY for menu items. Step 3 adds
+--      the menu node to databases that already have the menu.
+--
+-- Both steps are written to work on a fresh database too: the migrate tool runs
+-- DbUp before the seeder, so on a fresh DB step 1 inserts the permission, step 2
+-- finds no Admin role yet and matches nothing (the seeder then grants it as part
+-- of the initial all-permissions grant), and step 3 inserts the menu row that the
+-- seeder subsequently finds already present.
+--
+-- Notes:
+--   * auth.MenuItems' PK column is MenuItemId; auth.Permissions' is PermissionId
+--     and its code column is PermissionCode (both remapped from the entity's Id/
+--     PermissionCode -- see PermissionConfiguration).
+--   * IconStyle 0 = Solid, Scope 0 = Main.
+--   * RolePermissions is a plain (RoleId, PermissionId) link table.
+--   * AspNetRoles lives in the auth schema.
+--   * Keep Database/Scripts/Maintenance/RestoreAllRolePermissions.sql in sync --
+--     it is the rebuild-from-scratch artifact for role grants.
+--   * MenuTreeCache ("auth:menu:full") has NO TTL, so RESTART THE API after this
+--     runs (every instance -- it is a per-node IMemoryCache).
+--
+-- Idempotent: every statement is guarded by a NOT EXISTS.
+-- ============================================================
+
+SET QUOTED_IDENTIFIER ON;
+SET ANSI_NULLS ON;
+GO
+
+-- ---------- 1. The permission ----------
+-- Mirrors the entry added to AuthDataSeed.SeedPermissionsAsync, so a database
+-- that is upgraded before the next boot is not left without it.
+INSERT INTO auth.Permissions (PermissionId, PermissionCode, DisplayName, [Description], Module, CreatedAt)
+SELECT NEWID(), N'JOB_SCHEDULE_MANAGE', N'Manage Scheduled Jobs',
+       N'Change the cron schedule, timezone, and enabled state of recurring background jobs',
+       N'Common', SYSDATETIME()
+WHERE NOT EXISTS (SELECT 1 FROM auth.Permissions WHERE PermissionCode = N'JOB_SCHEDULE_MANAGE');
+
+-- ---------- 2. Grant it to Admin ----------
+INSERT INTO auth.RolePermissions (RoleId, PermissionId)
+SELECT r.Id, p.PermissionId
+FROM auth.AspNetRoles r
+CROSS JOIN auth.Permissions p
+WHERE r.Name = N'Admin'
+  AND p.PermissionCode = N'JOB_SCHEDULE_MANAGE'
+  AND NOT EXISTS (
+      SELECT 1 FROM auth.RolePermissions rp
+      WHERE rp.RoleId = r.Id AND rp.PermissionId = p.PermissionId);
+
+-- ---------- 3. The menu node ----------
+-- Appended under the existing System container (main.system), after
+-- main.webhook-deliveries at SortOrder 30.
+DECLARE @JobSchedulesMenuId UNIQUEIDENTIFIER = '7C9E0104-4E1A-4C7B-9A01-4D2F5B6E0104';
+
+INSERT INTO auth.MenuItems
+    (MenuItemId, ItemKey, Scope, ParentId, [Path], IconName, IconStyle, IconColor,
+     SortOrder, ViewPermissionCode, ViewPermissionPrefix, EditPermissionCode, IsSystem, CreatedAt)
+SELECT @JobSchedulesMenuId, N'main.job-schedules', 0, p.MenuItemId, N'/admin/job-schedules',
+       N'clock', 0, N'text-slate-500', 40, N'JOB_SCHEDULE_MANAGE', NULL, N'JOB_SCHEDULE_MANAGE',
+       1, SYSDATETIME()
+FROM auth.MenuItems p
+WHERE p.ItemKey = N'main.system'
+  AND NOT EXISTS (SELECT 1 FROM auth.MenuItems m WHERE m.ItemKey = N'main.job-schedules');
+
+-- th and zh mirror English, matching AuthDataSeed.BuildTranslations for a node
+-- declared without an explicit LabelTh.
+INSERT INTO auth.MenuItemTranslations (MenuItemId, LanguageCode, Label, CreatedAt)
+SELECT m.MenuItemId, t.LanguageCode, t.Label, SYSDATETIME()
+FROM auth.MenuItems m
+CROSS APPLY (VALUES
+    (N'en', N'Scheduled Jobs'),
+    (N'th', N'Scheduled Jobs'),
+    (N'zh', N'Scheduled Jobs')
+) AS t(LanguageCode, Label)
+WHERE m.ItemKey = N'main.job-schedules'
+  AND NOT EXISTS (
+      SELECT 1 FROM auth.MenuItemTranslations x
+      WHERE x.MenuItemId = m.MenuItemId AND x.LanguageCode = t.LanguageCode);
+
+PRINT 'Job schedule admin: JOB_SCHEDULE_MANAGE permission granted to Admin, main.job-schedules menu added';
+GO

--- a/Database/Migration/Scripts/20260802120200_SeedData_AddressMasterAdmin.sql
+++ b/Database/Migration/Scripts/20260802120200_SeedData_AddressMasterAdmin.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- ADDRESS_MASTER_MANAGE permission + Address Masters menu entry
+-- Schema: auth
+--
+-- The Thai address masters (parameter.TitleProvinces/Districts/SubDistricts and the
+-- Dopa* equivalents) were seed-only: read endpoints existed, but there was no write
+-- path at all, so adding a missing province meant hand-written SQL.
+-- /admin/address-masters now maintains both hierarchies.
+--
+-- Same two seeder gaps as the job-schedule script:
+--   1. SeedAdminRoleAsync is CREATE-ONLY, so a newly added permission never reaches
+--      an existing Admin role. Step 2 grants it.
+--   2. UpsertTreeAsync is INSERT-ONLY for menu items. Step 3 adds the node.
+-- SeedPermissionsAsync IS additive, so step 1 is only needed for databases upgraded
+-- before the next boot.
+--
+-- Notes:
+--   * auth.Permissions PK is PermissionId; the code column is PermissionCode.
+--   * auth.MenuItems PK is MenuItemId. IconStyle 0 = Solid, Scope 0 = Main.
+--   * AspNetRoles lives in the auth schema.
+--   * Node is appended under main.business-rules at SortOrder 100, after
+--     main.system-configurations (90). No existing sibling moves.
+--   * Keep Database/Scripts/Maintenance/RestoreAllRolePermissions.sql in sync.
+--   * MenuTreeCache ("auth:menu:full") has NO TTL — RESTART THE API after this runs
+--     (every instance; it is a per-node IMemoryCache).
+--
+-- Idempotent: every statement is guarded by a NOT EXISTS.
+-- ============================================================
+
+SET QUOTED_IDENTIFIER ON;
+SET ANSI_NULLS ON;
+GO
+
+-- ---------- 1. The permission ----------
+INSERT INTO auth.Permissions (PermissionId, PermissionCode, DisplayName, [Description], Module, CreatedAt)
+SELECT NEWID(), N'ADDRESS_MASTER_MANAGE', N'Manage Address Masters',
+       N'Create, rename, and remove Title/DOPA provinces, districts, and sub-districts',
+       N'Common', SYSDATETIME()
+WHERE NOT EXISTS (SELECT 1 FROM auth.Permissions WHERE PermissionCode = N'ADDRESS_MASTER_MANAGE');
+
+-- ---------- 2. Grant it to Admin ----------
+INSERT INTO auth.RolePermissions (RoleId, PermissionId)
+SELECT r.Id, p.PermissionId
+FROM auth.AspNetRoles r
+CROSS JOIN auth.Permissions p
+WHERE r.Name = N'Admin'
+  AND p.PermissionCode = N'ADDRESS_MASTER_MANAGE'
+  AND NOT EXISTS (
+      SELECT 1 FROM auth.RolePermissions rp
+      WHERE rp.RoleId = r.Id AND rp.PermissionId = p.PermissionId);
+
+-- ---------- 3. The menu node ----------
+DECLARE @AddressMenuId UNIQUEIDENTIFIER = '7C9E0105-4E1A-4C7B-9A01-4D2F5B6E0105';
+
+INSERT INTO auth.MenuItems
+    (MenuItemId, ItemKey, Scope, ParentId, [Path], IconName, IconStyle, IconColor,
+     SortOrder, ViewPermissionCode, ViewPermissionPrefix, EditPermissionCode, IsSystem, CreatedAt)
+SELECT @AddressMenuId, N'main.address-masters', 0, p.MenuItemId, N'/admin/address-masters',
+       N'map-location-dot', 0, N'text-rose-500', 100, N'ADDRESS_MASTER_MANAGE', NULL,
+       N'ADDRESS_MASTER_MANAGE', 1, SYSDATETIME()
+FROM auth.MenuItems p
+WHERE p.ItemKey = N'main.business-rules'
+  AND NOT EXISTS (SELECT 1 FROM auth.MenuItems m WHERE m.ItemKey = N'main.address-masters');
+
+-- th and zh mirror English, matching AuthDataSeed.BuildTranslations for a node
+-- declared without an explicit LabelTh.
+INSERT INTO auth.MenuItemTranslations (MenuItemId, LanguageCode, Label, CreatedAt)
+SELECT m.MenuItemId, t.LanguageCode, t.Label, SYSDATETIME()
+FROM auth.MenuItems m
+CROSS APPLY (VALUES
+    (N'en', N'Address Masters'),
+    (N'th', N'Address Masters'),
+    (N'zh', N'Address Masters')
+) AS t(LanguageCode, Label)
+WHERE m.ItemKey = N'main.address-masters'
+  AND NOT EXISTS (
+      SELECT 1 FROM auth.MenuItemTranslations x
+      WHERE x.MenuItemId = m.MenuItemId AND x.LanguageCode = t.LanguageCode);
+
+PRINT 'Address master admin: ADDRESS_MASTER_MANAGE granted to Admin, main.address-masters menu added';
+GO

--- a/Modules/Auth/Auth/AuthModule.cs
+++ b/Modules/Auth/Auth/AuthModule.cs
@@ -333,6 +333,8 @@ public static class AuthModule
             .AddUserPermissionPrefixPolicy("task-monitor.reassign", "TASK_MONITOR_REASSIGN")
             .AddUserPermissionPolicy("history-search.view", "HISTORY_SEARCH_VIEW")
             .AddUserPermissionPolicy("sla-config.manage", "SLA_CONFIG_MANAGE")
+            .AddUserPermissionPolicy("job-schedule.manage", "JOB_SCHEDULE_MANAGE")
+            .AddUserPermissionPolicy("address-master.manage", "ADDRESS_MASTER_MANAGE")
             .AddUserPermissionPolicy("reappraisal.generate-test-file", "REAPPRAISAL_GENERATE_TEST_FILE")
             // ── Monitoring feature policies (FSD §2.6.8) ──────────────────────────
             // Any-prefix policies: caller needs ANY permission with the given prefix.

--- a/Modules/Auth/Auth/Infrastructure/Seed/AuthDataSeed.cs
+++ b/Modules/Auth/Auth/Infrastructure/Seed/AuthDataSeed.cs
@@ -227,22 +227,15 @@ public class AuthDataSeed(
                 throw new InvalidOperationException(
                     $"Failed to create {roleName} role: {string.Join(", ", createResult.Errors.Select(e => e.Description))}");
         }
-        else if (await dbContext.Set<RolePermission>().AnyAsync(rp => rp.RoleId == role.Id))
+        else
         {
-            // The role exists AND already carries a permission set, so that set belongs to the
-            // admin. Re-adding the seed permissions here would silently restore anything they
-            // had deliberately revoked via /admin/roles on the next app restart.
+            // CREATE-ONLY: the role already exists, so its permission set belongs to the admin.
+            // Re-adding the seed permissions here would silently restore anything an admin had
+            // deliberately revoked via /admin/roles on the next app restart.
             // To grant a NEW permission to an existing role in a later release, write a one-off
             // script in Database/Migration/Scripts/ — the same convention UpsertTreeAsync uses.
             return;
         }
-
-        // Falling through means the role exists but has never been granted anything, which only
-        // happens when something outside this seeder created it — as
-        // 20260323201000_SeedData_WorkflowUsersAndRoles.sql did before it was retired, leaving
-        // 10 roles permission-less on any database built while the migrator ran ahead of the
-        // API. Grant the seed set once so such a database repairs itself on the next boot; the
-        // guard above stops a second pass (AddRangeAsync below has no duplicate check).
 
         var permissionIds = await dbContext.Permissions
             .AsNoTracking()
@@ -985,7 +978,15 @@ public class AuthDataSeed(
                 "View the user/role/permission/group/team change history", "Auth"),
             // Company maintenance
             ("COMPANY_MANAGE", "Manage Companies",
-                "Create, update, and delete external appraisal companies", "Auth")
+                "Create, update, and delete external appraisal companies", "Auth"),
+            // Recurring background job schedules (per-module {schema}.JobSchedules)
+            ("JOB_SCHEDULE_MANAGE", "Manage Scheduled Jobs",
+                "Change the cron schedule, timezone, and enabled state of recurring background jobs",
+                "Common"),
+            // Thai address masters — Title (Department of Lands) and DOPA geocode hierarchies
+            ("ADDRESS_MASTER_MANAGE", "Manage Address Masters",
+                "Create, rename, and remove Title/DOPA provinces, districts, and sub-districts",
+                "Common")
         };
 
         foreach (var (code, displayName, description, module) in seedPermissions)
@@ -1128,18 +1129,14 @@ public class AuthDataSeed(
                 throw new InvalidOperationException(
                     $"Failed to create Admin role: {string.Join(", ", createResult.Errors.Select(e => e.Description))}");
         }
-        else if (await dbContext.Set<RolePermission>().AnyAsync(rp => rp.RoleId == adminRole.Id))
+        else
         {
-            // Same reasoning as SeedRoleWithPermissionsAsync: once the Admin role exists and has
-            // a permission set, that set is the admin's to manage. Re-granting every permission
-            // on each boot would undo any deliberate revocation. New permissions added in a later
+            // CREATE-ONLY, same reasoning as SeedRoleWithPermissionsAsync: once the Admin role
+            // exists its permission set is the admin's to manage. Re-granting every permission on
+            // each boot would undo any deliberate revocation. New permissions added in a later
             // release reach Admin via a one-off script in Database/Migration/Scripts/.
             return;
         }
-
-        // An Admin role with no permissions at all can only have been created outside this
-        // seeder, and one that cannot administer anything locks everybody out — so grant the
-        // full set rather than leaving it empty.
 
         var allPermissionIds = await dbContext.Permissions
             .AsNoTracking()

--- a/Modules/Auth/Auth/Infrastructure/Seed/MenuSeedData.cs
+++ b/Modules/Auth/Auth/Infrastructure/Seed/MenuSeedData.cs
@@ -211,6 +211,8 @@ public static class MenuSeedData
                 new("main.appointment-approval-rule", "Appointment Approval Rule", "calendar-xmark", IconStyle.Solid, "text-orange-500", "/admin/appointment-approval-rule", "APPOINTMENT_APPROVAL_CONFIG", "APPOINTMENT_APPROVAL_CONFIG"),
                 new("main.evaluation-config", "Evaluation Criteria Config", "star-half-stroke", IconStyle.Solid, "text-orange-500", "/admin/evaluation-config", "EVALUATION_CONFIG_MANAGE", "EVALUATION_CONFIG_MANAGE"),
                 new("main.sla-config", "OLA / SLA Targets", "stopwatch", IconStyle.Solid, "text-orange-500", "/admin/sla-config", "SLA_CONFIG_MANAGE", "SLA_CONFIG_MANAGE"),
+                // Title (Land Dept) and DOPA geocode hierarchies — two separate datasets.
+                new("main.address-masters", "Address Masters", "map-location-dot", IconStyle.Solid, "text-rose-500", "/admin/address-masters", "ADDRESS_MASTER_MANAGE", "ADDRESS_MASTER_MANAGE"),
             }, LabelTh: "กฎเกณฑ์ธุรกิจ"),
 
         // Gate USER_MANAGE: held by Admin + IntAdmin + ExtAdmin. OAuth / Audit Log / Access
@@ -251,6 +253,7 @@ public static class MenuSeedData
                 new("main.logs", "Application Logs", "file-lines", IconStyle.Solid, "text-slate-500", "/admin/logs", "LOGS_VIEW", null),
                 new("main.webhook-subscriptions", "Webhook Subscriptions", "plug-circle-bolt", IconStyle.Solid, "text-slate-500", "/admin/webhook-subscriptions", "WEBHOOK_SUBSCRIPTIONS_MANAGE", null),
                 new("main.webhook-deliveries", "Webhook Deliveries", "satellite-dish", IconStyle.Solid, "text-slate-500", "/admin/webhook-deliveries", "WEBHOOK_DELIVERIES_VIEW", null),
+                new("main.job-schedules", "Scheduled Jobs", "clock", IconStyle.Solid, "text-slate-500", "/admin/job-schedules", "JOB_SCHEDULE_MANAGE", "JOB_SCHEDULE_MANAGE"),
             }, LabelTh: "ระบบ"),
     };
 

--- a/Modules/Common/Common/Application/Features/JobSchedules/JobScheduleEndpoints.cs
+++ b/Modules/Common/Common/Application/Features/JobSchedules/JobScheduleEndpoints.cs
@@ -1,0 +1,171 @@
+using Carter;
+using Hangfire;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Shared.Scheduling;
+using Shared.Time;
+
+namespace Common.Application.Features.JobSchedules;
+
+/// <summary>
+/// Admin maintenance for the per-module <c>{schema}.JobSchedules</c> tables — the rows that override
+/// a Hangfire recurring job's cron, timezone and enabled state.
+///
+/// Rows live in nine module schemas, so this reads and writes through
+/// <see cref="IJobScheduleRegistry"/> rather than a DbContext of its own. The registry is populated
+/// at startup by <c>UseModuleRecurringJobs&lt;TContext&gt;</c>, so a job absent from the code catalog
+/// is not listed here — matching the startup behaviour, which ignores orphan rows.
+///
+/// Saving re-registers the job with Hangfire immediately: no restart is required.
+///
+/// Changing a cron affects every module's background processing, so this is gated on its own
+/// JOB_SCHEDULE_MANAGE permission rather than being login-only.
+/// </summary>
+public class JobScheduleEndpoints : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/admin/job-schedules")
+            .WithTags("JobSchedules")
+            .RequireAuthorization("job-schedule.manage");
+
+        group.MapGet("/", List)
+            .WithName("GetJobSchedules")
+            .Produces<List<JobScheduleDto>>()
+            .WithSummary("List every administrable recurring job across all modules");
+
+        group.MapPut("/{jobId}", Update)
+            .WithName("UpdateJobSchedule")
+            .Produces<JobScheduleDto>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Update a recurring job's cron, timezone, or enabled state");
+    }
+
+    private static async Task<IResult> List(
+        IJobScheduleRegistry registry,
+        IServiceProvider services,
+        IDateTimeProvider clock,
+        CancellationToken ct)
+    {
+        var result = new List<JobScheduleDto>();
+
+        foreach (var registration in registry.All)
+        {
+            var row = await registration.LoadAsync(services, ct);
+            result.Add(ToDto(registration, row, clock));
+        }
+
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> Update(
+        string jobId,
+        UpdateJobScheduleRequest request,
+        IJobScheduleRegistry registry,
+        IRecurringJobManager manager,
+        IServiceProvider services,
+        IDateTimeProvider clock,
+        CancellationToken ct)
+    {
+        var registration = registry.Find(jobId);
+        if (registration is null) return Results.NotFound();
+
+        if (string.IsNullOrWhiteSpace(request.CronExpression))
+            return Problem("Cron expression is required.");
+
+        // Resolve the timezone up front: an unknown id would otherwise be silently swallowed at
+        // startup (UseModuleRecurringJobs falls back to the app default and logs a warning).
+        var timeZone = clock.ApplicationTimeZone;
+        if (!string.IsNullOrWhiteSpace(request.TimeZoneId)
+            && !TimeZoneInfo.TryFindSystemTimeZoneById(request.TimeZoneId, out timeZone!))
+        {
+            return Problem($"Unknown time zone id '{request.TimeZoneId}'.");
+        }
+
+        var cron = request.CronExpression.Trim();
+
+        // Apply to Hangfire BEFORE persisting. AddOrUpdate parses the cron first and throws
+        // ArgumentException before touching storage, so an invalid expression leaves nothing
+        // changed and we can reject it cleanly. (If the save below were to fail after a successful
+        // registration, the next startup re-reads the DB row and restores the stored schedule.)
+        try
+        {
+            if (request.IsEnabled)
+                registration.Definition.Register(manager, cron, new RecurringJobOptions { TimeZone = timeZone });
+            else
+                manager.RemoveIfExists(jobId);
+        }
+        catch (ArgumentException ex)
+        {
+            return Problem($"Invalid cron expression '{cron}': {ex.Message}");
+        }
+
+        var updated = await registration.UpdateAsync(
+            services,
+            row =>
+            {
+                row.UpdateSchedule(cron, request.TimeZoneId);
+                row.SetEnabled(request.IsEnabled);
+            },
+            ct);
+
+        // The row is seeded at startup for every code-defined job, so a miss means the table was
+        // cleared out from under us rather than a bad request.
+        if (updated is null)
+            return Results.NotFound();
+
+        return Results.Ok(ToDto(registration, updated, clock));
+    }
+
+    private static IResult Problem(string detail) =>
+        Results.Problem(detail: detail, statusCode: StatusCodes.Status400BadRequest);
+
+    private static JobScheduleDto ToDto(
+        JobScheduleRegistration registration,
+        JobSchedule? row,
+        IDateTimeProvider clock)
+    {
+        // Mirrors the resolution in UseModuleRecurringJobs: the row wins, the code default is the
+        // fallback for a missing row.
+        var effectiveCron = row?.CronExpression ?? registration.Definition.DefaultCron;
+
+        return new JobScheduleDto(
+            registration.JobId,
+            registration.Module,
+            effectiveCron,
+            registration.Definition.DefaultCron,
+            IsOverridden: !string.Equals(
+                effectiveCron, registration.Definition.DefaultCron, StringComparison.Ordinal),
+            TimeZoneId: row?.TimeZoneId,
+            EffectiveTimeZoneId: row?.TimeZoneId ?? clock.ApplicationTimeZone.Id,
+            IsEnabled: row?.IsEnabled ?? true,
+            Description: row?.Description ?? registration.Definition.Description,
+            HasRow: row is not null);
+    }
+}
+
+// ── DTOs ──────────────────────────────────────────────────────────────────────
+
+/// <param name="EffectiveCron">The cron actually in force — the stored row, else the code default.</param>
+/// <param name="IsOverridden">True when the stored cron differs from the code default.</param>
+/// <param name="TimeZoneId">The stored override; null means "use the application timezone".</param>
+/// <param name="HasRow">False when no override row exists yet (startup seeds one per known job).</param>
+public record JobScheduleDto(
+    string JobId,
+    string Module,
+    string EffectiveCron,
+    string DefaultCron,
+    bool IsOverridden,
+    string? TimeZoneId,
+    string EffectiveTimeZoneId,
+    bool IsEnabled,
+    string? Description,
+    bool HasRow);
+
+public record UpdateJobScheduleRequest(
+    string CronExpression,
+    string? TimeZoneId,
+    bool IsEnabled);

--- a/Modules/Parameter/Parameter/Addresses/Features/AdminAddresses/AddressAdminEndpoints.cs
+++ b/Modules/Parameter/Parameter/Addresses/Features/AdminAddresses/AddressAdminEndpoints.cs
@@ -1,0 +1,442 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Parameter.Addresses.Models;
+using Parameter.Data;
+
+namespace Parameter.Addresses.Features.AdminAddresses;
+
+/// <summary>
+/// Maintenance for the two Thai address masters, which until now were seed-only (read endpoints
+/// <c>/parameters/addresses/title</c> and <c>/parameters/addresses/dopa</c>, no write path at all).
+///
+/// Title (Department of Lands) and DOPA (civil registration) are SEPARATE datasets that have
+/// diverged: Title carries historical and merged provinces (พระนคร, ธนบุรี, กรุงเก่า), non-numeric
+/// codes such as "A0"/"A1"/"A2", and nullable postcodes. They therefore share a route shape and a
+/// DTO but never share rows — <c>{dataset}</c> selects which pair of tables is touched.
+///
+/// The flat read endpoints return every sub-district in one payload, which suits dropdowns but not
+/// an editor over ~11k rows, so this exposes the hierarchy one level at a time instead.
+///
+/// Codes are natural keys referenced by child rows and by collateral (which stores the geocode, not
+/// the name), so a code is fixed at creation; renaming and reparenting are the supported edits.
+/// </summary>
+public class AddressAdminEndpoints : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/parameters/addresses/{dataset}")
+            .WithTags("Parameter")
+            .RequireAuthorization("address-master.manage");
+
+        group.MapGet("/provinces", GetProvinces);
+        group.MapPost("/provinces", CreateProvince);
+        group.MapPut("/provinces/{code}", UpdateProvince);
+        group.MapDelete("/provinces/{code}", DeleteProvince);
+
+        group.MapGet("/districts", GetDistricts);
+        group.MapPost("/districts", CreateDistrict);
+        group.MapPut("/districts/{code}", UpdateDistrict);
+        group.MapDelete("/districts/{code}", DeleteDistrict);
+
+        group.MapGet("/sub-districts", GetSubDistricts);
+        group.MapPost("/sub-districts", CreateSubDistrict);
+        group.MapPut("/sub-districts/{code}", UpdateSubDistrict);
+        group.MapDelete("/sub-districts/{code}", DeleteSubDistrict);
+    }
+
+    // ── Provinces ─────────────────────────────────────────────────────────────
+
+    private static async Task<IResult> GetProvinces(
+        string dataset, ParameterDbContext db, CancellationToken ct)
+    {
+        if (!TryParseDataset(dataset, out var isTitle)) return UnknownDataset(dataset);
+
+        // Child counts drive the delete guard in the UI, so return them with the list rather than
+        // making the screen probe each province.
+        var rows = isTitle
+            ? await db.TitleProvinces.AsNoTracking()
+                .Select(p => new ProvinceDto(p.Code, p.NameTh, p.NameEn, p.Districts.Count))
+                .ToListAsync(ct)
+            : await db.DopaProvinces.AsNoTracking()
+                .Select(p => new ProvinceDto(p.Code, p.NameTh, p.NameEn, p.Districts.Count))
+                .ToListAsync(ct);
+
+        return Results.Ok(rows.OrderBy(p => p.Code, StringComparer.Ordinal).ToList());
+    }
+
+    private static async Task<IResult> CreateProvince(
+        string dataset, SaveProvinceRequest request, ParameterDbContext db, CancellationToken ct)
+    {
+        if (!TryParseDataset(dataset, out var isTitle)) return UnknownDataset(dataset);
+
+        return await Guarded(async () =>
+        {
+            var code = AddressRules.RequireCode(
+                request.Code, nameof(request.Code), AddressRules.ProvinceCodeLength);
+
+            if (await ProvinceExists(db, isTitle, code, ct))
+                return Conflict($"Province code '{code}' already exists in the {dataset} dataset.");
+
+            if (isTitle) db.TitleProvinces.Add(TitleProvince.Create(code, request.NameTh, request.NameEn));
+            else db.DopaProvinces.Add(DopaProvince.Create(code, request.NameTh, request.NameEn));
+
+            await db.SaveChangesAsync(ct);
+            return Results.Created($"/parameters/addresses/{dataset}/provinces/{code}",
+                new ProvinceDto(code, request.NameTh.Trim(), request.NameEn.Trim(), 0));
+        });
+    }
+
+    private static async Task<IResult> UpdateProvince(
+        string dataset, string code, SaveProvinceRequest request,
+        ParameterDbContext db, CancellationToken ct)
+    {
+        if (!TryParseDataset(dataset, out var isTitle)) return UnknownDataset(dataset);
+
+        return await Guarded(async () =>
+        {
+            ProvinceBase? entity = isTitle
+                ? await db.TitleProvinces.FirstOrDefaultAsync(p => p.Code == code, ct)
+                : await db.DopaProvinces.FirstOrDefaultAsync(p => p.Code == code, ct);
+            if (entity is null) return Results.NotFound();
+
+            entity.Rename(request.NameTh, request.NameEn);
+            await db.SaveChangesAsync(ct);
+            return Results.Ok(new ProvinceDto(entity.Code, entity.NameTh, entity.NameEn, 0));
+        });
+    }
+
+    private static async Task<IResult> DeleteProvince(
+        string dataset, string code, ParameterDbContext db, CancellationToken ct)
+    {
+        if (!TryParseDataset(dataset, out var isTitle)) return UnknownDataset(dataset);
+
+        // Districts carry ProvinceCode, and collateral rows store the geocode itself, so a province
+        // that still has children is never safe to remove.
+        var childCount = isTitle
+            ? await db.TitleDistricts.CountAsync(d => d.ProvinceCode == code, ct)
+            : await db.DopaDistricts.CountAsync(d => d.ProvinceCode == code, ct);
+        if (childCount > 0)
+            return InUse($"Province '{code}' still has {childCount} district(s); delete or move those first.");
+
+        if (isTitle)
+        {
+            var entity = await db.TitleProvinces.FirstOrDefaultAsync(p => p.Code == code, ct);
+            if (entity is null) return Results.NotFound();
+            db.TitleProvinces.Remove(entity);
+        }
+        else
+        {
+            var entity = await db.DopaProvinces.FirstOrDefaultAsync(p => p.Code == code, ct);
+            if (entity is null) return Results.NotFound();
+            db.DopaProvinces.Remove(entity);
+        }
+
+        await db.SaveChangesAsync(ct);
+        return Results.NoContent();
+    }
+
+    // ── Districts ─────────────────────────────────────────────────────────────
+
+    private static async Task<IResult> GetDistricts(
+        string dataset, string? provinceCode, ParameterDbContext db, CancellationToken ct)
+    {
+        if (!TryParseDataset(dataset, out var isTitle)) return UnknownDataset(dataset);
+        if (string.IsNullOrWhiteSpace(provinceCode))
+            return BadRequest("provinceCode is required.");
+
+        var rows = isTitle
+            ? await db.TitleDistricts.AsNoTracking()
+                .Where(d => d.ProvinceCode == provinceCode)
+                .Select(d => new DistrictDto(
+                    d.Code, d.NameTh, d.NameEn, d.ProvinceCode, d.SubDistricts.Count))
+                .ToListAsync(ct)
+            : await db.DopaDistricts.AsNoTracking()
+                .Where(d => d.ProvinceCode == provinceCode)
+                .Select(d => new DistrictDto(
+                    d.Code, d.NameTh, d.NameEn, d.ProvinceCode, d.SubDistricts.Count))
+                .ToListAsync(ct);
+
+        return Results.Ok(rows.OrderBy(d => d.Code, StringComparer.Ordinal).ToList());
+    }
+
+    private static async Task<IResult> CreateDistrict(
+        string dataset, SaveDistrictRequest request, ParameterDbContext db, CancellationToken ct)
+    {
+        if (!TryParseDataset(dataset, out var isTitle)) return UnknownDataset(dataset);
+
+        return await Guarded(async () =>
+        {
+            var code = AddressRules.RequireCode(
+                request.Code, nameof(request.Code), AddressRules.DistrictCodeLength);
+            // Normalise the parent code up front so the lookup, the entity and the response all
+            // agree — the entity trims internally, so checking the raw value made " 10" miss.
+            var provinceCode = AddressRules.RequireCode(
+                request.ProvinceCode, nameof(request.ProvinceCode), AddressRules.ProvinceCodeLength);
+
+            if (!await ProvinceExists(db, isTitle, provinceCode, ct))
+                return BadRequest($"Province '{provinceCode}' does not exist in the {dataset} dataset.");
+
+            var exists = isTitle
+                ? await db.TitleDistricts.AnyAsync(d => d.Code == code, ct)
+                : await db.DopaDistricts.AnyAsync(d => d.Code == code, ct);
+            if (exists)
+                return Conflict($"District code '{code}' already exists in the {dataset} dataset.");
+
+            if (isTitle)
+                db.TitleDistricts.Add(TitleDistrict.Create(
+                    code, request.NameTh, request.NameEn, provinceCode));
+            else
+                db.DopaDistricts.Add(DopaDistrict.Create(
+                    code, request.NameTh, request.NameEn, provinceCode));
+
+            await db.SaveChangesAsync(ct);
+            return Results.Created($"/parameters/addresses/{dataset}/districts/{code}",
+                new DistrictDto(code, request.NameTh.Trim(), request.NameEn.Trim(),
+                    provinceCode, 0));
+        });
+    }
+
+    private static async Task<IResult> UpdateDistrict(
+        string dataset, string code, SaveDistrictRequest request,
+        ParameterDbContext db, CancellationToken ct)
+    {
+        if (!TryParseDataset(dataset, out var isTitle)) return UnknownDataset(dataset);
+
+        return await Guarded(async () =>
+        {
+            DistrictBase? entity = isTitle
+                ? await db.TitleDistricts.FirstOrDefaultAsync(d => d.Code == code, ct)
+                : await db.DopaDistricts.FirstOrDefaultAsync(d => d.Code == code, ct);
+            if (entity is null) return Results.NotFound();
+
+            var provinceCode = AddressRules.RequireCode(
+                request.ProvinceCode, nameof(request.ProvinceCode), AddressRules.ProvinceCodeLength);
+
+            if (!await ProvinceExists(db, isTitle, provinceCode, ct))
+                return BadRequest($"Province '{provinceCode}' does not exist in the {dataset} dataset.");
+
+            entity.Rename(request.NameTh, request.NameEn);
+            entity.MoveToProvince(provinceCode);
+            await db.SaveChangesAsync(ct);
+            return Results.Ok(new DistrictDto(
+                entity.Code, entity.NameTh, entity.NameEn, entity.ProvinceCode, 0));
+        });
+    }
+
+    private static async Task<IResult> DeleteDistrict(
+        string dataset, string code, ParameterDbContext db, CancellationToken ct)
+    {
+        if (!TryParseDataset(dataset, out var isTitle)) return UnknownDataset(dataset);
+
+        var childCount = isTitle
+            ? await db.TitleSubDistricts.CountAsync(s => s.DistrictCode == code, ct)
+            : await db.DopaSubDistricts.CountAsync(s => s.DistrictCode == code, ct);
+        if (childCount > 0)
+            return InUse($"District '{code}' still has {childCount} sub-district(s); delete or move those first.");
+
+        if (isTitle)
+        {
+            var entity = await db.TitleDistricts.FirstOrDefaultAsync(d => d.Code == code, ct);
+            if (entity is null) return Results.NotFound();
+            db.TitleDistricts.Remove(entity);
+        }
+        else
+        {
+            var entity = await db.DopaDistricts.FirstOrDefaultAsync(d => d.Code == code, ct);
+            if (entity is null) return Results.NotFound();
+            db.DopaDistricts.Remove(entity);
+        }
+
+        await db.SaveChangesAsync(ct);
+        return Results.NoContent();
+    }
+
+    // ── Sub-districts ─────────────────────────────────────────────────────────
+
+    private static async Task<IResult> GetSubDistricts(
+        string dataset, string? districtCode, ParameterDbContext db, CancellationToken ct)
+    {
+        if (!TryParseDataset(dataset, out var isTitle)) return UnknownDataset(dataset);
+        if (string.IsNullOrWhiteSpace(districtCode))
+            return BadRequest("districtCode is required.");
+
+        var rows = isTitle
+            ? await db.TitleSubDistricts.AsNoTracking()
+                .Where(s => s.DistrictCode == districtCode)
+                .Select(s => new SubDistrictDto(
+                    s.Code, s.NameTh, s.NameEn, s.DistrictCode, s.Postcode))
+                .ToListAsync(ct)
+            : await db.DopaSubDistricts.AsNoTracking()
+                .Where(s => s.DistrictCode == districtCode)
+                .Select(s => new SubDistrictDto(
+                    s.Code, s.NameTh, s.NameEn, s.DistrictCode, s.Postcode))
+                .ToListAsync(ct);
+
+        return Results.Ok(rows.OrderBy(s => s.Code, StringComparer.Ordinal).ToList());
+    }
+
+    private static async Task<IResult> CreateSubDistrict(
+        string dataset, SaveSubDistrictRequest request, ParameterDbContext db, CancellationToken ct)
+    {
+        if (!TryParseDataset(dataset, out var isTitle)) return UnknownDataset(dataset);
+
+        return await Guarded(async () =>
+        {
+            var code = AddressRules.RequireCode(
+                request.Code, nameof(request.Code), AddressRules.SubDistrictCodeLength);
+            var districtCode = AddressRules.RequireCode(
+                request.DistrictCode, nameof(request.DistrictCode), AddressRules.DistrictCodeLength);
+
+            if (!await DistrictExists(db, isTitle, districtCode, ct))
+                return BadRequest($"District '{districtCode}' does not exist in the {dataset} dataset.");
+
+            var exists = isTitle
+                ? await db.TitleSubDistricts.AnyAsync(s => s.Code == code, ct)
+                : await db.DopaSubDistricts.AnyAsync(s => s.Code == code, ct);
+            if (exists)
+                return Conflict($"Sub-district code '{code}' already exists in the {dataset} dataset.");
+
+            if (isTitle)
+                db.TitleSubDistricts.Add(TitleSubDistrict.Create(
+                    code, request.NameTh, request.NameEn, districtCode, request.Postcode));
+            else
+                db.DopaSubDistricts.Add(DopaSubDistrict.Create(
+                    code, request.NameTh, request.NameEn, districtCode, request.Postcode));
+
+            await db.SaveChangesAsync(ct);
+            return Results.Created($"/parameters/addresses/{dataset}/sub-districts/{code}",
+                new SubDistrictDto(code, request.NameTh.Trim(), request.NameEn.Trim(),
+                    districtCode, AddressRules.NormalisePostcode(request.Postcode)));
+        });
+    }
+
+    private static async Task<IResult> UpdateSubDistrict(
+        string dataset, string code, SaveSubDistrictRequest request,
+        ParameterDbContext db, CancellationToken ct)
+    {
+        if (!TryParseDataset(dataset, out var isTitle)) return UnknownDataset(dataset);
+
+        return await Guarded(async () =>
+        {
+            SubDistrictBase? entity = isTitle
+                ? await db.TitleSubDistricts.FirstOrDefaultAsync(s => s.Code == code, ct)
+                : await db.DopaSubDistricts.FirstOrDefaultAsync(s => s.Code == code, ct);
+            if (entity is null) return Results.NotFound();
+
+            var districtCode = AddressRules.RequireCode(
+                request.DistrictCode, nameof(request.DistrictCode), AddressRules.DistrictCodeLength);
+
+            if (!await DistrictExists(db, isTitle, districtCode, ct))
+                return BadRequest($"District '{districtCode}' does not exist in the {dataset} dataset.");
+
+            entity.Update(request.NameTh, request.NameEn, request.Postcode);
+            entity.MoveToDistrict(districtCode);
+            await db.SaveChangesAsync(ct);
+            return Results.Ok(new SubDistrictDto(
+                entity.Code, entity.NameTh, entity.NameEn, entity.DistrictCode, entity.Postcode));
+        });
+    }
+
+    private static async Task<IResult> DeleteSubDistrict(
+        string dataset, string code, ParameterDbContext db, CancellationToken ct)
+    {
+        if (!TryParseDataset(dataset, out var isTitle)) return UnknownDataset(dataset);
+
+        // A sub-district geocode is stored on collateral/request rows in OTHER schemas, which this
+        // module cannot query. Deleting one that is in use would orphan those addresses, so the
+        // screen warns and this stays a deliberate, low-frequency action.
+        if (isTitle)
+        {
+            var entity = await db.TitleSubDistricts.FirstOrDefaultAsync(s => s.Code == code, ct);
+            if (entity is null) return Results.NotFound();
+            db.TitleSubDistricts.Remove(entity);
+        }
+        else
+        {
+            var entity = await db.DopaSubDistricts.FirstOrDefaultAsync(s => s.Code == code, ct);
+            if (entity is null) return Results.NotFound();
+            db.DopaSubDistricts.Remove(entity);
+        }
+
+        await db.SaveChangesAsync(ct);
+        return Results.NoContent();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static bool TryParseDataset(string dataset, out bool isTitle)
+    {
+        isTitle = string.Equals(dataset, "title", StringComparison.OrdinalIgnoreCase);
+        return isTitle || string.Equals(dataset, "dopa", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Task<bool> ProvinceExists(
+        ParameterDbContext db, bool isTitle, string code, CancellationToken ct) =>
+        isTitle
+            ? db.TitleProvinces.AnyAsync(p => p.Code == code, ct)
+            : db.DopaProvinces.AnyAsync(p => p.Code == code, ct);
+
+    private static Task<bool> DistrictExists(
+        ParameterDbContext db, bool isTitle, string code, CancellationToken ct) =>
+        isTitle
+            ? db.TitleDistricts.AnyAsync(d => d.Code == code, ct)
+            : db.DopaDistricts.AnyAsync(d => d.Code == code, ct);
+
+    /// <summary>
+    /// Domain validation throws ArgumentException; surface it as a 400 rather than a 500.
+    ///
+    /// Also maps a unique-constraint violation to the same 409 the duplicate pre-check returns.
+    /// The pre-check and SaveChanges are not atomic, so two concurrent creates of the same code
+    /// both pass the check and one hits the primary key — the PK is the real guarantee, the
+    /// pre-check only makes the common case a friendlier message.
+    /// </summary>
+    private static async Task<IResult> Guarded(Func<Task<IResult>> action)
+    {
+        try
+        {
+            return await action();
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            return Conflict("That code already exists in this dataset.");
+        }
+    }
+
+    // 2627 = PK / unique constraint, 2601 = unique index. Anything else is a genuine failure and
+    // is left to propagate.
+    private static bool IsUniqueViolation(DbUpdateException ex) =>
+        ex.InnerException is SqlException { Number: 2627 or 2601 };
+
+    private static IResult UnknownDataset(string dataset) =>
+        BadRequest($"Unknown address dataset '{dataset}'. Expected 'title' or 'dopa'.");
+
+    private static IResult BadRequest(string detail) =>
+        Results.Problem(detail: detail, statusCode: StatusCodes.Status400BadRequest);
+
+    private static IResult Conflict(string detail) =>
+        Results.Problem(detail: detail, statusCode: StatusCodes.Status409Conflict);
+
+    private static IResult InUse(string detail) =>
+        Results.Problem(detail: detail, statusCode: StatusCodes.Status409Conflict);
+}
+
+// ── DTOs ──────────────────────────────────────────────────────────────────────
+
+public record ProvinceDto(string Code, string NameTh, string NameEn, int DistrictCount);
+
+public record DistrictDto(
+    string Code, string NameTh, string NameEn, string ProvinceCode, int SubDistrictCount);
+
+public record SubDistrictDto(
+    string Code, string NameTh, string NameEn, string DistrictCode, string? Postcode);
+
+public record SaveProvinceRequest(string Code, string NameTh, string NameEn);
+
+public record SaveDistrictRequest(string Code, string NameTh, string NameEn, string ProvinceCode);
+
+public record SaveSubDistrictRequest(
+    string Code, string NameTh, string NameEn, string DistrictCode, string? Postcode);

--- a/Modules/Parameter/Parameter/Addresses/Models/DistrictBase.cs
+++ b/Modules/Parameter/Parameter/Addresses/Models/DistrictBase.cs
@@ -2,8 +2,32 @@ namespace Parameter.Addresses.Models;
 
 public abstract class DistrictBase
 {
-    public string Code { get; private set; } = default!;
-    public string NameTh { get; private set; } = default!;
-    public string NameEn { get; private set; } = default!;
-    public string ProvinceCode { get; private set; } = default!;
+    public string Code { get; protected set; } = default!;
+    public string NameTh { get; protected set; } = default!;
+    public string NameEn { get; protected set; } = default!;
+    public string ProvinceCode { get; protected set; } = default!;
+
+    protected void Initialise(string code, string nameTh, string nameEn, string provinceCode)
+    {
+        Code = AddressRules.RequireCode(code, nameof(code), AddressRules.DistrictCodeLength);
+        ProvinceCode = AddressRules.RequireCode(
+            provinceCode, nameof(provinceCode), AddressRules.ProvinceCodeLength);
+        Rename(nameTh, nameEn);
+    }
+
+    public void Rename(string nameTh, string nameEn)
+    {
+        NameTh = AddressRules.RequireName(nameTh, nameof(nameTh));
+        NameEn = AddressRules.RequireName(nameEn, nameof(nameEn));
+    }
+
+    /// <summary>
+    /// Reparenting is a real correction in the Title dataset, where provinces have historically
+    /// been split and merged (e.g. the "(หนองคาย)บึงกาฬ" style entries).
+    /// </summary>
+    public void MoveToProvince(string provinceCode)
+    {
+        ProvinceCode = AddressRules.RequireCode(
+            provinceCode, nameof(provinceCode), AddressRules.ProvinceCodeLength);
+    }
 }

--- a/Modules/Parameter/Parameter/Addresses/Models/DopaDistrict.cs
+++ b/Modules/Parameter/Parameter/Addresses/Models/DopaDistrict.cs
@@ -5,4 +5,11 @@ public class DopaDistrict : DistrictBase
     public DopaProvince Province { get; private set; } = default!;
     public ICollection<DopaSubDistrict> SubDistricts { get; private set; } = [];
     private DopaDistrict() { }
+
+    public static DopaDistrict Create(string code, string nameTh, string nameEn, string provinceCode)
+    {
+        var district = new DopaDistrict();
+        district.Initialise(code, nameTh, nameEn, provinceCode);
+        return district;
+    }
 }

--- a/Modules/Parameter/Parameter/Addresses/Models/DopaProvince.cs
+++ b/Modules/Parameter/Parameter/Addresses/Models/DopaProvince.cs
@@ -4,4 +4,11 @@ public class DopaProvince : ProvinceBase
 {
     public ICollection<DopaDistrict> Districts { get; private set; } = [];
     private DopaProvince() { }
+
+    public static DopaProvince Create(string code, string nameTh, string nameEn)
+    {
+        var province = new DopaProvince();
+        province.Initialise(code, nameTh, nameEn);
+        return province;
+    }
 }

--- a/Modules/Parameter/Parameter/Addresses/Models/DopaSubDistrict.cs
+++ b/Modules/Parameter/Parameter/Addresses/Models/DopaSubDistrict.cs
@@ -4,4 +4,12 @@ public class DopaSubDistrict : SubDistrictBase
 {
     public DopaDistrict District { get; private set; } = default!;
     private DopaSubDistrict() { }
+
+    public static DopaSubDistrict Create(
+        string code, string nameTh, string nameEn, string districtCode, string? postcode)
+    {
+        var subDistrict = new DopaSubDistrict();
+        subDistrict.Initialise(code, nameTh, nameEn, districtCode, postcode);
+        return subDistrict;
+    }
 }

--- a/Modules/Parameter/Parameter/Addresses/Models/ProvinceBase.cs
+++ b/Modules/Parameter/Parameter/Addresses/Models/ProvinceBase.cs
@@ -2,7 +2,75 @@ namespace Parameter.Addresses.Models;
 
 public abstract class ProvinceBase
 {
-    public string Code { get; private set; } = default!;
-    public string NameTh { get; private set; } = default!;
-    public string NameEn { get; private set; } = default!;
+    public string Code { get; protected set; } = default!;
+    public string NameTh { get; protected set; } = default!;
+    public string NameEn { get; protected set; } = default!;
+
+    /// <summary>
+    /// Code is the natural key and is referenced by districts (and by collateral rows, which store
+    /// the geocode rather than the name), so it is set once at creation and never edited.
+    /// </summary>
+    protected void Initialise(string code, string nameTh, string nameEn)
+    {
+        Code = AddressRules.RequireCode(code, nameof(code), AddressRules.ProvinceCodeLength);
+        Rename(nameTh, nameEn);
+    }
+
+    public void Rename(string nameTh, string nameEn)
+    {
+        NameTh = AddressRules.RequireName(nameTh, nameof(nameTh));
+        NameEn = AddressRules.RequireName(nameEn, nameof(nameEn));
+    }
+}
+
+/// <summary>
+/// Column widths from the address tables, enforced in the domain so a bad value fails with a
+/// readable message instead of a SQL Server truncation error. Codes are NOT numeric: the Title
+/// (Land Department) dataset uses values such as "A0"/"A1"/"A2".
+/// </summary>
+public static class AddressRules
+{
+    public const int ProvinceCodeLength = 2;
+    public const int DistrictCodeLength = 4;
+    public const int SubDistrictCodeLength = 6;
+    public const int PostcodeLength = 5;
+    public const int NameMaxLength = 150;
+
+    public static string RequireCode(string? code, string paramName, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+            throw new ArgumentException("Code is required.", paramName);
+
+        var trimmed = code.Trim();
+        if (trimmed.Length > maxLength)
+            throw new ArgumentException($"Code cannot exceed {maxLength} characters.", paramName);
+
+        return trimmed;
+    }
+
+    public static string RequireName(string? name, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Name is required.", paramName);
+
+        var trimmed = name.Trim();
+        if (trimmed.Length > NameMaxLength)
+            throw new ArgumentException(
+                $"Name cannot exceed {NameMaxLength} characters.", paramName);
+
+        return trimmed;
+    }
+
+    /// <summary>Postcode is optional — the Title dataset leaves it null for historical entries.</summary>
+    public static string? NormalisePostcode(string? postcode)
+    {
+        if (string.IsNullOrWhiteSpace(postcode)) return null;
+
+        var trimmed = postcode.Trim();
+        if (trimmed.Length > PostcodeLength)
+            throw new ArgumentException(
+                $"Postcode cannot exceed {PostcodeLength} characters.", nameof(postcode));
+
+        return trimmed;
+    }
 }

--- a/Modules/Parameter/Parameter/Addresses/Models/SubDistrictBase.cs
+++ b/Modules/Parameter/Parameter/Addresses/Models/SubDistrictBase.cs
@@ -2,9 +2,31 @@ namespace Parameter.Addresses.Models;
 
 public abstract class SubDistrictBase
 {
-    public string Code { get; private set; } = default!;
-    public string NameTh { get; private set; } = default!;
-    public string NameEn { get; private set; } = default!;
-    public string DistrictCode { get; private set; } = default!;
-    public string? Postcode { get; private set; }
+    public string Code { get; protected set; } = default!;
+    public string NameTh { get; protected set; } = default!;
+    public string NameEn { get; protected set; } = default!;
+    public string DistrictCode { get; protected set; } = default!;
+    public string? Postcode { get; protected set; }
+
+    protected void Initialise(
+        string code, string nameTh, string nameEn, string districtCode, string? postcode)
+    {
+        Code = AddressRules.RequireCode(code, nameof(code), AddressRules.SubDistrictCodeLength);
+        DistrictCode = AddressRules.RequireCode(
+            districtCode, nameof(districtCode), AddressRules.DistrictCodeLength);
+        Update(nameTh, nameEn, postcode);
+    }
+
+    public void Update(string nameTh, string nameEn, string? postcode)
+    {
+        NameTh = AddressRules.RequireName(nameTh, nameof(nameTh));
+        NameEn = AddressRules.RequireName(nameEn, nameof(nameEn));
+        Postcode = AddressRules.NormalisePostcode(postcode);
+    }
+
+    public void MoveToDistrict(string districtCode)
+    {
+        DistrictCode = AddressRules.RequireCode(
+            districtCode, nameof(districtCode), AddressRules.DistrictCodeLength);
+    }
 }

--- a/Modules/Parameter/Parameter/Addresses/Models/TitleDistrict.cs
+++ b/Modules/Parameter/Parameter/Addresses/Models/TitleDistrict.cs
@@ -5,4 +5,11 @@ public class TitleDistrict : DistrictBase
     public TitleProvince Province { get; private set; } = default!;
     public ICollection<TitleSubDistrict> SubDistricts { get; private set; } = [];
     private TitleDistrict() { }
+
+    public static TitleDistrict Create(string code, string nameTh, string nameEn, string provinceCode)
+    {
+        var district = new TitleDistrict();
+        district.Initialise(code, nameTh, nameEn, provinceCode);
+        return district;
+    }
 }

--- a/Modules/Parameter/Parameter/Addresses/Models/TitleProvince.cs
+++ b/Modules/Parameter/Parameter/Addresses/Models/TitleProvince.cs
@@ -4,4 +4,11 @@ public class TitleProvince : ProvinceBase
 {
     public ICollection<TitleDistrict> Districts { get; private set; } = [];
     private TitleProvince() { }
+
+    public static TitleProvince Create(string code, string nameTh, string nameEn)
+    {
+        var province = new TitleProvince();
+        province.Initialise(code, nameTh, nameEn);
+        return province;
+    }
 }

--- a/Modules/Parameter/Parameter/Addresses/Models/TitleSubDistrict.cs
+++ b/Modules/Parameter/Parameter/Addresses/Models/TitleSubDistrict.cs
@@ -4,4 +4,12 @@ public class TitleSubDistrict : SubDistrictBase
 {
     public TitleDistrict District { get; private set; } = default!;
     private TitleSubDistrict() { }
+
+    public static TitleSubDistrict Create(
+        string code, string nameTh, string nameEn, string districtCode, string? postcode)
+    {
+        var subDistrict = new TitleSubDistrict();
+        subDistrict.Initialise(code, nameTh, nameEn, districtCode, postcode);
+        return subDistrict;
+    }
 }

--- a/Shared/Shared/Identity/DevAuthenticationHandler.cs
+++ b/Shared/Shared/Identity/DevAuthenticationHandler.cs
@@ -47,6 +47,8 @@ public class DevAuthenticationHandler(
             new Claim("permissions", "USER_MANAGE"),
             new Claim("permissions", "USER_CHANGE_PASSWORD"),
             new Claim("permissions", "USER_RESET_PASSWORD"),
+            new Claim("permissions", "JOB_SCHEDULE_MANAGE"),
+            new Claim("permissions", "ADDRESS_MASTER_MANAGE"),
             // Roles
             new Claim("roles", "Admin"),
             // Scopes

--- a/Shared/Shared/Scheduling/JobScheduleRegistry.cs
+++ b/Shared/Shared/Scheduling/JobScheduleRegistry.cs
@@ -1,0 +1,135 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Shared.Scheduling;
+
+/// <summary>
+/// One administrable recurring job: its code-side definition plus module-scoped accessors for the
+/// <c>{schema}.JobSchedules</c> row that overrides it.
+///
+/// <see cref="JobSchedule"/> is mapped once per module schema, so there is no single DbContext that
+/// can reach every row. The accessors below close over the concrete <c>TContext</c> inside
+/// <see cref="RecurringJobScheduleExtensions.UseModuleRecurringJobs{TContext}"/> — the only place
+/// that type is known — which lets an admin endpoint in any module read and write all of them.
+/// </summary>
+public sealed class JobScheduleRegistration
+{
+    public required string JobId { get; init; }
+
+    /// <summary>Owning module, derived from the DbContext name (e.g. "Appraisal").</summary>
+    public required string Module { get; init; }
+
+    public required RecurringJobDefinition Definition { get; init; }
+
+    /// <summary>Reads the persisted override, or null when the row is missing.</summary>
+    public required Func<IServiceProvider, CancellationToken, Task<JobSchedule?>> LoadAsync { get; init; }
+
+    /// <summary>
+    /// Applies <c>mutate</c> to the tracked row and saves. Returns the updated row, or null when
+    /// there is no row to update.
+    /// </summary>
+    public required Func<IServiceProvider, Action<JobSchedule>, CancellationToken, Task<JobSchedule?>>
+        UpdateAsync { get; init; }
+}
+
+/// <summary>
+/// Cross-module catalog of recurring jobs, populated at startup as each module registers its jobs.
+/// Registered as a singleton; it is written only during startup and read by the admin endpoints.
+/// </summary>
+public interface IJobScheduleRegistry
+{
+    IReadOnlyList<JobScheduleRegistration> All { get; }
+
+    JobScheduleRegistration? Find(string jobId);
+
+    void Add(JobScheduleRegistration registration);
+}
+
+public sealed class JobScheduleRegistry : IJobScheduleRegistry
+{
+    // Modules register on the startup thread, but UseXModule() ordering is not something this class
+    // controls, so keep the writes guarded rather than assuming single-threaded population.
+    private readonly Dictionary<string, JobScheduleRegistration> _byJobId = new(StringComparer.Ordinal);
+    private readonly Lock _gate = new();
+
+    public IReadOnlyList<JobScheduleRegistration> All
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _byJobId.Values
+                    .OrderBy(r => r.Module, StringComparer.Ordinal)
+                    .ThenBy(r => r.JobId, StringComparer.Ordinal)
+                    .ToList();
+            }
+        }
+    }
+
+    public JobScheduleRegistration? Find(string jobId)
+    {
+        lock (_gate)
+        {
+            return _byJobId.GetValueOrDefault(jobId);
+        }
+    }
+
+    public void Add(JobScheduleRegistration registration)
+    {
+        lock (_gate)
+        {
+            _byJobId[registration.JobId] = registration;
+        }
+    }
+}
+
+public static class JobScheduleRegistryExtensions
+{
+    /// <summary>
+    /// Must be called before the first <c>UseModuleRecurringJobs</c>; jobs registered while the
+    /// singleton is absent are simply not administrable.
+    /// </summary>
+    public static IServiceCollection AddJobScheduleRegistry(this IServiceCollection services)
+    {
+        services.AddSingleton<IJobScheduleRegistry, JobScheduleRegistry>();
+        return services;
+    }
+
+    /// <summary>"AppraisalDbContext" → "Appraisal"; used as the display/group name.</summary>
+    internal static string ToModuleName(this Type contextType)
+    {
+        var name = contextType.Name;
+        return name.EndsWith("DbContext", StringComparison.Ordinal)
+            ? name[..^"DbContext".Length]
+            : name;
+    }
+
+    internal static JobScheduleRegistration BuildRegistration<TContext>(
+        RecurringJobDefinition definition)
+        where TContext : DbContext
+    {
+        return new JobScheduleRegistration
+        {
+            JobId = definition.JobId,
+            Module = typeof(TContext).ToModuleName(),
+            Definition = definition,
+            LoadAsync = async (services, ct) =>
+            {
+                var db = services.GetRequiredService<TContext>();
+                return await db.Set<JobSchedule>().AsNoTracking()
+                    .FirstOrDefaultAsync(s => s.JobId == definition.JobId, ct);
+            },
+            UpdateAsync = async (services, mutate, ct) =>
+            {
+                var db = services.GetRequiredService<TContext>();
+                var row = await db.Set<JobSchedule>()
+                    .FirstOrDefaultAsync(s => s.JobId == definition.JobId, ct);
+                if (row is null) return null;
+
+                mutate(row);
+                await db.SaveChangesAsync(ct);
+                return row;
+            },
+        };
+    }
+}

--- a/Shared/Shared/Scheduling/RecurringJobScheduleExtensions.cs
+++ b/Shared/Shared/Scheduling/RecurringJobScheduleExtensions.cs
@@ -32,6 +32,22 @@ public static class RecurringJobScheduleExtensions
 
         var set = db.Set<JobSchedule>();
 
+        // Publish this module's jobs to the cross-module admin catalog. Done here because this is
+        // the only place TContext is known, and JobSchedule is mapped once per module schema.
+        var registry = sp.GetService<IJobScheduleRegistry>();
+        if (registry is null)
+        {
+            logger.LogWarning(
+                "IJobScheduleRegistry is not registered; {Count} job(s) in {Context} will not be "
+                + "administrable. Call services.AddJobScheduleRegistry() during startup.",
+                jobs.Count, typeof(TContext).Name);
+        }
+        else
+        {
+            foreach (var def in jobs)
+                registry.Add(JobScheduleRegistryExtensions.BuildRegistration<TContext>(def));
+        }
+
         // Seed-if-missing: the code definition list is the single source of truth.
         var existingIds = set.AsNoTracking().Select(s => s.JobId).ToHashSet();
         var seeded = false;


### PR DESCRIPTION
> **Frontend counterpart:** immortalgky/collateral-appraisal-system-app#299
> **This PR must merge, and its seed scripts must be applied, before the frontend PR.**

## What

Two new admin screens. They share the permission-plumbing files (`AuthModule`, `DevAuthenticationHandler`,
`AuthDataSeed`, `MenuSeedData`), so they ship together.

### Job schedules — `/admin/job-schedules`

The per-module `{schema}.JobSchedules` tables (cron / timezone / enabled for every Hangfire recurring
job) had no API and no screen: changing a schedule meant hand-editing SQL and restarting.

The wrinkle is that `JobSchedule` is mapped once **per module schema**, so no single DbContext can reach
every row. `JobScheduleRegistry` is a startup-populated singleton catalog whose entries close over the
concrete `TContext` — captured inside `UseModuleRecurringJobs<TContext>`, the only place that type is
known — via `LoadAsync` / `UpdateAsync` delegates. The Carter module then reads and writes all nine
modules' rows through those delegates.

`GET` lists, `PUT {jobId}` updates. **The update applies to Hangfire before persisting**, so an invalid
cron is rejected without touching storage.

⚠ Ordering: `AddJobScheduleRegistry()` must precede the `UseModuleRecurringJobs` calls in `Program.cs`.
Otherwise the registry is absent, `RecurringJobScheduleExtensions` logs a warning and silently skips
registration.

### Address masters — `/parameters/addresses/{dataset}/…`

The Thai address masters (Title/Land-Dept and DOPA) were seed-only — read endpoints existed, but there
was no write path, so adding a missing province meant hand-written SQL.

Routes are `/parameters/addresses/{dataset}/{provinces|districts|sub-districts}` with GET/POST/PUT/DELETE,
`{dataset}` ∈ `title|dopa`. The hierarchy is walked one level at a time (`?provinceCode=`,
`?districtCode=`) rather than returning the existing flat ~11k-row payload.

Design decisions worth reviewing:

- **`Code` is immutable after creation.** It's the natural key that collateral geocodes reference.
  Rename and reparent are the supported edits.
- **Delete is child-count-guarded** at province and district level. Sub-district delete is deliberately
  unguarded — the referencing rows live in other schemas, so there's nothing local to count.

**No EF migration** — no schema change. The model diffs are `private set` → `protected set` plus new
domain behaviour (`Initialise`, `Rename`, `MoveToProvince`, `MoveToDistrict`, `Update`, `Create`
factories) and a new `AddressRules` static class in `ProvinceBase.cs`.

### Seeder is now strictly create-only

`SeedRoleWithPermissionsAsync` and `SeedAdminRoleAsync` drop their
`else if (... .AnyAsync(rp => rp.RoleId == role.Id))` self-repair fall-through, which existed to grant
the seed set to a role that existed but had zero permissions.

Both new SQL scripts depend on this: their Step 2 grants the new permission to the existing Admin role
**precisely because** the seeder won't.

## Seed scripts

`20260802120100_SeedData_JobScheduleAdmin.sql` and `20260802120200_SeedData_AddressMasterAdmin.sql` —
each adds the permission row, grants it to Admin, and inserts the menu node. Both skip gracefully when
their parent menu node is missing.

⚠ `MenuTreeCache` (`auth:menu:full`) has **no TTL** and is a per-node `IMemoryCache` — **restart every
API instance** after these run, or the new menu entries won't appear.

## Test

- [x] `dotnet build Bootstrapper/Api` — 0 errors.
- [ ] `GET /admin/job-schedules` returns rows from all nine module schemas.
- [ ] `PUT` with an invalid cron is rejected **and** leaves storage untouched.
- [ ] Address CRUD for both `title` and `dopa`; confirm `Code` is not editable after creation.
- [ ] Confirm province/district delete is blocked while children exist.
- [ ] Run `migrate` twice — the second run must be a clean no-op.

## Notes

Split out of a large combined working tree. `AuthDataSeed.cs` and `MenuSeedData.cs` were split at hunk
level; the appraisal role-permission overhaul that also touches those files is a **separate PR stacked
on this one**. Verified this branch contains none of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhV2jVwAfwgBu3JboaNnCC
