### PR TITLE
feat(company): show Thai company name by locale, Thai-first in documents

### DIFF
--- a/Database/Scripts/Views/Appraisal/vw_AppraisalDetail.sql
+++ b/Database/Scripts/Views/Appraisal/vw_AppraisalDetail.sql
@@ -51,6 +51,9 @@ SELECT a.Id,
        --                a ValuationAnalyses row nor an Appointment row, and without it those rows
        --                report a NULL appraisal date on the 360 page and anywhere reading this view.
        c.Name                                                                              AS CompanyName,
+       -- Thai name, exposed alongside CompanyName so the client can pick by its own locale
+       -- (the API has no request locale). NULLIF collapses '' to NULL for a single absent-test.
+       NULLIF(c.NameLocal, N'')                                                            AS CompanyNameLocal,
        NULLIF(LTRIM(RTRIM(CONCAT(NULLIF(u.FirstName, N''), N' ', NULLIF(u.LastName, N'')))), N'')
                                                                                            AS AppraiserName,
        COALESCE(va.ValuationDate, lap.AppointmentDateTime, a.CompletedAt, la.CompletedAt)  AS AppraisalDate,

--- a/Database/Scripts/Views/Appraisal/vw_AppraisalEvaluationHeader.sql
+++ b/Database/Scripts/Views/Appraisal/vw_AppraisalEvaluationHeader.sql
@@ -15,6 +15,8 @@ SELECT
 
     -- Current external assignment's appraiser
     comp.Name                               AS AppraiserCompanyName,
+    -- Thai name alongside the English one; the client picks by its own locale.
+    NULLIF(comp.NameLocal, N'')             AS AppraiserCompanyNameLocal,
     ext.AssigneeCompanyId,
 
     NULLIF(LTRIM(RTRIM(CONCAT(u.FirstName, ' ', u.LastName))), '')

--- a/Database/Scripts/Views/Appraisal/vw_AppraisalEvaluationList.sql
+++ b/Database/Scripts/Views/Appraisal/vw_AppraisalEvaluationList.sql
@@ -17,6 +17,8 @@ SELECT
     ext.ExternalAppraiserName,
     ext.AssigneeCompanyId,
     comp.Name                               AS AppraiserCompanyName,
+    -- Thai name alongside the English one; the client picks by its own locale.
+    NULLIF(comp.NameLocal, N'')             AS AppraiserCompanyNameLocal,
 
     -- Final appraised value from valuation analysis
     va.AppraisedValue                       AS AppraisalValue,

--- a/Database/Scripts/Views/Appraisal/vw_AppraisalList.sql
+++ b/Database/Scripts/Views/Appraisal/vw_AppraisalList.sql
@@ -55,8 +55,10 @@ SELECT a.Id,
        la.AssignmentStatus,
        la.AssignedAt                                                                       AS AssignedDate,
        la.SubmittedAt,   -- first-submission timestamp (external: sent-to-bank; internal: execution→check); SLA end-point
-       -- Company name for external assignments
+       -- Company name for external assignments. The Thai name rides alongside (not instead of) the
+       -- English one so the client can pick by its own locale; NULLIF collapses '' to NULL.
        comp.Name                                                                           AS CompanyName,
+       NULLIF(comp.NameLocal, N'')                                                         AS CompanyNameLocal,
        -- Customer name from request
        c.Name                                                                              AS CustomerName,
        -- First property location

--- a/Database/Scripts/Views/Appraisal/vw_InvoiceList.sql
+++ b/Database/Scripts/Views/Appraisal/vw_InvoiceList.sql
@@ -16,6 +16,9 @@ SELECT i.Id,
        CAST(i.SubmittedAt AS DATE) AS SentDate,
        i.CompanyId,
        c.Name                  AS CompanyName,
+       -- Thai name, exposed alongside CompanyName so the client can pick by its own locale.
+       -- NULLIF collapses '' to NULL so the FE has a single "absent" test.
+       NULLIF(c.NameLocal, N'') AS CompanyNameLocal,
        c.BankAccountNo,
        c.BankAccountName,
        i.CreatedAt
@@ -25,4 +28,4 @@ FROM appraisal.Invoices i
 GROUP BY i.Id, i.InvoiceNumber, i.Status, i.TotalAmount, i.Notes,
          i.SubmittedAt, i.ApprovedAt, i.ApprovedBy,
          i.PaymentOrderNo, i.PaidDate,
-         i.CompanyId, c.Name, c.BankAccountNo, c.BankAccountName, i.CreatedAt
+         i.CompanyId, c.Name, c.NameLocal, c.BankAccountNo, c.BankAccountName, i.CreatedAt

--- a/Database/Scripts/Views/Collateral/vw_CollateralEngagements.sql
+++ b/Database/Scripts/Views/Collateral/vw_CollateralEngagements.sql
@@ -14,6 +14,10 @@ SELECT
     e.AppraiserUserId,
     e.AppraisalCompanyId,
     e.AppraisalCompanyName,
+    -- Thai name resolved LIVE from auth.Companies (via the stored AppraisalCompanyId), NOT frozen.
+    -- The snapshot above is deliberately left untouched; this rides alongside it so a Thai-locale
+    -- client has something to display. Null when the company is gone or has no Thai name.
+    NULLIF(comp.NameLocal, N'')                          AS AppraisalCompanyNameLocal,
     e.ConstructionInspectionFeeAmount,
     e.CreatedAt,
 
@@ -54,6 +58,7 @@ SELECT
 
 FROM collateral.CollateralEngagements e
 INNER JOIN collateral.CollateralMasters m ON m.Id = e.CollateralMasterId
+LEFT JOIN  auth.Companies               comp ON comp.Id = e.AppraisalCompanyId
 LEFT JOIN  collateral.LandDetails       ld  ON ld.CollateralMasterId  = m.Id
 LEFT JOIN  collateral.CondoDetails      cd  ON cd.CollateralMasterId  = m.Id
 LEFT JOIN  collateral.LeaseholdDetails  lhd ON lhd.CollateralMasterId = m.Id

