### PR TITLE
fix(parameter): shorten address master cache TTL from 24h to 5m

### DIFF
--- a/Modules/Parameter/Parameter/Data/Repository/CachedAddressRepository.cs
+++ b/Modules/Parameter/Parameter/Data/Repository/CachedAddressRepository.cs
@@ -4,7 +4,11 @@ namespace Parameter.Data.Repository;
 
 public class CachedAddressRepository(IAddressRepository inner, IMemoryCache cache) : IAddressRepository
 {
-    private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(24);
+    // Kept short deliberately: this is an in-process cache, so on a multi-node deployment each node
+    // holds and expires its own copy and a cache.Remove would only clear the node that served the
+    // request. The admin CRUD in Addresses/Features/AdminAddresses does not invalidate this cache,
+    // so the TTL is what bounds how long an added province stays invisible.
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
 
     public async Task<List<AddressDto>> GetTitleAddressesAsync(CancellationToken ct = default)
     {

--- a/docs/address-api-contract.md
+++ b/docs/address-api-contract.md
@@ -147,9 +147,28 @@ ORDER BY sd.Code;
 
 ## Caching Behavior
 
-- Frontend caches both responses for the **entire browser session** (no re-fetching)
-- Consider adding `Cache-Control` headers for HTTP-level caching if desired
-- Address data changes infrequently
+### Frontend
+- Caches both responses for the **entire browser session** (no re-fetching). A user will not see a
+  master-data change until they reload the page.
+
+### Backend
+- `CachedAddressRepository` caches both responses in-process (`IMemoryCache`) with a **5-minute
+  absolute TTL**, keyed `addresses:title` / `addresses:dopa`.
+- **The cache is per app node and is never invalidated.** Production runs two IIS nodes, so each
+  holds and expires its own copy independently — there is no cross-node invalidation, and a
+  `cache.Remove` would only affect the node that served the request.
+- Consequence: after the masters are changed — via the admin CRUD under
+  `/parameters/addresses/{dataset}/…` (`Addresses/Features/AdminAddresses/AddressAdminEndpoints.cs`)
+  or via the DbUp seed scripts — the change takes **up to 5 minutes to appear**, on the node that
+  served the write as well as the other one. It then still requires a browser reload to reach the
+  user.
+- ⚠ The admin CRUD endpoints do **not** invalidate this cache. Adding a `cache.Remove` there would
+  make the change immediate on the writing node only, so the TTL remains the bound for the rest.
+- To publish a change immediately, recycle both app pools — that clears the in-process cache at
+  once rather than waiting out the TTL.
+- No HTTP-level caching is applied: these endpoints emit no `Cache-Control`, `ETag`, or
+  `Last-Modified`, and response compression is not enabled, so every client request re-serializes
+  and re-transfers the full array.
 
 ## Error Responses
 


### PR DESCRIPTION
## Problem

`GET /parameters/addresses/title` and `/dopa` are cached in-process by `CachedAddressRepository` with a **24-hour TTL** and **no invalidation at all**.

Because `IMemoryCache` is per-process and production runs two IIS nodes behind the F5, each node holds and expires its own copy independently. Worse, the admin CRUD added in #356 (`Addresses/Features/AdminAddresses/AddressAdminEndpoints.cs`) never touches the cache — so after an admin adds a province, **neither** node reflects it, including the one that served the write, for up to 24 hours.

## Change

One line — `CacheDuration` 24 h → 5 min. Both `GetTitleAddressesAsync` and `GetDopaAddressesAsync` share the constant, so it covers `addresses:title` and `addresses:dopa`.

Cost is negligible: a miss is one `AsNoTracking` three-table join (~11,144 rows Title, ~7,436 DOPA), so at most 12 executions per hour per endpoint per node.

Cache keys are unchanged — they're constants, so there are exactly two entries ever, with no collision risk or cardinality growth.

Also rewrites the "Caching Behavior" section of `docs/address-api-contract.md`, which previously documented only the frontend session cache.

## Deliberately out of scope

- **Redis / `IDistributedCache`** — registered at `Program.cs:74` with zero consumers repo-wide. Would fix this properly, but it's new infrastructure, and Redis is health-gated as `ready`, so an outage pulls a node out of LB rotation.
- **Cross-node invalidation over RabbitMQ** — not possible as deployed; each node runs its own non-clustered broker (`Program.cs:133-135`), so a `Publish` on one node never reaches the other.
- **`cache.Remove` in the admin CRUD handlers** — would make the change instant on the writing node only; the other still waits out the TTL. Worth doing as a follow-up.
- **HTTP caching (ETag/`Cache-Control`) and response compression** — neither exists anywhere in the solution; real wins for these payloads but orthogonal to this bug.

## Testing

- `dotnet build` clean, 0 errors / 0 warnings on the Parameter module.
- Both endpoints verified returning 200 with the correct DTO shape.
- The TTL itself is time-based behaviour; verify by adding a sub-district via the admin UI and confirming it appears within 5 minutes without an app restart.

Note: an app-pool recycle clears the in-process cache immediately, so that remains the way to publish a master-data change right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGL3tpCLecYadXFRXR66Ay