### PR TITLE
refactor(db): stop running data seeders at application start

### DIFF
--- a/Bootstrapper/Api/appsettings.Development.json
+++ b/Bootstrapper/Api/appsettings.Development.json
@@ -99,6 +99,7 @@
   "AppBaseUrl": "https://localhost:7111",
   "AllowedHosts": "*",
   "SeedData": {
+    "RunSeeders": true,
     "IncludeDemoData": true,
     "AdminUser": {
       "Username": "admin",

--- a/Bootstrapper/Api/appsettings.Production.json.template
+++ b/Bootstrapper/Api/appsettings.Production.json.template
@@ -206,6 +206,7 @@
     "TaskLockExpiry": { "Interval": "00:05:00", "LockTimeout": "00:30:00" }
   },
   "SeedData": {
+    "RunSeeders": false,
     "IncludeDemoData": false,
     "AdminUser": {
       "Username": "#{ADMIN_USERNAME}#",

--- a/Bootstrapper/Api/appsettings.json
+++ b/Bootstrapper/Api/appsettings.json
@@ -24,6 +24,7 @@
     }
   },
   "SeedData": {
+    "RunSeeders": false,
     "IncludeDemoData": false,
     "AdminUser": {
       "Username": "<ADMIN_USERNAME>",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,6 +303,25 @@ dotnet run --project Database/Database.csproj history
 The application never applies migrations itself. In production the DBA runs a generated plain-SQL
 bundle instead of this tool — see `deploy/README.md`.
 
+### Reference data: the app does not seed outside Development
+
+`SeedData:RunSeeders` gates every `IDataSeeder` and **fails closed** — unset means off. It is `true`
+only in `appsettings.Development.json`. On a live database the per-key seeders silently re-inserted
+rows an admin had deleted, undoing their work on every app-pool recycle, so seeding is now treated as
+a fresh-install convenience rather than a production mechanism.
+
+When adding or changing reference data, decide by **who reads the value**:
+
+- **Code reads it by name → ship a script in `Database/Migration/Scripts/`, in the same PR as the
+  feature.** Permission codes, activity IDs, pipeline processor names, menu item keys wired to
+  frontend route guards. DbUp journals these once per database by filename. Also add it to the C#
+  seeder so fresh Development databases still get it — but the script is what reaches UAT/production.
+- **Only humans read it → the admin UI owns it. Do not ship it again after go-live.** SLA hours, fee
+  ladders, cron schedules, committee thresholds, business hours.
+
+Never "fix" seeded data by editing a seeder and relying on a restart: outside Development it will not
+run, and inside Development an already-populated table is usually skipped anyway.
+
 ### Project Structure Commands
 
 ```bash

--- a/Database/Scripts/Maintenance/RestrictPmaPropertyPermissionToIntAppraisalStaff.sql
+++ b/Database/Scripts/Maintenance/RestrictPmaPropertyPermissionToIntAppraisalStaff.sql
@@ -13,10 +13,15 @@
 -- every role EXCEPT IntAppraisalStaff and Admin (Admin intentionally keeps all
 -- permissions). Idempotent: re-running is a no-op once the rows are gone.
 --
--- The complementary additive changes (new TASK_INT_PMA_INPUT permission, the
--- int-pma-input task menu item, and the ActivityMenuOverride rows) are INSERT-ONLY
--- in the seeder and apply automatically on the next application boot — no script
--- needed for those.
+-- The complementary additive changes to permissions and menu items (new
+-- TASK_INT_PMA_INPUT permission, the int-pma-input task menu item) are INSERT-ONLY
+-- in the seeder and apply automatically on the next application boot.
+--
+-- The ActivityMenuOverride rows are NOT in that group: that seeder is fresh-install
+-- only (it skips entirely once auth.ActivityMenuOverrides has any row), because
+-- "inherit" is stored as the absence of a row and re-inserting missing pairs would
+-- undo admin edits on every app-pool recycle. On an already-seeded database the
+-- override rows must be added by an explicit script in Database/Migration/Scripts/.
 -- =============================================================================
 
 DELETE rp

--- a/Modules/Auth/Auth/Infrastructure/Seed/ActivityMenuOverrideSeedData.cs
+++ b/Modules/Auth/Auth/Infrastructure/Seed/ActivityMenuOverrideSeedData.cs
@@ -7,6 +7,14 @@ namespace Auth.Infrastructure.Seed;
 /// is only visible/editable if the user's role already permits it. So only seed
 /// rows that take a right away; omitting a (activity, menu) pair (or a no-op
 /// IsVisible=true/CanEdit=true row) leaves the item at its plain role-based state.
+///
+/// FRESH-INSTALL BLUEPRINT ONLY. The seeder applies this list once, on a database whose
+/// auth.ActivityMenuOverrides table is still empty. From then on the table is owned by the
+/// admin UI (PUT /admin/activity-menu-overrides/{activityId}), because "inherit" is stored
+/// as the absence of a row — a seeder that re-inserted missing pairs would undo every
+/// cleared restriction on the next app-pool recycle. So editing this list does NOT change
+/// any existing database: ship those changes as a one-off script in
+/// Database/Migration/Scripts/, which DbUp journals once per database.
 /// </summary>
 public static class ActivityMenuOverrideSeedData
 {

--- a/Modules/Auth/Auth/Infrastructure/Seed/AuthDataSeed.cs
+++ b/Modules/Auth/Auth/Infrastructure/Seed/AuthDataSeed.cs
@@ -1085,29 +1085,36 @@ public class AuthDataSeed(
         var seed = ActivityMenuOverrideSeedData.GetSeed();
         if (seed.Count == 0) return;
 
+        // Fresh-install only. "Inherit" is stored as the ABSENCE of a row (see
+        // UpdateActivityOverridesEndpoint, which deletes a row when the admin clears its
+        // restrictions), so a per-pair insert-only guard cannot tell "never seeded" from
+        // "admin deliberately cleared this restriction" — it re-imposed the blueprint on
+        // every app-pool recycle. Once the table has any row it belongs to the admin UI.
+        // Ship blueprint changes for existing databases as a one-off script in
+        // Database/Migration/Scripts/ instead.
+        if (await dbContext.ActivityMenuOverrides.AnyAsync())
+            return;
+
         var menuItemIdsByKey = await dbContext.MenuItems
             .Where(m => m.Scope == MenuScope.Appraisal)
             .ToDictionaryAsync(m => m.ItemKey, m => m.Id);
 
-        var existing = await dbContext.ActivityMenuOverrides
-            .ToDictionaryAsync(o => (o.ActivityId, o.MenuItemId));
-
-        var added = false;
         foreach (var entry in seed)
         {
             if (!menuItemIdsByKey.TryGetValue(entry.MenuItemKey, out var menuItemId))
-                continue; // menu item not seeded yet — skip gracefully
+            {
+                // This runs once per database, so an unresolved key is lost for good — make it loud.
+                logger.LogWarning(
+                    "ActivityMenuOverride seed skipped: appraisal menu item '{MenuItemKey}' not found (activity '{ActivityId}')",
+                    entry.MenuItemKey, entry.ActivityId);
+                continue;
+            }
 
-            if (existing.ContainsKey((entry.ActivityId, menuItemId)))
-                continue; // INSERT-ONLY, like MenuSeedData — admin edits win.
-
-            var row = ActivityMenuOverride.Create(entry.ActivityId, menuItemId, entry.IsVisible, entry.CanEdit);
-            dbContext.ActivityMenuOverrides.Add(row);
-            added = true;
+            dbContext.ActivityMenuOverrides.Add(
+                ActivityMenuOverride.Create(entry.ActivityId, menuItemId, entry.IsVisible, entry.CanEdit));
         }
 
-        if (added)
-            await dbContext.SaveChangesAsync();
+        await dbContext.SaveChangesAsync();
     }
 
     private async Task SeedAdminRoleAsync()

--- a/Modules/Workflow/Workflow/Data/Seed/ActivityProcessConfigurationAssertion.cs
+++ b/Modules/Workflow/Workflow/Data/Seed/ActivityProcessConfigurationAssertion.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Workflow.Data.Seed;
+
+/// <summary>
+/// Read-only boot check for the appraisal workflow's activity pipeline.
+///
+/// Data seeding is disabled outside Development (see MigrationExtension.UseDataSeeding), so on
+/// UAT/production these rows arrive as a one-off script in Database/Migration/Scripts/. That trade is
+/// deliberate — a seeder that re-inserts missing rows also re-inserts rows an admin deleted — but it
+/// removes the accidental safety net the additive seeder used to provide, and a missing row here is
+/// not cosmetic: without ValidateTaskOwnership / the appraisal-creation steps, an activity silently
+/// skips its gate, or no appraisal is created at workflow start at all.
+///
+/// So this asserts instead of writing. It logs CRITICAL naming every missing pair rather than throwing,
+/// because one absent optional validation step should not stop a whole cluster from booting — the log
+/// is the signal that a Migration/Scripts script was forgotten.
+/// </summary>
+public static class ActivityProcessConfigurationAssertion
+{
+    public static IApplicationBuilder UseActivityProcessAssertion(this IApplicationBuilder app)
+    {
+        using var scope = app.ApplicationServices.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<WorkflowDbContext>();
+        var logger = scope.ServiceProvider
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger(typeof(ActivityProcessConfigurationAssertion));
+
+        var present = context.ActivityProcessConfigurations
+            .Select(c => new { c.ActivityName, c.ProcessorName })
+            .ToList()
+            .Select(x => (x.ActivityName, x.ProcessorName))
+            .ToHashSet();
+
+        var required = ActivityProcessConfigurationSeeder.RequiredPairs();
+        var missing = required
+            .Where(p => !present.Contains(p))
+            .ToList();
+
+        if (missing.Count == 0)
+        {
+            // Log the success case too — a silent check is indistinguishable from one that never ran.
+            logger.LogInformation(
+                "Activity-process configuration verified: all {Required} required row(s) present ({Total} total).",
+                required.Count, present.Count);
+            return app;
+        }
+
+        logger.LogCritical(
+            "{Count} required activity-process configuration row(s) are missing from " +
+            "workflow.ActivityProcessConfigurations — the affected activities will skip their validation " +
+            "steps. Apply the Database/Migration/Scripts/ script that ships them. Missing: {Missing}",
+            missing.Count,
+            string.Join(", ", missing.Select(p => $"{p.ActivityName}/{p.ProcessorName}")));
+
+        return app;
+    }
+}

--- a/Modules/Workflow/Workflow/Data/Seed/ActivityProcessConfigurationSeeder.cs
+++ b/Modules/Workflow/Workflow/Data/Seed/ActivityProcessConfigurationSeeder.cs
@@ -27,6 +27,17 @@ public class ActivityProcessConfigurationSeeder(
     private const string ForwardOnly = "activity.movement === 'F'";
     private const string System = "system";
 
+    /// <summary>
+    /// The (ActivityName, ProcessorName) pairs the appraisal workflow requires in order to function.
+    /// Exposed so <see cref="ActivityProcessConfigurationAssertion"/> can verify them at boot without
+    /// duplicating the list — seeding is disabled outside Development, so on UAT/production these rows
+    /// arrive via a Database/Migration/Scripts/ script and nothing would otherwise notice a gap.
+    /// </summary>
+    public static IReadOnlyList<(string ActivityName, string ProcessorName)> RequiredPairs() =>
+        BuildDesiredConfigs()
+            .Select(c => (c.ActivityName, c.ProcessorName))
+            .ToList();
+
     public async Task SeedAllAsync()
     {
         // ── Desired managed rows (real workflow activities) ───────────────────────

--- a/Modules/Workflow/Workflow/WorkflowModule.cs
+++ b/Modules/Workflow/Workflow/WorkflowModule.cs
@@ -1,4 +1,5 @@
 using Shared.Data.Seed;
+using Workflow.Data.Seed;
 using Workflow.AssigneeSelection.Engine;
 using Workflow.AssigneeSelection.Configuration;
 using Workflow.AssigneeSelection.Pipeline;
@@ -264,6 +265,9 @@ public static class WorkflowModule
     public static IApplicationBuilder UseWorkflowModule(this IApplicationBuilder app)
     {
         app.UseDataSeeding<WorkflowDbContext>();
+        // Read-only: seeding is off outside Development, so nothing else would notice if the
+        // activity-pipeline rows were never applied to this database.
+        app.UseActivityProcessAssertion();
         app.UseModuleRecurringJobs<WorkflowDbContext>(WorkflowRecurringJobs.All);
 
         return app;

--- a/Shared/Shared/Data/Extensions/MigrationExtension.cs
+++ b/Shared/Shared/Data/Extensions/MigrationExtension.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Shared.Data.Seed;
@@ -9,7 +10,8 @@ namespace Shared.Data.Extensions;
 public static class MigrationExtension
 {
     /// <summary>
-    /// Asserts the database schema is current, then runs the module's data seeders.
+    /// Asserts the database schema is current, then — only where seeding is explicitly enabled —
+    /// runs the module's data seeders.
     ///
     /// The app deliberately does NOT apply migrations. Schema is owned by the DBA and applied
     /// out-of-band from the generated SQL bundle (see deploy/README.md) — running two IIS nodes
@@ -17,12 +19,34 @@ public static class MigrationExtension
     /// module order here does not match the dependency order in EfCoreMigrationService.
     ///
     /// The check below is read-only: it applies nothing, it just refuses to start a node whose
-    /// schema is behind the code, so seeders never run against a stale database.
+    /// schema is behind the code.
+    ///
+    /// Data seeding is a fresh-install convenience, NOT a production mechanism. On a live database
+    /// the whole-table-guarded seeders are already no-ops, while the per-key ones silently re-insert
+    /// rows an admin deleted — undoing their work on every app-pool recycle. So reference data that
+    /// code depends on ships as a one-off script in Database/Migration/Scripts/ (journaled once per
+    /// database), and everything else belongs to the admin UI and is never rewritten from code.
     /// </summary>
     public static IApplicationBuilder UseDataSeeding<TContext>(this IApplicationBuilder app)
         where TContext : DbContext
     {
         EnsureSchemaCurrentAsync<TContext>(app.ApplicationServices).GetAwaiter().GetResult();
+
+        // Fails closed: an unset SeedData:RunSeeders means NO seeding. A dropped config line or a
+        // failed deployment transform therefore costs nothing on an environment that is already
+        // seeded, instead of silently resuming the overwrites described above.
+        var configuration = app.ApplicationServices.GetRequiredService<IConfiguration>();
+        if (!configuration.GetValue<bool>("SeedData:RunSeeders"))
+        {
+            app.ApplicationServices
+                .GetRequiredService<ILoggerFactory>()
+                .CreateLogger(typeof(MigrationExtension))
+                .LogInformation(
+                    "Data seeding is disabled (SeedData:RunSeeders); skipping seeders for {Context}.",
+                    typeof(TContext).Name);
+            return app;
+        }
+
         SeedDatabaseAsync<TContext>(app.ApplicationServices).GetAwaiter().GetResult();
         return app;
     }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -41,18 +41,36 @@ the IIS/certificate side.
 
 On each app server, create `appsettings.Production.json` from
 `Bootstrapper/Api/appsettings.Production.json.template` and substitute **every** `#{TOKEN}#`.
-It must be complete **before the app is started for the first time**, because that first start
-is when the data seeders run. Three values decide whether the environment is usable at all:
+`ConnectionStrings:Database` must be right or the app cannot start.
 
-| Setting | If it is wrong/missing at first start |
+> **The application no longer seeds data.** `SeedData:RunSeeders` gates every data seeder and
+> **fails closed** — unset means off, and the production template sets it to `false` explicitly.
+> Seeding is a fresh-install convenience for Development only. On a live database the
+> whole-table-guarded seeders were already no-ops, while the per-key ones silently re-inserted rows
+> an admin had deleted, undoing their work on every app-pool recycle. Reference data that code
+> depends on now ships as a one-off script in `Database/Migration/Scripts/`, applied once per
+> database by the `db/` bundle; everything else belongs to the admin UI and is never rewritten.
+
+### Standing up a brand-new environment
+
+Because seeding is off, a **new, empty** database will have no permissions, menus, roles, workflow
+groups or admin account, and — unlike before — **this no longer self-heals on restart**. For a new
+environment, one of the following is required:
+
+1. Restore or script the reference data from an existing environment (preferred — the C# blueprints
+   have drifted from the real databases in places, so the live data is the more truthful source), or
+2. Set `SeedData:RunSeeders: true` for the **first boot only**, confirm sign-in works, then set it
+   back to `false` before the environment is handed over.
+
+If you take option 2, these two values must be correct *at that first boot*, or the deployment looks
+healthy while nobody can sign in:
+
+| Setting | If it is wrong/missing at the seeding boot |
 |---|---|
-| `ConnectionStrings:Database` | app cannot start |
 | `SeedData:AdminUser` | no admin account is created — nobody can sign in |
-| `Cors:AllowedOrigins` | the `spa` OAuth client is skipped and logged as an error — the deployment looks healthy but **nobody can sign in** |
+| `Cors:AllowedOrigins` | the `spa` OAuth client is skipped and logged as an error — nobody can sign in |
 
-Both sign-in failures self-heal on a restart once the config is corrected (the seeders are
-insert-only, so the missing rows are simply retried) — but they present as a *successful*
-deployment, which is an expensive thing to diagnose mid go-live.
+This does not apply to an already-live environment, where those rows exist already.
 
 **1. Build (build box):**
 ```bash
@@ -139,15 +157,16 @@ nothing to enable. Just connect to the right database and press Execute. Two poi
 .\deploy\Deploy-App.ps1 -Version 20260723-101500
 .\deploy\Deploy-Web.ps1 -Version 20260723-101500
 ```
-**This is where data seeding happens.** On startup each node verifies the schema is current and
-then runs its modules' data seeders — permissions, menus, roles, workflow assignment groups,
-lookup tables, workflow definitions. Seeding runs while the pipeline is being built, before the
-app listens (`Program.cs`: `MapCarter()` → the `UseXModule()` chain → `app.Run()`), so a node
-serves no traffic until its seeders have finished.
+On startup each node verifies the schema is current and refuses to boot if it is behind the build.
+**No data is written at startup** — see the seeding note above. The Workflow module additionally
+logs `CRITICAL` if any required `workflow.ActivityProcessConfigurations` row is missing, which is
+the signal that a `Database/Migration/Scripts/` script shipped with a feature was not applied;
+it logs rather than throws, so it will not stop a node from serving.
 
-Confirm `/health/ready` before moving to the next server. This is not only an F5 courtesy: a
-healthy server 1 means seeding is complete, so server 2's seeders find everything present and
-no-op. Starting both nodes at once would let the insert-only seeders race on check-then-insert.
+Confirm `/health/ready` before moving to the next server — an F5 courtesy so one node keeps
+serving throughout the rollout. (This used to be a hard requirement because the insert-only
+seeders would race on check-then-insert if both nodes started together. With seeding disabled
+that race is gone, but rolling one server at a time is still the right way to deploy.)
 
 **5. Post-deployment steps that are NOT automated.** These are manual on purpose —
 they need per-environment values the repo cannot hold:
@@ -155,12 +174,17 @@ they need per-environment values the repo cannot hold:
 | Step | Why it is manual |
 |---|---|
 | `Database/Scripts/Maintenance/WebhookSubscriptions_LOS_PMA.sql` | Registers the LOS PMA push subscription. Contains `<LOS-HOST>` and `<LOS-PROVIDED-CLIENT-SECRET>` placeholders that **must** be replaced with the real LOS values before running. Not in the `db/` bundle. |
-| Committee members | `CommitteeDataSeed` seeds the committees and their thresholds but resolves members by username, so a production database gets **no members**. Add them via the admin UI. |
-| `los` / `cls` OAuth clients | Seeded only when `Authentication:Clients:<id>:ClientSecret` is set in `appsettings.Production.json`; otherwise skipped with a warning. Either set the secrets or create the clients via `/admin/clients`. |
+| Committee members | Committees and thresholds exist, but members resolve by username, so a production database gets **no members**. Add them via the admin UI. |
+| `los` / `cls` OAuth clients | Not created by the app (seeding is off). Create them via `/admin/clients`, or set `Authentication:Clients:<id>:ClientSecret` and use a first-boot seeding run on a new environment only. |
 
 Everything else — schema, views, procs, reference data, menus, permissions, roles and
-the workflow assignment groups — is applied by the `db/` bundle plus the application's
-own boot-time seeders.
+the workflow assignment groups — is applied by the `db/` bundle.
+
+The application writes no *reference data* at startup. The one exception is `JobSchedules`:
+`UseModuleRecurringJobs` inserts a row for any recurring job that does not have one yet
+(`Shared/Shared/Scheduling/RecurringJobScheduleExtensions.cs`), which is deliberate and safe — an
+existing row always wins over the code default, so a cron edited through `/admin/job-schedules`
+is re-applied on every boot and never overwritten.
 
 ## How the SQL bundle is generated
 


### PR DESCRIPTION
## Why

An admin set an activity menu tab from **read-only** back to **inherit**; after the app pool recycled it was read-only again.

Root cause: "inherit" is stored as the **absence** of a row, so the admin action deletes it — and the seeder's per-`(ActivityId, MenuItemId)` guard cannot tell "never seeded" from "admin deliberately cleared this", so it re-inserted the blueprint value on every boot.

That prompted an audit of **all 20 `IDataSeeder` implementations**:

| | Count | Behaviour |
|---|---|---|
| Rewrites existing rows every boot | **1** | `AppraisalSlaPolicySeeder` re-stamps `AnchorType` |
| Re-inserts rows an admin deleted | **6** | activity-process config, workflow groups, roles, permissions, OAuth clients, SLA policies |
| Safe (whole-table guard) | **12** | already no-ops on a populated database |

## What changed

**1. `ActivityMenuOverride` seeding is fresh-install-only** (`618cee1c`) — the direct fix for the reported bug.

**2. Data seeding no longer runs at application start** (`2e95d677`) — `SeedData:RunSeeders` gates every seeder at the single choke point `UseDataSeeding<TContext>()`. **Fails closed: an unset key means no seeding.** `true` only in `appsettings.Development.json`. The schema assertion still runs unconditionally.

This beat patching the seven seeders individually: it removes the whole bug class in ~6 lines instead of requiring a per-table judgement about who owns which data. It also finishes a contract the codebase already committed to — the app refuses to boot when schema is behind and never migrates, so data should come from the same DBA-applied path.

**3. A replacement safety net.** `workflow.ActivityProcessConfigurations` rows are load-bearing (without them an activity silently skips its gate, or no appraisal is created at workflow start), and that seeder's additive behaviour was covering for forgotten scripts. `ActivityProcessConfigurationAssertion` replaces it with a **read-only** boot check that logs `CRITICAL` naming any missing pair. It shares the seeder's own list via `RequiredPairs()` and never writes or throws.

## ⚠️ Consequence for new environments

A brand-new, empty database no longer self-heals: no permissions, menus, roles or admin account, and a restart won't fix it. It needs its reference data scripted from an existing environment, or `RunSeeders: true` for the first boot only. Documented in `deploy/README.md`, and the key is now in the production template so the switch is visible.

**Going forward**, decide by who reads the value: code reads it by name (permission codes, activity IDs, processor names) → ship a `Database/Migration/Scripts/` script with the feature; only humans read it (SLA hours, fee ladders, cron) → the admin UI owns it.

## Verified

- Seeding off: all **11** DbContexts skip, **zero** writes; every seeded-table count byte-identical to baseline.
- Deleted `int-appraisal-verification/RequireDocumentFollowupCleared` → **stayed deleted** across a restart. The bug class is gone.
- Assertion logged the missing row by name and the app still started.
- Development still seeds: seeder logged "1 added", assertion then confirmed "all 26 required present".
- `dotnet build --configuration Release` clean (the job CI gates on).

## Found but deliberately not fixed here

- `AuthDataSeed.cs:383-385` re-grants the `Admin` role to the seeded account on **every boot** — outside the create-guard and ungated by `IncludeDemoData`, so it runs in production. The gate neutralises it there, but it remains in Development.
- Workflow Builder endpoints (create/update definition, publish, migrate, delete draft) carry **no** `RequireAuthorization` policy — any authenticated user can publish a workflow. Sibling admin endpoints use `workflow.admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEr4gpjhznKGDRVTKYSjC5