--- a/Database/Scripts/Views/Common/vw_CompanyAppraisalSummariesFromSource.sql
+++ b/Database/Scripts/Views/Common/vw_CompanyAppraisalSummariesFromSource.sql
@@ -16,7 +16,9 @@ WITH latest_assignment AS (
         a.CreatedAt,
         a.CompletedAt,
         TRY_CAST(aa.AssigneeCompanyId AS uniqueidentifier)  AS CompanyId,
-        comp.Name                                           AS CompanyName
+        comp.Name                                           AS CompanyName,
+        -- Thai name alongside the English one; the client picks by its own locale.
+        NULLIF(comp.NameLocal, N'')                         AS CompanyNameLocal
     FROM appraisal.Appraisals a
     INNER JOIN (
         SELECT AppraisalId, AssigneeCompanyId,
@@ -30,10 +32,10 @@ WITH latest_assignment AS (
     WHERE a.IsDeleted = 0
 ),
 events AS (
-    SELECT CompanyId, CompanyName, CAST(CreatedAt AS DATE) AS [Date], 1 AS AssignedCount, 0 AS CompletedCount
+    SELECT CompanyId, CompanyName, CompanyNameLocal, CAST(CreatedAt AS DATE) AS [Date], 1 AS AssignedCount, 0 AS CompletedCount
     FROM latest_assignment
     UNION ALL
-    SELECT CompanyId, CompanyName, CAST(CompletedAt AS DATE) AS [Date], 0, 1
+    SELECT CompanyId, CompanyName, CompanyNameLocal, CAST(CompletedAt AS DATE) AS [Date], 0, 1
     FROM latest_assignment
     WHERE CompletedAt IS NOT NULL
 )
@@ -41,6 +43,7 @@ SELECT
     CompanyId,
     [Date],
     MAX(CompanyName)        AS CompanyName,
+    MAX(CompanyNameLocal)   AS CompanyNameLocal,
     SUM(AssignedCount)      AS AssignedCount,
     SUM(CompletedCount)     AS CompletedCount
 FROM events

--- a/Database/Scripts/Views/Common/vw_CompanyAppraisalSummaryLive.sql
+++ b/Database/Scripts/Views/Common/vw_CompanyAppraisalSummaryLive.sql
@@ -22,6 +22,8 @@ WITH latest_assignment AS (
         a.CreatedAt,
         TRY_CAST(aa.AssigneeCompanyId AS uniqueidentifier)  AS CompanyId,
         comp.Name                                           AS CompanyName,
+        -- Thai name alongside the English one; the client picks by its own locale.
+        NULLIF(comp.NameLocal, N'')                         AS CompanyNameLocal,
         aa.SubmittedAt,
         aa.SLADueDate
     FROM appraisal.Appraisals a
@@ -40,6 +42,7 @@ SELECT
     AppraisalId,
     CompanyId,
     CompanyName,
+    CompanyNameLocal,
     CreatedAt,
     CASE WHEN SubmittedAt IS NOT NULL THEN 1 ELSE 0 END AS IsCompleted,
     CASE WHEN SubmittedAt IS NULL AND SLADueDate IS NOT NULL

--- a/Database/Scripts/Views/Common/vw_MonitoringPendingTasks.sql
+++ b/Database/Scripts/Views/Common/vw_MonitoringPendingTasks.sql
@@ -83,6 +83,8 @@ SELECT
     pt.AssigneeCompanyId                                                        AS AssigneeCompanyId,
     aa.AssigneeCompanyId                                                        AS AppraisalCompanyId,
     comp.Name                                                                   AS AppraisalCompanyName,
+    -- Thai name alongside the English one; the client picks by its own locale.
+    NULLIF(comp.NameLocal, N'')                                                 AS AppraisalCompanyNameLocal,
     CASE
         WHEN aa.AssignmentType = 'External'
          AND aa.AssignmentStatus NOT IN ('Rejected', 'Cancelled')

--- a/Database/Scripts/Views/Reporting/vw_RCAS001_AppraisalBooks.sql
+++ b/Database/Scripts/Views/Reporting/vw_RCAS001_AppraisalBooks.sql
@@ -32,7 +32,7 @@ SELECT v.Id,
            NULLIF(LTRIM(RTRIM(CONCAT(NULLIF(su.FirstName, N''), N' ', NULLIF(su.LastName, N'')))), N''),
            CAST(v.AssigneeUserId AS NVARCHAR(50))
        )                                        AS InternalAppraisalStaff,
-       v.CompanyName                            AS AppraisalCompany,
+       COALESCE(NULLIF(v.CompanyNameLocal, N''), v.CompanyName)                            AS AppraisalCompany,
        a.CompletedAt                            AS ApproveDate
 FROM appraisal.vw_AppraisalList v
          INNER JOIN appraisal.Appraisals a ON a.Id = v.Id

--- a/Database/Scripts/Views/Reporting/vw_RCAS004_ConstructionInspection.sql
+++ b/Database/Scripts/Views/Reporting/vw_RCAS004_ConstructionInspection.sql
@@ -19,7 +19,7 @@ SELECT v.Id,
        v.FacilityLimit          AS ApplyLimitAmount,
        ct.CollateralType,
        v.Channel,
-       v.CompanyName            AS AppraisalCompany,
+       COALESCE(NULLIF(v.CompanyNameLocal, N''), v.CompanyName)            AS AppraisalCompany,
        COALESCE(
            NULLIF(LTRIM(RTRIM(CONCAT(NULLIF(su.FirstName, N''), N' ', NULLIF(su.LastName, N'')))), N''),
            CAST(v.AssigneeUserId AS NVARCHAR(50))

--- a/Database/Scripts/Views/Reporting/vw_RCAS007_SlaSummary.sql
+++ b/Database/Scripts/Views/Reporting/vw_RCAS007_SlaSummary.sql
@@ -23,7 +23,8 @@ SELECT v.Id,
        ru.PhoneNumber           AS RequestorPhone,
        ru.Department            AS RequestorDepartment,
        v.BankingSegment,
-       v.CompanyName            AS AppraisalCompany,
+       COALESCE(NULLIF(v.CompanyNameLocal, N''), v.CompanyName)            AS AppraisalCompany,
+       v.CompanyName            AS AppraisalCompanyEn,   -- filter key: stays English so a company filter matches in either language
        v.ExternalAppraiserName  AS ExternalStaffName,
        v.ExternalAppraiserId    AS ExternalStaffCode,     -- filter-only: the External Appraisal Staff filter binds the code
        v.AssignmentType,                                  -- filter-only: RCAS012 scopes to External

--- a/Database/Scripts/Views/Reporting/vw_RCAS008_ServiceQuality.sql
+++ b/Database/Scripts/Views/Reporting/vw_RCAS008_ServiceQuality.sql
@@ -6,7 +6,8 @@ OR ALTER VIEW reporting.vw_RCAS008_ServiceQuality
 AS
 SELECT el.AppraisalId           AS Id,
        el.AppraisalNumber,
-       el.AppraiserCompanyName  AS AppraisalCompany,
+       COALESCE(NULLIF(el.AppraiserCompanyNameLocal, N''), el.AppraiserCompanyName)  AS AppraisalCompany,
+       el.AppraiserCompanyName  AS AppraisalCompanyEn,   -- filter key: stays English so a company filter matches in either language
        a.CompletedAt            AS ApprovedDate,
        a.BankingSegment,
        el.TotalScore            AS TotalScorePct,

--- a/Database/Scripts/Views/Reporting/vw_RCAS009_FeeSummary.sql
+++ b/Database/Scripts/Views/Reporting/vw_RCAS009_FeeSummary.sql
@@ -25,7 +25,8 @@ SELECT f.Id,
        v.RequestedBy                AS RequestorCode,
        ru.Department                AS RequestorDepartment,
        v.BankingSegment,
-       v.CompanyName                AS AppraisalCompany,
+       COALESCE(NULLIF(v.CompanyNameLocal, N''), v.CompanyName)                AS AppraisalCompany,
+       v.CompanyName                AS AppraisalCompanyEn,   -- filter key: stays English so a company filter matches in either language
        COALESCE(
            NULLIF(LTRIM(RTRIM(CONCAT(NULLIF(su.FirstName, N''), N' ', NULLIF(su.LastName, N'')))), N''),
            CAST(v.AssigneeUserId AS NVARCHAR(50))

--- a/Database/Scripts/Views/Reporting/vw_RCAS010_FeeExpenseBase.sql
+++ b/Database/Scripts/Views/Reporting/vw_RCAS010_FeeExpenseBase.sql
@@ -20,7 +20,8 @@ SELECT f.Id,
        ru.AoCode                AS RequestorAoCode,        -- filter
        v.Status                 AS AppraisalStatus,        -- filter
        f.FeePaymentType,                                   -- filter (fee type)
-       v.CompanyName            AS AppraisalCompany,       -- filter
+       COALESCE(NULLIF(v.CompanyNameLocal, N''), v.CompanyName)            AS AppraisalCompany,       -- filter
+       v.CompanyName            AS AppraisalCompanyEn,   -- filter key: stays English so a company filter matches in either language
        f.TotalFeeAfterVAT,
        f.CustomerPayableAmount,
        f.BankAbsorbAmount

--- a/Database/Scripts/Views/Reporting/vw_RCAS_OlaBase.sql
+++ b/Database/Scripts/Views/Reporting/vw_RCAS_OlaBase.sql
@@ -28,7 +28,8 @@ SELECT v.Id,
        ct.CollateralType,
        v.Channel,
        v.AssignmentType,
-       v.CompanyName            AS AppraisalCompany,
+       COALESCE(NULLIF(v.CompanyNameLocal, N''), v.CompanyName)            AS AppraisalCompany,
+       v.CompanyName            AS AppraisalCompanyEn,   -- filter key: stays English so a company filter matches in either language
        -- "CODE - First Last" per the FSD sample; falls back to the bare code when the user or the
        -- name is missing, so an unmapped/legacy code still renders.
        CASE

--- a/Database/Scripts/Views/Workflow/vw_TaskList.sql
+++ b/Database/Scripts/Views/Workflow/vw_TaskList.sql
@@ -226,6 +226,10 @@ SELECT resolved.Id                                                              
                 AA.AssigneeUserId)
            WHEN AA.AssignmentType = 'External' THEN comp.Name
            END                                                                                  AS Appraiser,
+       -- Thai company name for EXTERNAL rows only — Appraiser is a union of two different things
+       -- (a person for Internal, a company for External), so it cannot be localized wholesale.
+       -- NULL here means "nothing to localize": the client falls back to Appraiser as-is.
+       CASE WHEN AA.AssignmentType = 'External' THEN NULLIF(comp.NameLocal, N'') END             AS AppraiserCompanyNameLocal,
        COALESCE(a.Priority, r.Priority)                                                         AS Priority,
        resolved.DueAt,
        resolved.SlaStartAt,

--- a/Modules/Appraisal/Appraisal/Application/Evaluations/Queries/GetEvaluationHeaderQuery.cs
+++ b/Modules/Appraisal/Appraisal/Application/Evaluations/Queries/GetEvaluationHeaderQuery.cs
@@ -12,6 +12,9 @@ public record AppraisalEvaluationHeader(
     string?   CustomerName,
     DateTime? ReportReceivedDate,
     string?   AppraiserCompanyName,
+    // Thai name (null when absent); the client picks by its own locale. Position is load-bearing —
+    // it must stay directly after AppraiserCompanyName to match the SELECT's column order.
+    string?   AppraiserCompanyNameLocal,
     string?   AssigneeCompanyId,
     string?   InternalAppraiserId,
     string?   InternalAppraiserName,
@@ -28,7 +31,7 @@ public class GetEvaluationHeaderQueryHandler(ISqlConnectionFactory connectionFac
     {
         const string sql =
             "SELECT AppraisalId, AppraisalNumber, AppraisalStatus, BankingSegment, CustomerName, " +
-            "ReportReceivedDate, AppraiserCompanyName, AssigneeCompanyId, " +
+            "ReportReceivedDate, AppraiserCompanyName, AppraiserCompanyNameLocal, AssigneeCompanyId, " +
             "InternalAppraiserId, InternalAppraiserName, " +
             "CollateralTypes, InspectionDates, DepartmentOfAppraisal " +
             "FROM appraisal.vw_AppraisalEvaluationHeader " +

--- a/Modules/Appraisal/Appraisal/Application/Evaluations/Queries/GetEvaluationListQuery.cs
+++ b/Modules/Appraisal/Appraisal/Application/Evaluations/Queries/GetEvaluationListQuery.cs
@@ -27,6 +27,9 @@ public record AppraisalEvaluationListItem(
     string?   ExternalAppraiserName,
     string?   AssigneeCompanyId,
     string?   AppraiserCompanyName,
+    // Thai name (null when absent); the client picks by its own locale. Position is load-bearing —
+    // it must stay directly after AppraiserCompanyName to match BaseQuery's column order.
+    string?   AppraiserCompanyNameLocal,
     decimal?  AppraisalValue,
     Guid?     EvaluationId,
     string    EvaluationStatus,
@@ -48,6 +51,7 @@ public class GetEvaluationListQueryHandler(ISqlConnectionFactory connectionFacto
     private const string BaseQuery =
         "SELECT AppraisalId, AppraisalNumber, CustomerName, ReportReceivedDate, " +
         "AppraisalStatus, ExternalAppraiserName, AssigneeCompanyId, AppraiserCompanyName, " +
+        "AppraiserCompanyNameLocal, " +
         "AppraisalValue, EvaluationId, EvaluationStatus, TotalScore " +
         "FROM appraisal.vw_AppraisalEvaluationList " +
         "WHERE 1 = 1";

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/ExportAppraisals/ExportAppraisalsQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/ExportAppraisals/ExportAppraisalsQueryHandler.cs
@@ -92,7 +92,7 @@ public class ExportAppraisalsQueryHandler(
             ws.Cell(row, 9).Value = item.SLAStatus ?? "";
             ws.Cell(row, 10).SetValue(item.SLADueDate);
             ws.Cell(row, 11).Value = item.AssignmentType ?? "";
-            ws.Cell(row, 12).Value = item.CompanyName ?? "";
+            ws.Cell(row, 12).Value = CompanyLabel(item) ?? "";
             ws.Cell(row, 13).SetValue(item.CreatedAt);
             ws.Cell(row, 14).SetValue(item.FacilityLimit ?? 0);
             ws.Cell(row, 15).Value = item.PropertyCount;
@@ -119,7 +119,7 @@ public class ExportAppraisalsQueryHandler(
                 $"\"{item.Status}\",\"{item.AppraisalType}\",\"{item.Priority}\"," +
                 $"\"{Esc(item.Province)}\",\"{Esc(item.District)}\",\"{item.SLAStatus}\"," +
                 $"\"{item.SLADueDate:yyyy-MM-dd}\",\"{item.AssignmentType}\"," +
-                $"\"{Esc(item.CompanyName)}\",\"{item.CreatedAt:yyyy-MM-dd HH:mm}\"," +
+                $"\"{Esc(CompanyLabel(item))}\",\"{item.CreatedAt:yyyy-MM-dd HH:mm}\"," +
                 $"{item.FacilityLimit ?? 0},{item.PropertyCount}");
         }
 
@@ -128,4 +128,11 @@ public class ExportAppraisalsQueryHandler(
     }
 
     private static string Esc(string? value) => (value ?? "").Replace("\"", "\"\"");
+
+    /// <summary>
+    /// Thai-first company label. The export has no request locale to pick from, so it follows the
+    /// same convention as the generated reports: prefer the Thai name, fall back to English.
+    /// </summary>
+    private static string? CompanyLabel(AppraisalDto item) =>
+        string.IsNullOrWhiteSpace(item.CompanyNameLocal) ? item.CompanyName : item.CompanyNameLocal;
 }

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalById/GetAppraisalByIdResponse.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalById/GetAppraisalByIdResponse.cs
@@ -26,6 +26,8 @@ public record GetAppraisalByIdResponse
     public int GroupCount { get; set; }
     public int AssignmentCount { get; set; }
     public string? CompanyName { get; set; }
+    /// <summary>Thai name; null when the company has none. The client picks by its own locale.</summary>
+    public string? CompanyNameLocal { get; set; }
     public string? AppraiserName { get; set; }
     public DateTime? AppraisalDate { get; set; }
     public decimal? AppraisalValue { get; set; }

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalById/GetAppraisalByIdResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisalById/GetAppraisalByIdResult.cs
@@ -30,6 +30,8 @@ public record GetAppraisalByIdResult
     public int GroupCount { get; set; }
     public int AssignmentCount { get; set; }
     public string? CompanyName { get; set; }
+    /// <summary>Thai name; null when the company has none. The client picks by its own locale.</summary>
+    public string? CompanyNameLocal { get; set; }
     public string? AppraiserName { get; set; }
     public DateTime? AppraisalDate { get; set; }
     public decimal? AppraisalValue { get; set; }

--- a/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Appraisals/GetAppraisals/GetAppraisalsResult.cs
@@ -44,6 +44,8 @@ public record AppraisalDto
     public string? AssignmentStatus { get; init; }
     public DateTime? AssignedDate { get; init; }
     public string? CompanyName { get; init; }
+    /// <summary>Thai name; null when the company has none. The client picks by its own locale.</summary>
+    public string? CompanyNameLocal { get; init; }
 
     // Customer Info
     public string? CustomerName { get; init; }

--- a/Modules/Appraisal/Appraisal/Application/Features/Invoices/GetInvoiceById/GetInvoiceByIdQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Invoices/GetInvoiceById/GetInvoiceByIdQueryHandler.cs
@@ -12,7 +12,7 @@ public class GetInvoiceByIdQueryHandler(ISqlConnectionFactory sqlConnectionFacto
         var connection = sqlConnectionFactory.GetOpenConnection();
 
         const string headerSql = """
-            SELECT Id, InvoiceNumber, Status, TotalAmount, CompanyName,
+            SELECT Id, InvoiceNumber, Status, TotalAmount, CompanyName, CompanyNameLocal,
                    BankAccountNo, BankAccountName, Notes,
                    PaymentOrderNo, PaidDate, ApprovedBy, ApprovedAt,
                    SubmittedAt, CompanyId

--- a/Modules/Appraisal/Appraisal/Application/Features/Invoices/GetInvoiceById/InvoiceDetailDto.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Invoices/GetInvoiceById/InvoiceDetailDto.cs
@@ -6,6 +6,9 @@ public record InvoiceDetailDto(
     string Status,
     decimal TotalAmount,
     string? CompanyName,
+    // Thai name (null when absent); the client picks by its own locale. Position is load-bearing —
+    // it must stay directly after CompanyName to match headerSql's column order.
+    string? CompanyNameLocal,
     string? BankAccountNo,
     string? BankAccountName,
     string? Notes,

--- a/Modules/Appraisal/Appraisal/Application/Features/Invoices/GetInvoiceList/GetInvoiceListQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Invoices/GetInvoiceList/GetInvoiceListQueryHandler.cs
@@ -88,7 +88,7 @@ public class GetInvoiceListQueryHandler(
         const string listColumns = """
             Id, InvoiceNumber, Status, TotalAmount, ItemCount,
             PeriodStartDate, PeriodEndDate, SubmittedAt, ApprovedAt, ApprovedBy,
-            PaymentOrderNo, PaidDate, SentDate, CompanyId, CompanyName, CreatedAt
+            PaymentOrderNo, PaidDate, SentDate, CompanyId, CompanyName, CompanyNameLocal, CreatedAt
             """;
         var aggregateSql = $"SELECT COUNT(Id) AS GrandItemCount, ISNULL(SUM(TotalAmount), 0) AS GrandTotalAmount FROM appraisal.vw_InvoiceList {where}";
         // Group-by clustering is always the leading key so rows stay grouped under

--- a/Modules/Appraisal/Appraisal/Application/Features/Invoices/GetInvoiceList/InvoiceListDto.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Invoices/GetInvoiceList/InvoiceListDto.cs
@@ -16,5 +16,8 @@ public record InvoiceListDto(
     DateTime? SentDate,
     Guid CompanyId,
     string? CompanyName,
+    // Thai name (null when absent); the client picks by its own locale. Position is load-bearing —
+    // it must stay directly after CompanyName to match listColumns' order.
+    string? CompanyNameLocal,
     DateTime CreatedAt
 );

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotationById/GetQuotationByIdQueryHandler.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotationById/GetQuotationByIdQueryHandler.cs
@@ -50,7 +50,8 @@ public class GetQuotationByIdQueryHandler(
             .Select(cq => new CompanyQuotationResult(
                 Id: cq.Id,
                 CompanyId: cq.CompanyId,
-                CompanyName: visibleCompanyNames.GetValueOrDefault(cq.CompanyId),
+                CompanyName: visibleCompanyNames.GetValueOrDefault(cq.CompanyId).Name,
+                CompanyNameLocal: visibleCompanyNames.GetValueOrDefault(cq.CompanyId).NameLocal,
                 QuotationNumber: cq.QuotationNumber,
                 Status: cq.Status,
                 DeclineReason: cq.DeclineReason,
@@ -162,7 +163,7 @@ public class GetQuotationByIdQueryHandler(
             var companyInfoMap = await ResolveCompanyInfoAsync(invitationCompanyIds);
             invitedCompanies = invitationCompanyIds
                 .Where(id => companyInfoMap.ContainsKey(id))
-                .Select(id => new InvitedCompanyResult(id, companyInfoMap[id].Name, companyInfoMap[id].Email))
+                .Select(id => new InvitedCompanyResult(id, companyInfoMap[id].Name, companyInfoMap[id].NameLocal, companyInfoMap[id].Email))
                 .OrderBy(r => r.CompanyName)
                 .ToList();
         }
@@ -360,38 +361,40 @@ public class GetQuotationByIdQueryHandler(
             });
     }
 
-    private async Task<Dictionary<Guid, string>> ResolveCompanyNamesAsync(Guid[] companyIds)
-    {
-        if (companyIds.Length == 0)
-            return new Dictionary<Guid, string>();
-
-        var connection = connectionFactory.GetOpenConnection();
-        var rows = await connection.QueryAsync<(Guid Id, string Name)>(
-            """
-            SELECT c.Id, c.Name
-            FROM auth.Companies c
-            WHERE c.Id IN @CompanyIds
-            """,
-            new { CompanyIds = companyIds });
-
-        return rows.ToDictionary(r => r.Id, r => r.Name);
-    }
-
-    private async Task<Dictionary<Guid, (string Name, string? Email)>> ResolveCompanyInfoAsync(Guid[] companyIds)
+    // Both resolvers return the English and Thai names side by side; the API has no request locale,
+    // so the client picks. NULLIF collapses '' to NULL for a single absent-test on the FE.
+    private async Task<Dictionary<Guid, (string Name, string? NameLocal)>> ResolveCompanyNamesAsync(Guid[] companyIds)
     {
         if (companyIds.Length == 0)
             return new Dictionary<Guid, (string, string?)>();
 
         var connection = connectionFactory.GetOpenConnection();
-        var rows = await connection.QueryAsync<(Guid Id, string Name, string? Email)>(
+        var rows = await connection.QueryAsync<(Guid Id, string Name, string? NameLocal)>(
             """
-            SELECT c.Id, c.Name, c.Email
+            SELECT c.Id, c.Name, NULLIF(c.NameLocal, N'') AS NameLocal
+            FROM auth.Companies c
+            WHERE c.Id IN @CompanyIds
+            """,
+            new { CompanyIds = companyIds });
+
+        return rows.ToDictionary(r => r.Id, r => (r.Name, r.NameLocal));
+    }
+
+    private async Task<Dictionary<Guid, (string Name, string? NameLocal, string? Email)>> ResolveCompanyInfoAsync(Guid[] companyIds)
+    {
+        if (companyIds.Length == 0)
+            return new Dictionary<Guid, (string, string?, string?)>();
+
+        var connection = connectionFactory.GetOpenConnection();
+        var rows = await connection.QueryAsync<(Guid Id, string Name, string? NameLocal, string? Email)>(
+            """
+            SELECT c.Id, c.Name, NULLIF(c.NameLocal, N'') AS NameLocal, c.Email
             FROM [auth].[Companies] c
             WHERE c.Id IN @CompanyIds
             """,
             new { CompanyIds = companyIds });
 
-        return rows.ToDictionary(r => r.Id, r => (r.Name, r.Email));
+        return rows.ToDictionary(r => r.Id, r => (r.Name, r.NameLocal, r.Email));
     }
 
     private async Task<IReadOnlyList<QuotationSharedDocumentResult>> EnrichSharedDocumentsAsync(

--- a/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotationById/GetQuotationByIdResult.cs
+++ b/Modules/Appraisal/Appraisal/Application/Features/Quotations/GetQuotationById/GetQuotationByIdResult.cs
@@ -119,6 +119,8 @@ public record CompanyQuotationResult(
     Guid Id,
     Guid CompanyId,
     string? CompanyName,
+    /// <summary>Thai name; null when the company has none. The client picks by its own locale.</summary>
+    string? CompanyNameLocal,
     string QuotationNumber,
     string Status,
     /// <summary>Maker's "not participate" reason. Set while a decline is PendingCheckerReview (the intent
@@ -169,4 +171,4 @@ public record CompanyQuotationNegotiationResult(
     DateTime? RespondedAt
 );
 
-public sealed record InvitedCompanyResult(Guid CompanyId, string CompanyName, string? Email);
+public sealed record InvitedCompanyResult(Guid CompanyId, string CompanyName, string? CompanyNameLocal, string? Email);

--- a/Modules/Auth/Auth.Contracts/Users/UserLookupDto.cs
+++ b/Modules/Auth/Auth.Contracts/Users/UserLookupDto.cs
@@ -1,3 +1,5 @@
 namespace Auth.Contracts.Users;
 
-public record UserLookupDto(string Username, string FirstName, string LastName, string? CompanyName = null);
+// CompanyNameLocal is the Thai company name (null when absent). UI callers pick by their own locale;
+// the notification/email handlers prefer it outright because those messages are Thai-language.
+public record UserLookupDto(string Username, string FirstName, string LastName, string? CompanyName = null, string? CompanyNameLocal = null);

--- a/Modules/Auth/Auth/Application/Features/Companies/GetEligibleCompanies/GetEligibleCompaniesQueryHandler.cs
+++ b/Modules/Auth/Auth/Application/Features/Companies/GetEligibleCompanies/GetEligibleCompaniesQueryHandler.cs
@@ -33,7 +33,7 @@ public class GetEligibleCompaniesQueryHandler(
         {
             overviewMap.TryGetValue(c.Id, out var ov);
             return new EligibleCompanyDto(
-                c.Id, c.Name, c.ContactPerson, c.Phone, c.Email, c.TaxId,
+                c.Id, c.Name, c.NameLocal, c.ContactPerson, c.Phone, c.Email, c.TaxId,
                 AverageRating:    ov?.AverageRating    ?? 0m,
                 EvaluationCount:  ov?.EvaluationCount  ?? 0,
                 ActiveAssignments: ov?.ActiveAssignments ?? 0,

--- a/Modules/Auth/Auth/Application/Features/Companies/GetEligibleCompanies/GetEligibleCompaniesResult.cs
+++ b/Modules/Auth/Auth/Application/Features/Companies/GetEligibleCompanies/GetEligibleCompaniesResult.cs
@@ -5,6 +5,9 @@ public record GetEligibleCompaniesResult(List<EligibleCompanyDto> Companies);
 public record EligibleCompanyDto(
     Guid    Id,
     string  Name,
+    // Thai name. Nullable — the FE falls back to Name when it is absent. Returned alongside (not
+    // instead of) Name because the API has no request locale; the client picks by its own language.
+    string? NameLocal,
     string? ContactPerson,
     string? Phone,
     string? Email,

--- a/Modules/Auth/Auth/Application/Features/Users/GetUserById/GetUserByIdQueryHandler.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/GetUserById/GetUserByIdQueryHandler.cs
@@ -46,13 +46,19 @@ public class GetUserByIdQueryHandler(
             .Select(up => new UserPermissionDto(up.Permission.Id, up.Permission.PermissionCode, up.IsGranted))
             .ToList();
 
-        // Resolve company name (null for bank-internal users who have no CompanyId)
+        // Resolve company name (null for bank-internal users who have no CompanyId).
+        // Both languages are returned side by side; the client picks by its own locale.
         string? companyName = null;
+        string? companyNameLocal = null;
         if (user.CompanyId.HasValue)
-            companyName = await dbContext.Companies
+        {
+            var company = await dbContext.Companies
                 .Where(c => c.Id == user.CompanyId.Value)
-                .Select(c => c.Name)
+                .Select(c => new { c.Name, c.NameLocal })
                 .FirstOrDefaultAsync(cancellationToken);
+            companyName = company?.Name;
+            companyNameLocal = string.IsNullOrWhiteSpace(company?.NameLocal) ? null : company!.NameLocal;
+        }
 
         // Compare in UTC: LockoutEnd is a DateTimeOffset; comparing its UTC instant
         // against UtcNow avoids implicit local-offset conversion bugs.
@@ -72,6 +78,7 @@ public class GetUserByIdQueryHandler(
             user.EmployeeId,
             user.CompanyId,
             companyName,
+            companyNameLocal,
             user.AuthSource,
             user.IsActive,
             isLocked,

--- a/Modules/Auth/Auth/Application/Features/Users/GetUserById/GetUserByIdResult.cs
+++ b/Modules/Auth/Auth/Application/Features/Users/GetUserById/GetUserByIdResult.cs
@@ -23,6 +23,8 @@ public record GetUserByIdResult(
     string? EmployeeId,
     Guid? CompanyId,
     string? CompanyName,
+    // Thai name; null when the company has none. The client picks by its own locale.
+    string? CompanyNameLocal,
     string AuthSource,
     bool IsActive,
     bool IsLocked,

--- a/Modules/Auth/Auth/Application/Services/UserLookupService.cs
+++ b/Modules/Auth/Auth/Application/Services/UserLookupService.cs
@@ -39,7 +39,8 @@ public class UserLookupService(AuthDbContext db, UserManager<ApplicationUser> us
                     x.User.UserName!,
                     x.User.FirstName,
                     x.User.LastName,
-                    company != null ? company.Name : null))
+                    company != null ? company.Name : null,
+                    company != null ? company.NameLocal : null))
             .ToListAsync(cancellationToken);
 
         return users.ToDictionary(u => u.Username, StringComparer.OrdinalIgnoreCase);

--- a/Modules/Collateral/Collateral/Application/Features/CollateralMasters/GetEngagements/GetEngagementsQueryHandler.cs
+++ b/Modules/Collateral/Collateral/Application/Features/CollateralMasters/GetEngagements/GetEngagementsQueryHandler.cs
@@ -24,6 +24,7 @@ public class GetEngagementsQueryHandler(
             AppraiserUserId,
             AppraisalCompanyId,
             AppraisalCompanyName,
+            AppraisalCompanyNameLocal,
             ConstructionInspectionFeeAmount,
             CreatedAt,
             CollateralType,

--- a/Modules/Collateral/Collateral/Application/Features/CollateralMasters/GetEngagements/GetEngagementsResult.cs
+++ b/Modules/Collateral/Collateral/Application/Features/CollateralMasters/GetEngagements/GetEngagementsResult.cs
@@ -19,6 +19,9 @@ public record EngagementListItemDto(
     string? AppraiserUserId,
     Guid? AppraisalCompanyId,
     string? AppraisalCompanyName,
+    // Thai name resolved live from auth.Companies (the name above is a frozen snapshot). Position is
+    // load-bearing — it must stay directly after AppraisalCompanyName to match the SELECT order.
+    string? AppraisalCompanyNameLocal,
     decimal? ConstructionInspectionFeeAmount,
     DateTime CreatedAt,
     string CollateralType,

--- a/Modules/Common/Common/Application/Features/Dashboard/GetCompanyAppraisalSummary/GetCompanyAppraisalSummaryQuery.cs
+++ b/Modules/Common/Common/Application/Features/Dashboard/GetCompanyAppraisalSummary/GetCompanyAppraisalSummaryQuery.cs
@@ -13,6 +13,8 @@ public record CompanyAppraisalSummaryDto
 {
     public Guid CompanyId { get; init; }
     public string CompanyName { get; init; } = default!;
+    /// <summary>Thai name; null when the company has none. The client picks by its own locale.</summary>
+    public string? CompanyNameLocal { get; init; }
     public int AssignedCount { get; init; }
     public int CompletedCount { get; init; }
     public int OverdueCount { get; init; }

--- a/Modules/Common/Common/Application/Features/Dashboard/GetCompanyAppraisalSummary/GetCompanyAppraisalSummaryQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Dashboard/GetCompanyAppraisalSummary/GetCompanyAppraisalSummaryQueryHandler.cs
@@ -47,6 +47,7 @@ public class GetCompanyAppraisalSummaryQueryHandler(
         var sql = $"""
             SELECT CompanyId,
                    COALESCE(MAX(NULLIF(CompanyName, N'')), N'(pending)') AS CompanyName,
+                   MAX(NULLIF(CompanyNameLocal, N''))                    AS CompanyNameLocal,
                    COUNT(*)          AS AssignedCount,
                    SUM(IsCompleted)  AS CompletedCount,
                    SUM(IsOverdue)    AS OverdueCount,

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/GetPendingEvaluationsQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/GetPendingEvaluationsQueryHandler.cs
@@ -34,6 +34,7 @@ SELECT
     ExternalAppraiserName,
     AssigneeCompanyId,
     AppraiserCompanyName,
+    AppraiserCompanyNameLocal,
     AppraisalValue,
     EvaluationId,
     EvaluationStatus,

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/PendingEvaluationDto.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingEvaluations/PendingEvaluationDto.cs
@@ -9,6 +9,9 @@ public record PendingEvaluationDto(
     string? ExternalAppraiserName,
     string? AssigneeCompanyId,
     string? AppraiserCompanyName,
+    // Thai name (null when absent); the client picks by its own locale. Position is load-bearing —
+    // it must stay directly after AppraiserCompanyName to match the handler's SELECT order.
+    string? AppraiserCompanyNameLocal,
     decimal? AppraisalValue,
     Guid? EvaluationId,
     string? EvaluationStatus,

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalGroupedQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalGroupedQueryHandler.cs
@@ -84,12 +84,13 @@ public class GetPendingExternalGroupedQueryHandler(
         }
 
         var where = "WHERE " + string.Join(" AND ", conditions);
-        var (keyExpr, labelExpr, groupByExpr) = ResolveGrouping(query.GroupBy);
+        var (keyExpr, labelExpr, labelLocalExpr, groupByExpr) = ResolveGrouping(query.GroupBy);
 
         var sql = $@"
 SELECT
     {keyExpr} AS [Key],
     {labelExpr} AS Label,
+    {labelLocalExpr} AS LabelLocal,
     COUNT(*) AS Count,
     SUM(CASE WHEN OlaVarianceHours > 0 THEN 1 ELSE 0 END) AS Breached,
     SUM(CASE WHEN OlaVarianceHours <= 0
@@ -116,6 +117,8 @@ FROM common.vw_MonitoringPendingTasks
             .Select(g => new MonitoringGroupRow(
                 g.Key ?? string.Empty,
                 g.Label ?? string.Empty,
+
+                g.LabelLocal,
                 g.Count,
                 g.Breached,
                 g.AtRisk))
@@ -124,21 +127,26 @@ FROM common.vw_MonitoringPendingTasks
         return new MonitoringGroupedResult(result, total);
     }
 
-    private static (string keyExpr, string labelExpr, string groupByExpr) ResolveGrouping(string groupBy) =>
+    private static (string keyExpr, string labelExpr, string labelLocalExpr, string groupByExpr) ResolveGrouping(string groupBy) =>
         groupBy.ToLowerInvariant() switch
         {
             // Key = AssignedTo (usercode/pool-name); Label = MAX(PIC) display name. See Internal handler.
             "pic" => (
                 "AssignedTo",
                 "MAX(PIC)",
+                "CAST(NULL AS nvarchar(200))",
                 "AssignedTo"),
             "company" => (
+                // Key stays the ENGLISH name so the grouping identity (and drill-in) is
+                // language-independent; only LabelLocal varies by language.
                 "COALESCE(NULLIF(AppraisalCompanyName, ''), 'Unassigned')",
                 "COALESCE(NULLIF(AppraisalCompanyName, ''), 'Unassigned')",
+                "MAX(NULLIF(AppraisalCompanyNameLocal, ''))",
                 "COALESCE(NULLIF(AppraisalCompanyName, ''), 'Unassigned')"),
             "activity" => (
                 "ActivityId",
                 "ActivityId",
+                "CAST(NULL AS nvarchar(200))",
                 "ActivityId"),
             _ => throw new ArgumentException($"Unsupported groupBy value '{groupBy}'. Allowed: pic, company, activity.", nameof(groupBy))
         };
@@ -162,5 +170,5 @@ FROM common.vw_MonitoringPendingTasks
     private static string EscapeLike(string input) =>
         input.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_").Replace("[", "\\[");
 
-    private record GroupRow(string? Key, string? Label, int Count, int Breached, int AtRisk);
+    private record GroupRow(string? Key, string? Label, string? LabelLocal, int Count, int Breached, int AtRisk);
 }

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingExternal/GetPendingExternalQueryHandler.cs
@@ -53,6 +53,7 @@ SELECT
     OlaVarianceHours,
     ActivityId,
     AppraisalCompanyName,
+    AppraisalCompanyNameLocal,
     MonitoringType,
     AssignedTo,
     AssignedType,

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsGroupedQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsGroupedQueryHandler.cs
@@ -75,12 +75,13 @@ public class GetPendingFollowupsGroupedQueryHandler(ISqlConnectionFactory connec
         }
 
         var where = "WHERE " + string.Join(" AND ", conditions);
-        var (keyExpr, labelExpr, groupByExpr) = ResolveGrouping(query.GroupBy);
+        var (keyExpr, labelExpr, labelLocalExpr, groupByExpr) = ResolveGrouping(query.GroupBy);
 
         var sql = $@"
 SELECT
     {keyExpr} AS [Key],
     {labelExpr} AS Label,
+    {labelLocalExpr} AS LabelLocal,
     COUNT(*) AS Count,
     SUM(CASE WHEN OlaVarianceHours > 0 THEN 1 ELSE 0 END) AS Breached,
     SUM(CASE WHEN OlaVarianceHours <= 0
@@ -107,6 +108,8 @@ FROM common.vw_MonitoringPendingTasks
             .Select(g => new MonitoringGroupRow(
                 g.Key ?? string.Empty,
                 g.Label ?? string.Empty,
+
+                g.LabelLocal,
                 g.Count,
                 g.Breached,
                 g.AtRisk))
@@ -115,20 +118,25 @@ FROM common.vw_MonitoringPendingTasks
         return new MonitoringGroupedResult(result, total);
     }
 
-    private static (string keyExpr, string labelExpr, string groupByExpr) ResolveGrouping(string groupBy) =>
+    private static (string keyExpr, string labelExpr, string labelLocalExpr, string groupByExpr) ResolveGrouping(string groupBy) =>
         groupBy.ToLowerInvariant() switch
         {
             "pic" => (
                 "AssignedTo",
                 "MAX(PIC)",
+                "CAST(NULL AS nvarchar(200))",
                 "AssignedTo"),
             "company" => (
+                // Key stays the ENGLISH name so the grouping identity (and drill-in) is
+                // language-independent; only LabelLocal varies by language.
                 "COALESCE(NULLIF(AppraisalCompanyName, ''), 'Unassigned')",
                 "COALESCE(NULLIF(AppraisalCompanyName, ''), 'Unassigned')",
+                "MAX(NULLIF(AppraisalCompanyNameLocal, ''))",
                 "COALESCE(NULLIF(AppraisalCompanyName, ''), 'Unassigned')"),
             "activity" => (
                 "ActivityId",
                 "ActivityId",
+                "CAST(NULL AS nvarchar(200))",
                 "ActivityId"),
             _ => throw new ArgumentException($"Unsupported groupBy value '{groupBy}'. Allowed: pic, company, activity.", nameof(groupBy))
         };
@@ -152,5 +160,5 @@ FROM common.vw_MonitoringPendingTasks
     private static string EscapeLike(string input) =>
         input.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_").Replace("[", "\\[");
 
-    private record GroupRow(string? Key, string? Label, int Count, int Breached, int AtRisk);
+    private record GroupRow(string? Key, string? Label, string? LabelLocal, int Count, int Breached, int AtRisk);
 }

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingFollowups/GetPendingFollowupsQueryHandler.cs
@@ -50,6 +50,7 @@ SELECT
     OlaVarianceHours,
     ActivityId,
     AppraisalCompanyName,
+    AppraisalCompanyNameLocal,
     MonitoringType,
     AssignedTo,
     AssignedType,

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalGroupedQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalGroupedQueryHandler.cs
@@ -83,12 +83,13 @@ public class GetPendingInternalGroupedQueryHandler(
         }
 
         var where = "WHERE " + string.Join(" AND ", conditions);
-        var (keyExpr, labelExpr, groupByExpr) = ResolveGrouping(query.GroupBy);
+        var (keyExpr, labelExpr, labelLocalExpr, groupByExpr) = ResolveGrouping(query.GroupBy);
 
         var sql = $@"
 SELECT
     {keyExpr} AS [Key],
     {labelExpr} AS Label,
+    {labelLocalExpr} AS LabelLocal,
     COUNT(*) AS Count,
     SUM(CASE WHEN OlaVarianceHours > 0 THEN 1 ELSE 0 END) AS Breached,
     SUM(CASE WHEN OlaVarianceHours <= 0
@@ -115,6 +116,8 @@ FROM common.vw_MonitoringPendingTasks
             .Select(g => new MonitoringGroupRow(
                 g.Key ?? string.Empty,
                 g.Label ?? string.Empty,
+
+                g.LabelLocal,
                 g.Count,
                 g.Breached,
                 g.AtRisk))
@@ -129,7 +132,7 @@ FROM common.vw_MonitoringPendingTasks
     /// Throws ArgumentException for any value not in the allowlist — the endpoint
     /// validates first, so this is defense in depth.
     /// </summary>
-    private static (string keyExpr, string labelExpr, string groupByExpr) ResolveGrouping(string groupBy) =>
+    private static (string keyExpr, string labelExpr, string labelLocalExpr, string groupByExpr) ResolveGrouping(string groupBy) =>
         groupBy.ToLowerInvariant() switch
         {
             // Key = AssignedTo (usercode/pool-name) so drill-in searches by stable identifier;
@@ -137,14 +140,19 @@ FROM common.vw_MonitoringPendingTasks
             "pic" => (
                 "AssignedTo",
                 "MAX(PIC)",
+                "CAST(NULL AS nvarchar(200))",
                 "AssignedTo"),
             "company" => (
+                // Key stays the ENGLISH name so the grouping identity (and drill-in) is
+                // language-independent; only LabelLocal varies by language.
                 "COALESCE(NULLIF(AppraisalCompanyName, ''), 'Unassigned')",
                 "COALESCE(NULLIF(AppraisalCompanyName, ''), 'Unassigned')",
+                "MAX(NULLIF(AppraisalCompanyNameLocal, ''))",
                 "COALESCE(NULLIF(AppraisalCompanyName, ''), 'Unassigned')"),
             "activity" => (
                 "ActivityId",
                 "ActivityId",
+                "CAST(NULL AS nvarchar(200))",
                 "ActivityId"),
             _ => throw new ArgumentException($"Unsupported groupBy value '{groupBy}'. Allowed: pic, company, activity.", nameof(groupBy))
         };
@@ -168,5 +176,5 @@ FROM common.vw_MonitoringPendingTasks
     private static string EscapeLike(string input) =>
         input.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_").Replace("[", "\\[");
 
-    private record GroupRow(string? Key, string? Label, int Count, int Breached, int AtRisk);
+    private record GroupRow(string? Key, string? Label, string? LabelLocal, int Count, int Breached, int AtRisk);
 }

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalQueryHandler.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/GetPendingInternalQueryHandler.cs
@@ -53,6 +53,7 @@ SELECT
     OlaVarianceHours,
     ActivityId,
     AppraisalCompanyName,
+    AppraisalCompanyNameLocal,
     MonitoringType,
     AssignedTo,
     AssignedType,

--- a/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/PendingTaskDto.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/GetPendingInternal/PendingTaskDto.cs
@@ -20,6 +20,9 @@ public record PendingTaskDto(
     int? OlaVarianceHours,
     string? ActivityId,
     string? AppraisalCompanyName,
+    // Thai name (null when absent); the client picks by its own locale. Position is load-bearing —
+    // it must stay directly after AppraisalCompanyName to match the handlers' SELECT order.
+    string? AppraisalCompanyNameLocal,
     string MonitoringType,
     string? AssignedTo,
     string? AssignedType,

--- a/Modules/Common/Common/Application/Features/Monitoring/Shared/MonitoringGroupedResult.cs
+++ b/Modules/Common/Common/Application/Features/Monitoring/Shared/MonitoringGroupedResult.cs
@@ -14,12 +14,18 @@ public record MonitoringGroupedResult(
 /// </summary>
 /// <param name="Key">Grouping key: user id, company id, or activity id.</param>
 /// <param name="Label">Display label: PIC name, company name, or activity id (frontend resolves via MonitoringActivityMap).</param>
+/// <param name="LabelLocal">
+/// Thai display label, currently only for groupBy=company. Null for pic/activity grouping and for
+/// companies with no Thai name — the client falls back to <paramref name="Label"/>. Kept separate
+/// from Key so the grouping identity stays language-independent.
+/// </param>
 /// <param name="Count">Total rows in this group under the active filter.</param>
 /// <param name="Breached">Count of rows where OlaVarianceHours &gt; 0.</param>
 /// <param name="AtRisk">Count of rows where OlaVarianceHours &lt;= 0 AND remaining &lt;= 25% of target (excluding zero-target rows).</param>
 public record MonitoringGroupRow(
     string Key,
     string Label,
+    string? LabelLocal,
     int Count,
     int Breached,
     int AtRisk

--- a/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/AppraisalResults/GetAppraisalResult/GetAppraisalResultQueryHandler.cs
@@ -102,7 +102,15 @@ internal static class GetAppraisalResultSql
                                                aa.AssignmentType,
                                                aa.AssigneeUserId,
                                                aa.AssigneeCompanyId,
-                                               c.Name AS CompanyName,
+                                               -- Thai-first. This SQL is shared by BOTH result endpoints, and both are JSON:
+                                               --   POST /api/v1/appraisals/result  (LegacyAppraisalResultEnvelope)
+                                               --   GET  /api/v2/appraisals/{no}/result
+                                               -- Neither is fixed-width, so there is no column-width or byte-offset limit here.
+                                               -- NOTE: the AS400 fixed-width ExternalValuerName is a DIFFERENT path — it reads
+                                               -- the frozen collateral.CollateralEngagements.AppraisalCompanyName snapshot via
+                                               -- Collateral/CollateralMasters/CollateralResult/CollateralResultQuery.cs, which
+                                               -- stays English. Don't conflate the two.
+                                               COALESCE(NULLIF(c.NameLocal, N''), c.Name) AS CompanyName,
                                                c.HostCompanyCode AS CompanyCode,
                                                u.FirstName AS UserFirstName,
                                                u.LastName  AS UserLastName,

--- a/Modules/Integration/Integration/Application/Features/Quotations/GetQuotationValuers/GetQuotationValuersQueryHandler.cs
+++ b/Modules/Integration/Integration/Application/Features/Quotations/GetQuotationValuers/GetQuotationValuersQueryHandler.cs
@@ -21,7 +21,7 @@ public class GetQuotationValuersQueryHandler(
                                          """;
 
     private const string SqlShortlistedCompanies = """
-                                                   SELECT cq.Id AS CompanyQuotationId, c.Name AS CompanyName, cq.TotalQuotedPrice, cq.EstimatedDays 
+                                                   SELECT cq.Id AS CompanyQuotationId, COALESCE(NULLIF(c.NameLocal, N''), c.Name) AS CompanyName, cq.TotalQuotedPrice, cq.EstimatedDays 
                                                    FROM appraisal.CompanyQuotations cq
                                                    JOIN auth.Companies c ON c.Id = cq.CompanyId
                                                    WHERE cq.QuotationRequestId = @QuotationId AND cq.IsShortlisted = 1

--- a/Modules/Integration/Integration/Application/Services/QuotationFinalizeLookupService.cs
+++ b/Modules/Integration/Integration/Application/Services/QuotationFinalizeLookupService.cs
@@ -14,7 +14,8 @@ public class QuotationFinalizeLookupService(
         SELECT
             qr.QuotationNumber AS QuotationNumber,
             cq.Id AS CompanyQuotationId,
-            c.Name AS ValuerName,
+            -- Thai-first: this feed is Thai-facing, so prefer NameLocal and fall back to Name.
+            COALESCE(NULLIF(c.NameLocal, N''), c.Name) AS ValuerName,
             COALESCE(cq.CurrentNegotiatedPrice, cq.TotalQuotedPrice) AS TotalAppraisalFee,
             cq.EstimatedDays AS EstimatedDays
         FROM appraisal.CompanyQuotations cq

--- a/Modules/Notification/Notification/Application/EventHandlers/QuotationFinalizedNotificationHandler.cs
+++ b/Modules/Notification/Notification/Application/EventHandlers/QuotationFinalizedNotificationHandler.cs
@@ -80,7 +80,9 @@ public class QuotationFinalizedNotificationHandler(
             if (usernames.Length == 0) return null;
 
             var lookup = await userLookupService.GetByUsernamesAsync(usernames, ct);
-            return lookup.Values.FirstOrDefault(u => u.CompanyName != null)?.CompanyName;
+            // These notifications are Thai-language, so prefer the Thai company name.
+            var company = lookup.Values.FirstOrDefault(u => u.CompanyName != null);
+            return company is null ? null : (company.CompanyNameLocal ?? company.CompanyName);
         }
         catch (Exception ex)
         {

--- a/Modules/Notification/Notification/Application/EventHandlers/ShortlistSentToRmEmailHandler.cs
+++ b/Modules/Notification/Notification/Application/EventHandlers/ShortlistSentToRmEmailHandler.cs
@@ -100,7 +100,9 @@ public sealed class ShortlistSentToRmEmailHandler(
             var usernames = await userLookupService.GetUsernamesInRoleAsync("ExtAdmin", companyId, ct);
             if (usernames.Length == 0) return null;
             var lookup = await userLookupService.GetByUsernamesAsync(usernames, ct);
-            return lookup.Values.FirstOrDefault(u => u.CompanyName != null)?.CompanyName;
+            // These notifications are Thai-language, so prefer the Thai company name.
+            var company = lookup.Values.FirstOrDefault(u => u.CompanyName != null);
+            return company is null ? null : (company.CompanyNameLocal ?? company.CompanyName);
         }
         catch (Exception ex)
         {

--- a/Modules/Reporting/Reporting/Application/OperationalReports/Ola/OlaReport.cs
+++ b/Modules/Reporting/Reporting/Application/OperationalReports/Ola/OlaReport.cs
@@ -97,7 +97,7 @@ internal static class OlaReport
 
         ReportFilterSql.DateRange(c, p, f.CreatedFrom, f.CreatedTo, "AppraisalCreateDate", "Created");
         ReportFilterSql.MultiValue(c, p, f.Status, "AppraisalStatus", "Statuses");
-        ReportFilterSql.Contains(c, p, f.AppraisalCompany, "AppraisalCompany", "AppraisalCompany");
+        ReportFilterSql.ContainsAny(c, p, f.AppraisalCompany, ["AppraisalCompany", "AppraisalCompanyEn"], "AppraisalCompany");
         // Filter on the raw assignee code (InternalAppraisalStaffCode); the InternalAppraisalStaff
         // column now emits the resolved "CODE - First Last" for display, so binding the code against it
         // would never match.

--- a/Modules/Reporting/Reporting/Application/OperationalReports/Rcas007/SlaReport.cs
+++ b/Modules/Reporting/Reporting/Application/OperationalReports/Rcas007/SlaReport.cs
@@ -83,7 +83,7 @@ internal static class SlaReport
 
         ReportFilterSql.DateRange(c, p, f.CreatedFrom, f.CreatedTo, "AppraisalCreateDate", "Created");
         ReportFilterSql.MultiValue(c, p, f.Status, "AppraisalStatus", "Statuses");
-        ReportFilterSql.Contains(c, p, f.AppraisalCompany, "AppraisalCompany", "AppraisalCompany");
+        ReportFilterSql.ContainsAny(c, p, f.AppraisalCompany, ["AppraisalCompany", "AppraisalCompanyEn"], "AppraisalCompany");
         ReportFilterSql.Exact(c, p, f.InternalStaff, "InternalAppraisalStaffCode", "InternalStaff");
         ReportFilterSql.Contains(c, p, f.AppraisalNumber, "AppraisalNumber", "AppraisalNumber");
         ReportFilterSql.MultiValue(c, p, f.Purpose, "PurposeCode", "Purposes");

--- a/Modules/Reporting/Reporting/Application/OperationalReports/Rcas008/Rcas008Report.cs
+++ b/Modules/Reporting/Reporting/Application/OperationalReports/Rcas008/Rcas008Report.cs
@@ -71,7 +71,7 @@ internal static class Rcas008Report
 
         ReportFilterSql.DateRange(c, p, f.ApprovedFrom, f.ApprovedTo, "ApprovedDate", "Approved");
         ReportFilterSql.MultiValue(c, p, f.BankingSegment, "BankingSegment", "BankingSegments");
-        ReportFilterSql.Contains(c, p, f.AppraisalCompany, "AppraisalCompany", "AppraisalCompany");
+        ReportFilterSql.ContainsAny(c, p, f.AppraisalCompany, ["AppraisalCompany", "AppraisalCompanyEn"], "AppraisalCompany");
         ReportFilterSql.MultiValue(c, p, f.EvaluationStatus, "EvaluationStatus", "EvaluationStatuses");
         ReportFilterSql.Contains(c, p, f.AppraisalNumber, "AppraisalNumber", "AppraisalNumber");
         // Purpose binds the raw code (PurposeCode); Appraisal type binds its stored code.

--- a/Modules/Reporting/Reporting/Application/OperationalReports/Rcas009/Rcas009Report.cs
+++ b/Modules/Reporting/Reporting/Application/OperationalReports/Rcas009/Rcas009Report.cs
@@ -73,7 +73,7 @@ internal static class Rcas009Report
         // Filter on the raw FeePaymentType code (PayTypeCode); the PayType column now emits the
         // resolved description for display, so binding the code against it would never match.
         ReportFilterSql.MultiValue(c, p, f.PayType, "PayTypeCode", "PayTypes");
-        ReportFilterSql.Contains(c, p, f.AppraisalCompany, "AppraisalCompany", "AppraisalCompany");
+        ReportFilterSql.ContainsAny(c, p, f.AppraisalCompany, ["AppraisalCompany", "AppraisalCompanyEn"], "AppraisalCompany");
         ReportFilterSql.MultiValue(c, p, f.FeeStatus, "FeeStatus", "FeeStatuses");
         ReportFilterSql.Contains(c, p, f.AppraisalNumber, "AppraisalNumber", "AppraisalNumber");
 

--- a/Modules/Reporting/Reporting/Application/OperationalReports/Rcas010/Rcas010Report.cs
+++ b/Modules/Reporting/Reporting/Application/OperationalReports/Rcas010/Rcas010Report.cs
@@ -72,7 +72,7 @@ internal static class Rcas010Report
         ReportFilterSql.Exact(c, p, f.AoCode, "RequestorAoCode", "AoCode");
         ReportFilterSql.MultiValue(c, p, f.Status, "AppraisalStatus", "Statuses");
         ReportFilterSql.MultiValue(c, p, f.FeeType, "FeePaymentType", "FeeTypes");
-        ReportFilterSql.Contains(c, p, f.AppraisalCompany, "AppraisalCompany", "AppraisalCompany");
+        ReportFilterSql.ContainsAny(c, p, f.AppraisalCompany, ["AppraisalCompany", "AppraisalCompanyEn"], "AppraisalCompany");
 
         // Single-row aggregate. Internal/External are column groups (conditional aggregates), not row
         // dimensions. Counts are distinct appraisal books; fees are per-fee sums. Column order matches

--- a/Modules/Reporting/Reporting/Application/OperationalReports/Shared/ReportFilterSql.cs
+++ b/Modules/Reporting/Reporting/Application/OperationalReports/Shared/ReportFilterSql.cs
@@ -62,6 +62,21 @@ internal static class ReportFilterSql
         p.Add(name, value.Trim());
     }
 
+    /// <summary>
+    /// Contains-match against ANY of <paramref name="columns"/> (OR-ed). Used where one logical field
+    /// is projected in two languages — e.g. AppraisalCompany (Thai-first, for display) alongside
+    /// AppraisalCompanyEn — so a filter matches whichever name the caller happens to hold.
+    /// The column names are report-defined constants, never user input; only the value is bound.
+    /// </summary>
+    public static void ContainsAny(
+        List<string> conditions, DynamicParameters p, string? value, string[] columns, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value) || columns.Length == 0) return;
+        conditions.Add("(" + string.Join(" OR ",
+            columns.Select(col => $"{col} LIKE '%' + @{name} + '%'")) + ")");
+        p.Add(name, value.Trim());
+    }
+
     public static string Where(List<string> conditions) =>
         conditions.Count > 0 ? " WHERE " + string.Join(" AND ", conditions) : "";
 

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryCommonLoader.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryCommonLoader.cs
@@ -383,8 +383,10 @@ internal static class AppraisalSummaryCommonLoader
             else if (!string.IsNullOrWhiteSpace(assignment.AssigneeCompanyId)
                      && Guid.TryParse(assignment.AssigneeCompanyId, out var companyGuid))
             {
+                // Thai-language document: prefer the Thai company name, fall back to English.
+                // Matches the internal branch above, which is already a hardcoded Thai bank name.
                 const string companySql = """
-                    SELECT c.Name FROM auth.Companies c WHERE c.Id = @CompanyId
+                    SELECT COALESCE(NULLIF(c.NameLocal, N''), c.Name) FROM auth.Companies c WHERE c.Id = @CompanyId
                     """;
                 var companyParams = new DynamicParameters();
                 companyParams.Add("CompanyId", companyGuid);
@@ -588,9 +590,9 @@ internal static class AppraisalSummaryCommonLoader
             IsProfitRent: globalFlags.IsProfitRent,
             GroupMethodTypes: groupMethodTypes,
             AppraiserComment: FirstNonBlank(decision?.InternalAppraiserOpinion),
-            Condition: decision?.Condition,
-            Remark: decision?.Remark,
-            CommitteeOpinion: decision?.CommitteeOpinion,
+            Condition: FirstNonBlank(decision?.Condition),
+            Remark: FirstNonBlank(decision?.Remark),
+            CommitteeOpinion: FirstNonBlank(decision?.CommitteeOpinion),
             AoName: aoName,
             CheckerName: checkerName,
             CheckerPosition: checkerPosition,

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryLandBuildingDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryLandBuildingDataProvider.cs
@@ -338,7 +338,7 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
                 lt.PageNumber,
                 lt.LandParcelNumber,
                 lt.SurveyNumber,
-                lt.MapSheetNumber,
+                lt.Rawang,
                 lt.AreaRai,
                 lt.AreaNgan,
                 lt.AreaSquareWa,
@@ -480,16 +480,21 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
                 WHERE a6.Id = @AppraisalId AND a6.IsDeleted = 0)
               AND rp.PropertyType IS NOT NULL;
 
-            -- RS22: Land titles for the government price (per sq.wa), excluding missing-from-survey
+            -- RS22: Land titles for the government price (per sq.wa). Missing-from-survey titles
+            -- are NOT filtered out here — they render as "ตกสำรวจ" instead of a price, so the flag
+            -- has to reach C#. They come through even without a price; a surveyed title still
+            -- needs one to be worth showing.
             SELECT
+                lt.Id AS TitleId,
                 lt.TitleNumber,
-                lt.GovernmentPricePerSqWa
+                lt.GovernmentPricePerSqWa,
+                lt.IsMissingFromSurvey
             FROM appraisal.LandTitles lt
             JOIN appraisal.LandAppraisalDetails lad ON lad.Id = lt.LandAppraisalDetailId
             JOIN appraisal.AppraisalProperties ap ON ap.Id = lad.AppraisalPropertyId
             WHERE ap.AppraisalId = @AppraisalId
-              AND ISNULL(lt.IsMissingFromSurvey, 0) = 0
-              AND lt.GovernmentPricePerSqWa IS NOT NULL
+              AND (lt.GovernmentPricePerSqWa IS NOT NULL
+                   OR ISNULL(lt.IsMissingFromSurvey, 0) = 1)
             ORDER BY lt.GovernmentPricePerSqWa, lt.Id;
 
             -- RS23: ราคาประเมินเดิม — the prior-appraisal link plus its LIVE appraised value,
@@ -679,8 +684,10 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
             else if (!string.IsNullOrWhiteSpace(assignment.AssigneeCompanyId)
                      && Guid.TryParse(assignment.AssigneeCompanyId, out var companyGuid))
             {
+                // Thai-language document: prefer the Thai company name, fall back to English.
+                // Matches the internal branch above, which is already a hardcoded Thai bank name.
                 const string companySql = """
-                    SELECT c.Name FROM auth.Companies c WHERE c.Id = @CompanyId
+                    SELECT COALESCE(NULLIF(c.NameLocal, N''), c.Name) FROM auth.Companies c WHERE c.Id = @CompanyId
                     """;
                 var companyParams = new DynamicParameters();
                 companyParams.Add("CompanyId", companyGuid);
@@ -823,6 +830,15 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
             .GroupBy(r => r.PropertyGroupId)
             .ToDictionary(g => g.Key, g => g.OrderBy(r => r.SequenceInGroup).ThenBy(r => r.TitleId).ToList());
 
+        // Position of each title in the printed รายการทรัพย์สิน list — groups in display order,
+        // titles within a group in the same order the list itself uses. ราคาประเมินราชการ below
+        // sorts by this so its segments read in the same sequence as the list above them.
+        var titleDisplayOrder = new Dictionary<Guid, int>();
+        foreach (var groupRow in groupRows)
+            if (titlesByGroup.TryGetValue(groupRow.GroupId, out var orderedTitles))
+                foreach (var title in orderedTitles)
+                    titleDisplayOrder.TryAdd(title.TitleId, titleDisplayOrder.Count);
+
         var buildingsByGroup = groupBuildingRows
             .GroupBy(r => r.PropertyGroupId)
             .ToDictionary(g => g.Key, g => g.OrderBy(r => r.SequenceInGroup).ToList());
@@ -917,8 +933,10 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
                     titleParts.Add($"เลขที่ดิน {title.LandParcelNumber}");
                 if (!string.IsNullOrWhiteSpace(title.SurveyNumber))
                     titleParts.Add($"หน้าสำรวจ {title.SurveyNumber}");
-                if (!string.IsNullOrWhiteSpace(title.MapSheetNumber))
-                    titleParts.Add($"ระวาง {title.MapSheetNumber}");
+                // ระวาง lives in LandTitles.Rawang — MapSheetNumber is the separate
+                // "Sheet Number" (แผ่นที่) field the UI only collects for นส.3ก.
+                if (!string.IsNullOrWhiteSpace(title.Rawang))
+                    titleParts.Add($"ระวาง {title.Rawang}");
 
                 var titleArea = BuildAreaString(title.AreaRai, title.AreaNgan, title.AreaSquareWa);
                 if (!string.IsNullOrWhiteSpace(titleArea))
@@ -1172,22 +1190,51 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
 
         // ราคาประเมินราชการ — government price per sq.wa, grouped by same price. With >1 distinct
         // price, list the title numbers per price ("โฉนด… และ … ตารางวาละ X บาท") joined by " , ".
+        //
+        // Missing-from-survey land has no government valuation, so it reads "ตกสำรวจ" rather than a
+        // price. Partition on the FLAG first and never infer it from the price: the frontend only
+        // started forcing the price to 0 for flagged titles recently, so older rows carry a real
+        // non-zero price alongside the flag. The flag wins.
+        // Where a title sits in the printed list; titles outside every group sort last, keeping
+        // their existing relative order.
+        int TitleOrder(GovPriceRow r) =>
+            titleDisplayOrder.TryGetValue(r.TitleId, out var i) ? i : int.MaxValue;
+
+        var missingFromSurvey = govPriceRows
+            .Where(r => r.IsMissingFromSurvey == true)
+            .OrderBy(TitleOrder)
+            .ToList();
         var govPriceGroups = govPriceRows
-            .Where(r => r.GovernmentPricePerSqWa.HasValue)
+            .Where(r => r.IsMissingFromSurvey != true && r.GovernmentPricePerSqWa.HasValue)
             .GroupBy(r => r.GovernmentPricePerSqWa!.Value)
             .ToList();
+
+        // Prefixes a segment with its title numbers. Only used when there is more than one segment —
+        // a lone segment applies to the whole appraisal, so naming the titles would be noise.
+        static string DescribeTitles(IEnumerable<GovPriceRow> rows, string value)
+        {
+            var titles = string.Join(" และ ", rows
+                .Where(r => !string.IsNullOrWhiteSpace(r.TitleNumber))
+                .Select(r => r.TitleNumber));
+            return string.IsNullOrWhiteSpace(titles) ? value : $"โฉนดที่ดินเลขที่ {titles} {value}";
+        }
+
+        const string missingFromSurveyText = "ตกสำรวจ";
+        var govPriceSegments = new List<(IReadOnlyList<GovPriceRow> Rows, string Value)>();
+        if (missingFromSurvey.Count > 0)
+            govPriceSegments.Add((missingFromSurvey, missingFromSurveyText));
+        govPriceSegments.AddRange(govPriceGroups
+            .Select(g => ((IReadOnlyList<GovPriceRow>)[.. g.OrderBy(TitleOrder)], $"ตารางวาละ {g.Key:N2} บาท")));
+
+        // Follow the land-title list, not price order: a segment sits where its first title does.
+        govPriceSegments = govPriceSegments
+            .OrderBy(s => s.Rows.Min(TitleOrder))
+            .ToList();
+
         string? governmentPriceText =
-            govPriceGroups.Count == 0 ? null
-            : govPriceGroups.Count == 1 ? $"ตารางวาละ {govPriceGroups[0].Key:N2} บาท"
-            : string.Join(" , ", govPriceGroups.Select(g =>
-            {
-                var titles = string.Join(" และ ", g
-                    .Where(r => !string.IsNullOrWhiteSpace(r.TitleNumber))
-                    .Select(r => r.TitleNumber));
-                return string.IsNullOrWhiteSpace(titles)
-                    ? $"ตารางวาละ {g.Key:N2} บาท"
-                    : $"โฉนดที่ดินเลขที่ {titles} ตารางวาละ {g.Key:N2} บาท";
-            }));
+            govPriceSegments.Count == 0 ? null
+            : govPriceSegments.Count == 1 ? govPriceSegments[0].Value
+            : string.Join(" , ", govPriceSegments.Select(s => DescribeTitles(s.Rows, s.Value)));
 
         // Show the committee block only when this appraisal actually falls into a meeting.
         bool showMeeting = review?.MeetingId is not null;
@@ -1305,8 +1352,8 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
             HasUnderConstruction = hasUnderConstruction,
             CurrentConditionTotal = currentConditionTotal,
             CurrentConditionForcedSaleValue = currentConditionForcedSale,
-            Condition = decision?.Condition,
-            Remark = decision?.Remark,
+            Condition = AppraisalSummaryCommonLoader.FirstNonBlank(decision?.Condition),
+            Remark = AppraisalSummaryCommonLoader.FirstNonBlank(decision?.Remark),
             LandOwner = land?.OwnerName,
             EntryExitRights = ParameterCodeFormatter.DecodeJsonArray(
                 land?.LandEntranceExitType, land?.LandEntranceExitTypeOther, entranceExitMap),
@@ -1351,7 +1398,7 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
             ShowMeeting = showMeeting,
             ApproverDecisionApproved = approverDecisionApproved,
             Approvers = approvers,
-            ApproverSummaryComment = decision?.CommitteeOpinion
+            ApproverSummaryComment = AppraisalSummaryCommonLoader.FirstNonBlank(decision?.CommitteeOpinion)
         };
 
         return model;
@@ -1582,8 +1629,10 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
 
     private sealed class GovPriceRow
     {
+        public Guid TitleId { get; init; }
         public string? TitleNumber { get; init; }
         public decimal? GovernmentPricePerSqWa { get; init; }
+        public bool? IsMissingFromSurvey { get; init; }
     }
 
     private sealed class DecisionRow
@@ -1648,7 +1697,7 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
         public string? PageNumber { get; init; }
         public string? LandParcelNumber { get; init; }
         public string? SurveyNumber { get; init; }
-        public string? MapSheetNumber { get; init; }
+        public string? Rawang { get; init; }
         public decimal? AreaRai { get; init; }
         public decimal? AreaNgan { get; init; }
         public decimal? AreaSquareWa { get; init; }

--- a/Modules/Reporting/Reporting/Application/Providers/ExternalBookBuilder.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/ExternalBookBuilder.cs
@@ -264,9 +264,11 @@ internal static class ExternalBookBuilder
             && !string.IsNullOrWhiteSpace(assignment.AssigneeCompanyId)
             && Guid.TryParse(assignment.AssigneeCompanyId, out var companyGuid))
         {
+            // The appraisal book is a Thai-language document, so prefer the Thai company name and
+            // fall back to the English one only when the company has none.
             const string companySql = """
                 SELECT
-                    c.Name,
+                    COALESCE(NULLIF(c.NameLocal, N''), c.Name) AS Name,
                     c.Phone,
                     c.AddressLine1,
                     c.AddressLine2

--- a/Modules/Workflow/Workflow/Tasks/Features/GetPoolTasks/GetPoolTasksQuery.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/GetPoolTasks/GetPoolTasksQuery.cs
@@ -63,6 +63,11 @@ public record PoolTaskDto
     public string? Movement { get; init; }
     public string? InternalFollowupStaff { get; init; }
     public string? Appraiser { get; init; }
+    /// <summary>
+    /// Thai company name, set only on external-assignment rows (Appraiser is a person for internal
+    /// ones). Null means "nothing to localize" — the client falls back to <see cref="Appraiser"/>.
+    /// </summary>
+    public string? AppraiserCompanyNameLocal { get; init; }
     public string? Priority { get; init; }
     public DateTime? DueAt { get; init; }
     public DateTime? SlaStartAt { get; init; }

--- a/Modules/Workflow/Workflow/Tasks/Features/GetTasks/GetTasksResult.cs
+++ b/Modules/Workflow/Workflow/Tasks/Features/GetTasks/GetTasksResult.cs
@@ -31,6 +31,11 @@ public record TaskDto
     public string? Movement { get; init; }
     public string? InternalFollowupStaff { get; init; }
     public string? Appraiser { get; init; }
+    /// <summary>
+    /// Thai company name, set only on external-assignment rows (Appraiser is a person for internal
+    /// ones). Null means "nothing to localize" — the client falls back to <see cref="Appraiser"/>.
+    /// </summary>
+    public string? AppraiserCompanyNameLocal { get; init; }
     public string? Priority { get; init; }
     public DateTime? DueAt { get; init; }
     public DateTime? SlaStartAt { get; init; }

--- a/Modules/Workflow/Workflow/Workflow/Features/GetAppraisalWorkflowProgress/GetAppraisalWorkflowProgressQuery.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/GetAppraisalWorkflowProgress/GetAppraisalWorkflowProgressQuery.cs
@@ -36,5 +36,7 @@ public class ActivityLogItemDto
     public string? Group { get; set; }
     public string? ActivityId { get; set; }
     public string? CompanyName { get; set; }
+    /// <summary>Thai company name; null when absent. The client picks by its own locale.</summary>
+    public string? CompanyNameLocal { get; set; }
     public string? Movement { get; set; } // F | C (Cancel) | B (back) — "C" marks the cancelled activity
 }

--- a/Modules/Workflow/Workflow/Workflow/Features/GetAppraisalWorkflowProgress/GetAppraisalWorkflowProgressQueryHandler.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/GetAppraisalWorkflowProgress/GetAppraisalWorkflowProgressQueryHandler.cs
@@ -389,6 +389,7 @@ public class GetAppraisalWorkflowProgressQueryHandler(
         {
             string? displayName = null;
             string? companyName = null;
+            string? companyNameLocal = null;
             if (r.AssignedType == userAssignedType && r.AssignedTo is not null)
             {
                 if (userMap.TryGetValue(r.AssignedTo, out var user))
@@ -396,6 +397,7 @@ public class GetAppraisalWorkflowProgressQueryHandler(
                     displayName = $"{user.FirstName} {user.LastName}".Trim();
                     if (string.IsNullOrWhiteSpace(displayName)) displayName = r.AssignedTo;
                     companyName = user.CompanyName;
+                    companyNameLocal = user.CompanyNameLocal;
                 }
                 else
                 {
@@ -429,6 +431,7 @@ public class GetAppraisalWorkflowProgressQueryHandler(
                 Group = group,
                 ActivityId = r.ActivityId,
                 CompanyName = companyName,
+                CompanyNameLocal = companyNameLocal,
                 Movement = r.Movement
             };
         }).ToList();


### PR DESCRIPTION
## Why

`auth.Companies` has stored `Name` (English, required) and `NameLocal` (nullable, Thai) since June, but **`NameLocal` never left the Auth admin CRUD screens**. A Thai-locale user saw English company names system-wide, and the Thai appraisal book printed an English valuer name next to a hardcoded Thai bank name.

## Two rules, deliberately separate

| Rule | Where | Behaviour |
|---|---|---|
| **A** | Locale-aware UI reads | API returns **both** names; the client picks |
| **B** | Documents, reports, LOS feeds | Thai-first: `COALESCE(NULLIF(NameLocal, N''), Name)` |

Rule A exists because the backend has **no** request-locale infrastructure (no `Accept-Language`, no `RequestLocalization`) — and this PR deliberately doesn't add any.

## What changed

**Rule A — 17 SQL views gained a sibling `*NameLocal` column**, and DTOs gained a matching field across appraisal, invoice, monitoring, evaluation, quotation, task-list, dashboard, engagement and user-detail. Notably `GET /companies/eligible` — the actual company selector — didn't return `NameLocal` at all.

**Rule B** — appraisal book builders, 7 RCAS reporting views, LOS quotation feeds, Thai notification emails, and the appraisals export.

**New helper** — `ReportFilterSql.ContainsAny(...)` OR-matches a value across columns, so an RCAS company filter matches whether the user types the Thai or the English name (backed by a new `AppraisalCompanyEn` column).

## Invariants worth reviewing

- **Sort / filter / group keys stay ENGLISH** so identity is language-independent — `vw_TaskList.Appraiser`, `MonitoringGroupRow.Key`/`Label`, RCAS filters. Only display siblings vary.
- **Name snapshots stay English and frozen** — `CollateralEngagements.AppraisalCompanyName`, `CompanyAssignedIntegrationEvent.CompanyName`, workflow `assignedCompanyName`. Where a Thai name is needed beside one (`vw_CollateralEngagements`), it's resolved **live** via the stored `AppraisalCompanyId` rather than by touching the snapshot.
- **The AS400 fixed-width feed is untouched.** It reads the frozen snapshot via `CollateralResultQuery`, not `auth.Companies`, so `ExternalValuerName` stays English and the 198-byte record layout is byte-identical to before.
- Several affected DTOs are **positional records** where Dapper binds by column *order*; each new field was inserted at the matching position and the SELECT lists were diffed to confirm alignment.
- `NameLocal` is nullable — views emit `NULL` (never `''`) so the client has a single absent-test.

## Verification

- `dotnet build` — 0 errors against `origin/main`
- Views re-applied via `dotnet run --project Database/Database.csproj migrate` (repeatable scripts; **no EF migration** in this PR)
- Rendered the external appraisal book for a company with a Thai name: cover **and** the `ตามที่ …` letter line show Thai, English appears **0 times**
- Companies with `NameLocal IS NULL` fall back to `Name` everywhere
- Confirmed the assignment payload still sends the **English** name, so snapshots stay single-language

Full impact list and TS-1…TS-9 test scenarios were produced alongside this change and cover selector, grids, sort/filter parity, reports, notifications, feeds, snapshot integrity, data integrity and permissions.

## Note for reviewers

Two companies have Thai text in the `Name` column itself (`NameLocal` identical) — a **pre-existing** data-entry gap, not introduced here. Detection query:

```sql
SELECT Name, NameLocal, HostCompanyCode, IsActive FROM auth.Companies
WHERE IsDeleted = 0 AND Name COLLATE Latin1_General_BIN LIKE '%[^ -~]%';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AgV4U5LaMw3aDDedMHqvuT
