### PR TITLE
fix(reporting): hide blank หมายเหตุ blocks and show "-" for missing ราคาประเมินราชการ

### DIFF
--- a/Modules/Reporting/Reporting/Application/Providers/Sections/BuildingSectionLoader.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/Sections/BuildingSectionLoader.cs
@@ -313,7 +313,7 @@ internal static class BuildingSectionLoader
                 TotalArea = totalArea == 0 ? null : totalArea,
                 TotalPrice = totalPrice == 0 ? null : totalPrice,
                 TotalValueAfterDepreciation = totalValueAfterDepr == 0 ? null : totalValueAfterDepr,
-                Remark = hdr.Remark,
+                Remark = AppraisalSummaryCommonLoader.FirstNonBlank(hdr.Remark),
             });
         }
 

--- a/Modules/Reporting/Reporting/Application/Providers/Sections/LandSectionLoader.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/Sections/LandSectionLoader.cs
@@ -235,7 +235,7 @@ internal static class LandSectionLoader
                 IsInExpropriationLine  = landRow.IsInExpropriationLine,
                 UrbanPlanningType      = Resolve("TypeOfUrbanPlanning", landRow.UrbanPlanningType),
                 LandZoneType           = Resolve("Location", landRow.LandZoneType),
-                Remark                 = landRow.Remark,
+                Remark                 = AppraisalSummaryCommonLoader.FirstNonBlank(landRow.Remark),
                 Titles                 = titles
             });
         }

--- a/Modules/Reporting/Reporting/Templates/partials/summary-standard-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-standard-body.html
@@ -190,7 +190,7 @@
     </div>
     <div class="kv"><span class="k">พิกัด</span><span class="v">{{ model.gps }}</span></div>
     <div class="cols2">
-      <div class="kv"><span class="k">ราคาประเมินราชการ</span><span class="v">{{ model.government_price_text }}</span></div>
+      <div class="kv"><span class="k">ราคาประเมินราชการ</span><span class="v">{{ if model.government_price_text; model.government_price_text; else; "-"; end }}</span></div>
       <div class="kv"><span class="k">สภาพการใช้ประโยชน์</span><span class="v">{{ for u in model.utilizations }}{{ u }}{{ if !for.last }}<br>{{ end }}{{ end }}</span></div>
     </div>
     <div class="kv" style="margin-top:3px;">


### PR DESCRIPTION
## Problem

A user filled in the appraisal-book หมายเหตุ, then deleted it — and the block kept printing as an empty labelled section.

Clearing a textarea saves `""`, not `null`: the frontend posts raw form state and `AppraisalDecision.Update` persists it verbatim. Scriban follows Liquid, where **only `null` and `false` are falsy**, so `""` is truthy and `{{ if section.remark }}` still renders.

Confirmed against the dev database — this app really does store empty strings:

| Column | `''` | `NULL` |
|---|---|---|
| `BuildingAppraisalDetails.Remark` | 74 | 152 |
| `LandAppraisalDetails.Remark` | 45 | 101,822 |

## Fix

Normalise at the source with the existing `AppraisalSummaryCommonLoader.FirstNonBlank(...)` helper, so every existing template guard becomes correct without touching Scriban. The helper's own doc-comment already names this exact trap.

This completes the pass begun in #363, which covered the decision-level `Condition` / `Remark` / `CommitteeOpinion` but missed the two section loaders:

- `LandSectionLoader.cs` — drives the `หมายเหตุ` bar in `section-land.html`
- `BuildingSectionLoader.cs` — same for `section-building.html`

Also gives **ราคาประเมินราชการ** the `else "-"` fallback its neighbouring totals rows already use, so an appraisal with no government price reads as `-` rather than an empty cell.

## Verification

- `dotnet build Modules/Reporting/Reporting` — 0 errors, 0 warnings.
- Rendered before/after via the report HTML endpoint on a spare port. With a whitespace-only `Condition`, the เงื่อนไข row rendered empty before and is gone after; ราคาประเมินราชการ renders `-` when there is no data. Full normalised diff of the rendered reports showed only the intended lines changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwPhZH2GLLH8cwzkXjupEL
