### PR TITLE
fix(reporting): list enhancement-only properties under ส่วนพัฒนา and add thousand separators

### DIFF
--- a/Modules/Reporting/Reporting/Application/Formatting/ThaiLandAreaFormatter.cs
+++ b/Modules/Reporting/Reporting/Application/Formatting/ThaiLandAreaFormatter.cs
@@ -19,7 +19,7 @@ public static class ThaiLandAreaFormatter
     public static string FormatTotal(decimal sumRai, decimal sumNgan, decimal sumSqWa)
     {
         var t = NormalizeTotal(sumRai, sumNgan, sumSqWa);
-        return $"{t.Rai} - {t.Ngan} - {t.Wa} ไร่ หรือ {t.TotalSquareWa:0.##} ตารางวา";
+        return $"{t.Rai:#,##0} - {t.Ngan} - {t.Wa} ไร่ หรือ {t.TotalSquareWa:#,##0.##} ตารางวา";
     }
 
     /// <summary>

--- a/Modules/Reporting/Reporting/Application/Models/AppraisalSummaryModel.cs
+++ b/Modules/Reporting/Reporting/Application/Models/AppraisalSummaryModel.cs
@@ -581,8 +581,15 @@ public sealed class SummaryGroupRow
     public List<string> LandDescriptions { get; init; } = [];
 
     /// <summary>Building clause (พร้อม…), newline-joined per building. Shown after the land
-    /// titles in the market/combined land row (separated from the land title list).</summary>
+    /// titles in the market/combined land row (separated from the land title list). Excludes
+    /// enhancement-only properties — see <see cref="DevelopmentDescriptions"/>.</summary>
     public string? BuildingDescription { get; init; }
+
+    /// <summary>ส่วนพัฒนา lines for the market/combined row — descriptive only, since that layout
+    /// carries a single blended figure with no per-line money column. Holds just the rows of
+    /// properties whose Building Detail is entirely non-building, which therefore print no
+    /// "พร้อม…" clause of their own.</summary>
+    public List<string> DevelopmentDescriptions { get; init; } = [];
 
     /// <summary>Per-item detail lines (e.g. each machine) — rendered as a numbered list.</summary>
     public List<string> DetailItems { get; init; } = [];
@@ -610,7 +617,9 @@ public sealed class SummaryGroupRow
     /// <summary>Land appraised value (PricingFinalValues.LandValue). Cost approach only.</summary>
     public decimal? LandValue { get; init; }
 
-    /// <summary>Building line items (BuildingDepreciationDetails where IsBuilding=1). Cost approach only.</summary>
+    /// <summary>Building line items — one per BuildingAppraisalDetail, valued by its IsBuilding=1
+    /// depreciation rows. Cost approach only. A property whose Building Detail holds ONLY
+    /// non-building rows is excluded: it prints under <see cref="DevelopmentItems"/> instead.</summary>
     public IReadOnlyList<SummaryItemRow> Buildings { get; init; } = [];
 
     /// <summary>Development/improvement items (ส่วนพัฒนา; IsBuilding=0). Cost approach only.</summary>

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryBlockDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryBlockDataProvider.cs
@@ -467,7 +467,7 @@ public sealed class AppraisalSummaryBlockDataProvider(
         {
             parts.Append(
                 $" พื้นที่โครงการประมาณ " +
-                $"{project.LandAreaRai.GetValueOrDefault():0.##}-{project.LandAreaNgan.GetValueOrDefault():0.##}-{project.LandAreaSquareWa.GetValueOrDefault():0.##} ไร่");
+                $"{project.LandAreaRai.GetValueOrDefault():#,##0.##}-{project.LandAreaNgan.GetValueOrDefault():#,##0.##}-{project.LandAreaSquareWa.GetValueOrDefault():#,##0.##} ไร่");
         }
 
         if (project.UnitForSaleCount.HasValue && project.UnitForSaleCount.Value > 0)
@@ -494,7 +494,7 @@ public sealed class AppraisalSummaryBlockDataProvider(
                     modelParts.Add(m.BuildingType);
 
                 if (m.NumberOfFloors.HasValue && m.NumberOfFloors.Value > 0)
-                    modelParts.Add($"{m.NumberOfFloors:0.##} ชั้น");
+                    modelParts.Add($"{m.NumberOfFloors:#,##0.##} ชั้น");
 
                 if (m.NumberOfHouse.HasValue && m.NumberOfHouse.Value > 0)
                     modelParts.Add($"จำนวน {m.NumberOfHouse} หลัง");
@@ -502,7 +502,7 @@ public sealed class AppraisalSummaryBlockDataProvider(
                 // Area: prefer StandardUsableArea, fall back to UsableAreaMin
                 var area = m.StandardUsableArea ?? m.UsableAreaMin;
                 if (area.HasValue && area.Value > 0)
-                    modelParts.Add($"พื้นที่ใช้สอย {area:0.##} ตร.ม.");
+                    modelParts.Add($"พื้นที่ใช้สอย {area:#,##0.##} ตร.ม.");
 
                 // Price range
                 if (m.StartingPriceMin.HasValue && m.StartingPriceMax.HasValue

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryCondoDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryCondoDataProvider.cs
@@ -276,20 +276,20 @@ public sealed class AppraisalSummaryCondoDataProvider(
                         var label = string.IsNullOrWhiteSpace(ar.AreaDescription)
                             ? "พื้นที่"
                             : ar.AreaDescription!.Trim();
-                        parts.Add($"{label} {sz:0.##} ตารางเมตร");
+                        parts.Add($"{label} {sz:#,##0.##} ตารางเมตร");
                     }
                     var totalArea = areas.Sum(a => a.AreaSize ?? 0m);
                     if (areas.Count > 1 && totalArea > 0)
-                        parts.Add($"รวมพื้นที่ {totalArea:0.##} ตารางเมตร");
+                        parts.Add($"รวมพื้นที่ {totalArea:#,##0.##} ตารางเมตร");
                 }
                 else if (c.UsableArea is { } ua && ua > 0)
                 {
-                    parts.Add($"พื้นที่ห้องชุด {ua:0.##} ตารางเมตร");
+                    parts.Add($"พื้นที่ห้องชุด {ua:#,##0.##} ตารางเมตร");
                 }
 
                 // Building height / age / condition
                 if (c.NumberOfFloors.HasValue)
-                    parts.Add($"อาคารสูง {c.NumberOfFloors:0.##} ชั้น");
+                    parts.Add($"อาคารสูง {c.NumberOfFloors:#,##0.##} ชั้น");
                 if (c.BuildingAge.HasValue)
                     parts.Add($"อายุอาคาร {c.BuildingAge} ปี");
                 if (!string.IsNullOrWhiteSpace(c.BuildingConditionDisplay))

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryLandBuildingDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryLandBuildingDataProvider.cs
@@ -917,6 +917,38 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
             depreciationByGroup.TryGetValue(g.GroupId, out var deps);
             deps ??= [];
 
+            // Appraisers now enter an enhancement (fence, paving, water tank, roofed open area) as
+            // its OWN property, whose Building Detail carries only Non-Building rows. Such a
+            // property is not a สิ่งปลูกสร้าง and must not print as one — neither as a numbered cost
+            // line (it would be blank-valued, duplicating the ส่วนพัฒนา rows below) nor as a
+            // "พร้อม…" clause on the combined row ("พร้อมถังน้ำ 3 ชั้น … อายุอาคาร 0 ปี"). Both
+            // layouts list it under ส่วนพัฒนา instead. A building with NO rows at all is NOT one of
+            // these: nothing was entered yet, so it keeps printing as an unvalued building.
+            // Neither is one carrying a house number: an enhancement never has one, so it is proof
+            // the appraiser meant a real สิ่งปลูกสร้าง and its rows were merely flagged wrong —
+            // reclassifying would erase the house, its เลขที่ and its พื้นที่ใช้สอย from the document.
+            var depRowsByBuilding = deps
+                .GroupBy(d => d.BuildingAppraisalDetailId)
+                .ToDictionary(grp => grp.Key, grp => grp.ToList());
+
+            bool IsDevelopmentOnly(GroupBuildingRow b) =>
+                !HasHouseNumber(b.HouseNumber)
+                && depRowsByBuilding.TryGetValue(b.BuildingId, out var rows)
+                && rows.TrueForAll(r => !r.IsBuilding);
+
+            // Rows moved out of the สิ่งปลูกสร้าง list lose the only place their type was printed, so
+            // they lead with it under ส่วนพัฒนา — "รั้วตาข่ายเหล็ก …" instead of a bare "พื้นที่ใช้สอย …".
+            // Rows under a normal building are left alone: that building still names itself on its
+            // own line, so a prefix would only repeat it.
+            // GroupBy (not a bare ToDictionary): RS14 joins parameter.Parameters on Group+Language
+            // +Code while that table is unique on (Group, Country, Language, Code), so a second
+            // active row for the same code can fan one building into two — a duplicate key here
+            // would 500 the whole report.
+            var movedNameByBuilding = buildings
+                .Where(IsDevelopmentOnly)
+                .GroupBy(b => b.BuildingId)
+                .ToDictionary(grp => grp.Key, grp => BuildingDisplayName(grp.First()));
+
             // Land description (titles only — no building clause).
             var landParts = new List<string>();
             foreach (var title in titles)
@@ -957,6 +989,9 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
             var buildingDescParts = new List<string>();
             foreach (var bld in buildings)
             {
+                if (IsDevelopmentOnly(bld))
+                    continue;   // listed under ส่วนพัฒนา instead — see DevelopmentDescriptions below
+
                 var bldParts = new List<string>();
                 if (!string.IsNullOrWhiteSpace(bld.BuildingTypeDisplay))
                     bldParts.Add($"พร้อม{bld.BuildingTypeDisplay}");
@@ -1012,6 +1047,7 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
                 .ToDictionary(grp => grp.Key, grp => grp.Sum(d => d.PriceAfterDepreciation ?? 0m));
 
             var buildingItems = buildings
+                .Where(b => !IsDevelopmentOnly(b))
                 .Select(b =>
                 {
                     var value = buildingValueById.TryGetValue(b.BuildingId, out var v) ? v : (decimal?)null;
@@ -1025,24 +1061,51 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
                 })
                 .ToList();
 
+            // Print the moved rows in property order rather than the ORDER BY bdd.Id the query gives
+            // (a Guid v7 sorts arbitrarily under SQL Server's uniqueidentifier collation), so each
+            // property's items stay together. OrderBy is stable — rows within a property keep their
+            // existing relative order.
+            var sequenceByProperty = buildings
+                .GroupBy(b => b.AppraisalPropertyId)
+                .ToDictionary(grp => grp.Key, grp => grp.Min(b => b.SequenceInGroup));
+
             // ส่วนพัฒนา: development items are the non-building (IsBuilding=0) depreciation rows.
-            var developmentItems = deps.Where(d => !d.IsBuilding)
+            var developmentRows = deps.Where(d => !d.IsBuilding)
+                .OrderBy(d => sequenceByProperty.TryGetValue(d.AppraisalPropertyId, out var seq) ? seq : int.MaxValue)
                 .Select(d =>
                 {
                     var pct = ProgressPctOf(d.AppraisalPropertyId);
-                    return new SummaryItemRow
-                    {
-                        Description = BuildItemDesc(d, "พื้นที่", pct),
-                        Value = d.PriceAfterDepreciation,
-                        CurrentValue = CurrentValueOf(d.PriceAfterDepreciation, pct)
-                    };
+                    var isMoved = movedNameByBuilding.TryGetValue(d.BuildingAppraisalDetailId, out var namePrefix);
+                    return (
+                        IsMoved: isMoved,
+                        Row: new SummaryItemRow
+                        {
+                            Description = BuildItemDesc(d, "พื้นที่", pct, namePrefix),
+                            Value = d.PriceAfterDepreciation,
+                            CurrentValue = CurrentValueOf(d.PriceAfterDepreciation, pct)
+                        });
                 })
+                .ToList();
+
+            var developmentItems = developmentRows.ConvertAll(x => x.Row);
+
+            // The combined/market row carries ONE blended figure and has no valued ส่วนพัฒนา block,
+            // so it lists only the rows whose property just lost its "พร้อม…" clause — as plain text
+            // under a ส่วนพัฒนา heading. Rows belonging to a normal building stay unlisted there,
+            // exactly as before.
+            var developmentDescriptions = developmentRows
+                .Where(x => x.IsMoved && !string.IsNullOrWhiteSpace(x.Row.Description))
+                .Select(x => x.Row.Description!)
                 .ToList();
 
             var groupTotal = g.GroupAppraisalValue ?? g.AppraisalPrice ?? g.FinalValueRounded;
 
             // Group composition — also drives the first-column label (see DeriveFamily).
             var hasLand = titles.Count > 0 || g.LandValue.HasValue;
+            // Counts enhancement-only properties too, deliberately: their ส่วนพัฒนา rows ARE the
+            // group's building block — they total into รวมมูลค่าสิ่งปลูกสร้าง, and the template gates
+            // both per-type subtotals on has_building. Narrowing this to buildingItems deletes those
+            // subtotal rows from a land + fence cost group.
             var hasBuilding = buildingItems.Count > 0 || buildings.Count > 0;
 
             // Whether the group renders the per-item breakdown (☑ ที่ดิน / ☑ สิ่งปลูกสร้าง as
@@ -1112,6 +1175,7 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
                 LandDescription = landDescription,
                 LandDescriptions = landParts,
                 BuildingDescription = buildingDescription,
+                DevelopmentDescriptions = developmentDescriptions,
                 TotalSquareWa = totalSquareWa == 0m ? null : totalSquareWa,
                 LandUnitPrice = g.LandUnitPrice,
                 LandValue = g.LandValue,
@@ -1406,6 +1470,15 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
 
     // ── Helpers ───────────────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Whether a Building Detail actually carries a house number. Appraisers type "-" for "none"
+    /// (35 of the 232 rows on the dev database), so a dash-only value must read as absent — it is
+    /// used as proof that a mis-flagged building is a real สิ่งปลูกสร้าง, and a placeholder is not
+    /// proof of anything.
+    /// </summary>
+    private static bool HasHouseNumber(string? houseNumber) =>
+        !string.IsNullOrWhiteSpace(houseNumber) && houseNumber.Trim().Trim('-', '–', '—').Length > 0;
+
     private static string BuildAreaString(decimal? rai, decimal? ngan, decimal? sqwa)
         // Thai land-area shorthand rai-ngan-wa; every empty position shows 0 (e.g. "9-2-41 ไร่", "1-0-0 ไร่").
         => $"{rai ?? 0:0.##}-{ngan ?? 0:0.##}-{sqwa ?? 0:0.##} ไร่";
@@ -1413,11 +1486,20 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
     /// <summary>
     /// Builds a cost-breakdown line, e.g. "อาคารโรงงานชั้นเดียว พื้นที่ใช้สอย 1,800 ตารางเมตร อายุ 9 ปี".
     /// <paramref name="areaLabel"/> is "พื้นที่ใช้สอย" for buildings, "พื้นที่" for development items.
+    /// <paramref name="namePrefix"/> is the owning property's building type, passed for ส่วนพัฒนา
+    /// rows whose property prints no สิ่งปลูกสร้าง line of its own. It NAMES the item, replacing the
+    /// row's free-text <c>AreaDescription</c> — the two describe the same thing, and the building
+    /// type is the curated one. Rows under a normal building pass none and keep their own text.
+    /// An enhancement property carries a single Non-Building row in practice, so the replacement
+    /// loses nothing; were it to carry several, they would all print under this one name.
     /// </summary>
-    private static string? BuildItemDesc(GroupDepreciationRow d, string areaLabel, decimal? progressPct = null)
+    private static string? BuildItemDesc(
+        GroupDepreciationRow d, string areaLabel, decimal? progressPct = null, string? namePrefix = null)
     {
         var parts = new List<string>();
-        if (!string.IsNullOrWhiteSpace(d.AreaDescription))
+        if (!string.IsNullOrWhiteSpace(namePrefix))
+            parts.Add(namePrefix!.Trim());
+        else if (!string.IsNullOrWhiteSpace(d.AreaDescription))
             parts.Add(d.AreaDescription!.Trim());
         if (d.Area is { } a && a != 0)
             parts.Add($"{areaLabel} {a:0.##} ตารางเมตร");
@@ -1442,17 +1524,25 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
     };
 
     /// <summary>
+    /// How a building names itself: the building TYPE (BuildingTypeDisplay already resolves code 99
+    /// "อื่นๆ" to the appraiser's remark), with the free-text property name as a last-resort
+    /// fallback. Null when neither is filled in.
+    /// </summary>
+    private static string? BuildingDisplayName(GroupBuildingRow b)
+    {
+        var name = !string.IsNullOrWhiteSpace(b.BuildingTypeDisplay) ? b.BuildingTypeDisplay : b.PropertyName;
+        return string.IsNullOrWhiteSpace(name) ? null : name!.Trim();
+    }
+
+    /// <summary>
     /// Builds a per-building cost line: building type + floors + usable area + age + condition,
     /// e.g. "อาคารโรงงาน ชั้นเดียว พื้นที่ใช้สอย 1,800 ตารางเมตร อายุอาคาร 9 ปี สภาพอาคารปานกลาง".
     /// </summary>
     private static string? BuildBuildingLine(GroupBuildingRow b, decimal? progressPct = null)
     {
         var parts = new List<string>();
-        // Lead with the building TYPE (BuildingTypeDisplay already resolves code 99 "อื่นๆ" to the
-        // appraiser's remark); the free-text property name is only a last-resort fallback.
-        var name = !string.IsNullOrWhiteSpace(b.BuildingTypeDisplay) ? b.BuildingTypeDisplay : b.PropertyName;
-        if (!string.IsNullOrWhiteSpace(name))
-            parts.Add(name!.Trim());
+        if (BuildingDisplayName(b) is { } name)
+            parts.Add(name);
         if (b.NumberOfFloors.HasValue)
             parts.Add($"{b.NumberOfFloors:0.##} ชั้น");
         if (b.TotalBuildingArea.HasValue)

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryLandBuildingDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryLandBuildingDataProvider.cs
@@ -996,11 +996,11 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
                 if (!string.IsNullOrWhiteSpace(bld.BuildingTypeDisplay))
                     bldParts.Add($"พร้อม{bld.BuildingTypeDisplay}");
                 if (bld.NumberOfFloors.HasValue)
-                    bldParts.Add($"{bld.NumberOfFloors:0.##} ชั้น");
+                    bldParts.Add($"{bld.NumberOfFloors:#,##0.##} ชั้น");
                 if (!string.IsNullOrWhiteSpace(bld.HouseNumber))
                     bldParts.Add($"เลขที่ {bld.HouseNumber}");
                 if (bld.TotalBuildingArea.HasValue)
-                    bldParts.Add($"พื้นที่ใช้สอย {bld.TotalBuildingArea:0.##} ตารางเมตร");
+                    bldParts.Add($"พื้นที่ใช้สอย {bld.TotalBuildingArea:#,##0.##} ตารางเมตร");
                 if (bld.BuildingAge.HasValue)
                     bldParts.Add($"อายุอาคาร {bld.BuildingAge} ปี");
                 if (!string.IsNullOrWhiteSpace(bld.BuildingConditionDisplay))
@@ -1481,7 +1481,7 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
 
     private static string BuildAreaString(decimal? rai, decimal? ngan, decimal? sqwa)
         // Thai land-area shorthand rai-ngan-wa; every empty position shows 0 (e.g. "9-2-41 ไร่", "1-0-0 ไร่").
-        => $"{rai ?? 0:0.##}-{ngan ?? 0:0.##}-{sqwa ?? 0:0.##} ไร่";
+        => $"{rai ?? 0:#,##0.##}-{ngan ?? 0:#,##0.##}-{sqwa ?? 0:#,##0.##} ไร่";
 
     /// <summary>
     /// Builds a cost-breakdown line, e.g. "อาคารโรงงานชั้นเดียว พื้นที่ใช้สอย 1,800 ตารางเมตร อายุ 9 ปี".
@@ -1502,7 +1502,7 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
         else if (!string.IsNullOrWhiteSpace(d.AreaDescription))
             parts.Add(d.AreaDescription!.Trim());
         if (d.Area is { } a && a != 0)
-            parts.Add($"{areaLabel} {a:0.##} ตารางเมตร");
+            parts.Add($"{areaLabel} {a:#,##0.##} ตารางเมตร");
         if (d.Year > 0)
             parts.Add($"อายุ {d.Year} ปี");
         if (ProgressSuffix(progressPct) is { } suffix)
@@ -1520,7 +1520,7 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
         null => null,
         <= 0m => "(ยังไม่ก่อสร้าง)",
         >= 100m => null,
-        _ => $"(แล้วเสร็จ {progressPct.Value:0.##}%)"
+        _ => $"(แล้วเสร็จ {progressPct.Value:#,##0.##}%)"
     };
 
     /// <summary>
@@ -1544,9 +1544,9 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
         if (BuildingDisplayName(b) is { } name)
             parts.Add(name);
         if (b.NumberOfFloors.HasValue)
-            parts.Add($"{b.NumberOfFloors:0.##} ชั้น");
+            parts.Add($"{b.NumberOfFloors:#,##0.##} ชั้น");
         if (b.TotalBuildingArea.HasValue)
-            parts.Add($"พื้นที่ใช้สอย {b.TotalBuildingArea:0.##} ตารางเมตร");
+            parts.Add($"พื้นที่ใช้สอย {b.TotalBuildingArea:#,##0.##} ตารางเมตร");
         if (b.BuildingAge.HasValue)
             parts.Add($"อายุอาคาร {b.BuildingAge} ปี");
         if (!string.IsNullOrWhiteSpace(b.BuildingConditionDisplay))

--- a/Modules/Reporting/Reporting/Application/Providers/ExternalBookBuilder.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/ExternalBookBuilder.cs
@@ -371,7 +371,7 @@ internal static class ExternalBookBuilder
             if (!string.IsNullOrWhiteSpace(building.BuildingTypeDisplay))
                 bParts.Add(building.BuildingTypeDisplay);
             if (building.NumberOfFloors.HasValue)
-                bParts.Add($"{building.NumberOfFloors:0.##} ชั้น");
+                bParts.Add($"{building.NumberOfFloors:#,##0.##} ชั้น");
             if (!string.IsNullOrWhiteSpace(building.ModelName))
                 bParts.Add($"แบบ {building.ModelName}");
             buildingDetailsText = bParts.Count > 0 ? string.Join(" ", bParts) : null;
@@ -399,7 +399,7 @@ internal static class ExternalBookBuilder
             if (CollateralFamilyTranslator.IsCondoFamily(pc.PropertyType))
             {
                 section = condoUsableAreaTotal > 0
-                    ? $"{typeThai} จำนวน {pc.PropertyCount} ยูนิต เนื้อที่ {condoUsableAreaTotal:0.##} ตารางเมตร"
+                    ? $"{typeThai} จำนวน {pc.PropertyCount} ยูนิต เนื้อที่ {condoUsableAreaTotal:#,##0.##} ตารางเมตร"
                     : $"{typeThai} จำนวน {pc.PropertyCount} ยูนิต";
             }
             else if (CollateralFamilyTranslator.IsEquipmentFamily(pc.PropertyType))
@@ -414,7 +414,7 @@ internal static class ExternalBookBuilder
             else
             {
                 section = landSqWaTotal > 0
-                    ? $"{typeThai} จำนวน {pc.PropertyCount} หลัง เนื้อที่ {landSqWaTotal:0.##} ตารางวา"
+                    ? $"{typeThai} จำนวน {pc.PropertyCount} หลัง เนื้อที่ {landSqWaTotal:#,##0.##} ตารางวา"
                     : $"{typeThai} จำนวน {pc.PropertyCount} หลัง";
             }
             summarySections.Add(section);

--- a/Modules/Reporting/Reporting/Application/Providers/Sections/CondoSectionLoader.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/Sections/CondoSectionLoader.cs
@@ -275,7 +275,7 @@ internal static class CondoSectionLoader
 
         // Distance display
         string? distanceText = first.DistanceFromMainRoad.HasValue
-            ? $"{first.DistanceFromMainRoad:0.##} เมตร"
+            ? $"{first.DistanceFromMainRoad:#,##0.##} เมตร"
             : null;
 
         // PublicUtilityType is a JSON-serialised List<string> of codes → translate each.

--- a/Modules/Reporting/Reporting/Application/Providers/Sections/WqsSectionLoader.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/Sections/WqsSectionLoader.cs
@@ -455,8 +455,8 @@ internal static class WqsSectionLoader
             LineY1 = lineY1.HasValue ? My(lineY1.Value) : 0,
             LineX2 = lineY2.HasValue ? Mx(xMax) : 0,
             LineY2 = lineY2.HasValue ? My(lineY2.Value) : 0,
-            XMinLabel = xMin.ToString("0.##"),
-            XMaxLabel = xMax.ToString("0.##"),
+            XMinLabel = xMin.ToString("#,##0.##"),
+            XMaxLabel = xMax.ToString("#,##0.##"),
             YMinLabel = yMin.ToString("N0"),
             YMaxLabel = yMax.ToString("N0")
         };

--- a/Modules/Reporting/Reporting/Templates/partials/section-condo.html
+++ b/Modules/Reporting/Reporting/Templates/partials/section-condo.html
@@ -99,8 +99,8 @@
 <div class="section-bar" style="font-size:8pt;">ทางเข้าออกอาคารชุด</div>
 <div class="pad">
   <div class="cols2">
-    <div class="kv"><span class="k">ผิวจราจรกว้าง :</span><span class="v">{{ if model.condo_section.road_surface_width; model.condo_section.road_surface_width | math.format "0.##"; end }}{{ if model.condo_section.road_surface_width }} เมตร{{ end }}</span></div>
-    <div class="kv"><span class="k">เขตทางกว้าง :</span><span class="v">{{ if model.condo_section.road_zone_width; model.condo_section.road_zone_width | math.format "0.##"; end }}{{ if model.condo_section.road_zone_width }} เมตร{{ end }}</span></div>
+    <div class="kv"><span class="k">ผิวจราจรกว้าง :</span><span class="v">{{ if model.condo_section.road_surface_width; model.condo_section.road_surface_width | math.format "#,##0.##"; end }}{{ if model.condo_section.road_surface_width }} เมตร{{ end }}</span></div>
+    <div class="kv"><span class="k">เขตทางกว้าง :</span><span class="v">{{ if model.condo_section.road_zone_width; model.condo_section.road_zone_width | math.format "#,##0.##"; end }}{{ if model.condo_section.road_zone_width }} เมตร{{ end }}</span></div>
   </div>
   <div class="cols2">
     <div class="kv"><span class="k">ลักษณะผิวจราจร :</span><span class="v">{{ model.condo_section.road_surface_type }}</span></div>
@@ -112,7 +112,7 @@
 <div class="pad">
   <div class="cols2">
     <div class="kv"><span class="k">อายุอาคาร :</span><span class="v">{{ model.condo_section.building_age }}{{ if model.condo_section.building_age }} ปี{{ end }}</span></div>
-    <div class="kv"><span class="k">ความสูง (ชั้น) :</span><span class="v">{{ if model.condo_section.building_height_floors; model.condo_section.building_height_floors | math.format "0.##"; end }}{{ if model.condo_section.building_height_floors }} ชั้น{{ end }}</span></div>
+    <div class="kv"><span class="k">ความสูง (ชั้น) :</span><span class="v">{{ if model.condo_section.building_height_floors; model.condo_section.building_height_floors | math.format "#,##0.##"; end }}{{ if model.condo_section.building_height_floors }} ชั้น{{ end }}</span></div>
   </div>
   <div class="cols3">
     <div class="kv"><span class="k">รูปแบบอาคารชุด :</span><span class="v">{{ model.condo_section.building_form }}</span></div>

--- a/Modules/Reporting/Reporting/Templates/partials/section-land.html
+++ b/Modules/Reporting/Reporting/Templates/partials/section-land.html
@@ -33,18 +33,18 @@
       <td>{{ t.land_parcel_number }}</td>
       <td>{{ t.survey_number }}</td>
       <td>{{ t.map_sheet }}</td>
-      <td class="num">{{ (t.area_rai ?? 0) | math.format "0.##" }}</td>
-      <td class="num">{{ (t.area_ngan ?? 0) | math.format "0.##" }}</td>
-      <td class="num">{{ (t.area_square_wa ?? 0) | math.format "0.##" }}</td>
+      <td class="num">{{ (t.area_rai ?? 0) | math.format "#,##0.##" }}</td>
+      <td class="num">{{ (t.area_ngan ?? 0) | math.format "#,##0.##" }}</td>
+      <td class="num">{{ (t.area_square_wa ?? 0) | math.format "#,##0.##" }}</td>
       <td>{{ t.owner_name }}</td>
     </tr>
     {{ end }}
     <tr style="font-weight:700; background:#f5f5f5;">
       <td colspan="5" style="text-align:right;">รวมเนื้อที่ดิน</td>
-      <td class="num">{{ land_section.total_rai }}</td>
-      <td class="num">{{ land_section.total_ngan }}</td>
-      <td class="num">{{ land_section.total_square_wa }}</td>
-      <td>หรือ {{ land_section.total_area_in_wa | math.format "0.##" }} ตารางวา</td>
+      <td class="num">{{ land_section.total_rai | math.format "#,##0" }}</td>
+      <td class="num">{{ land_section.total_ngan | math.format "#,##0" }}</td>
+      <td class="num">{{ land_section.total_square_wa | math.format "#,##0" }}</td>
+      <td>หรือ {{ land_section.total_area_in_wa | math.format "#,##0.##" }} ตารางวา</td>
     </tr>
   </tbody>
 </table>
@@ -88,10 +88,10 @@
     <div class="kv"><span class="k">ลักษณะผิวจราจร :</span><span class="v">{{ land_section.road_surface_type }}</span></div>
     {{ end }}
     {{ if land_section.access_road_width }}
-    <div class="kv"><span class="k">เขตทางกว้าง :</span><span class="v">{{ land_section.access_road_width | math.format "0.##" }} เมตร</span></div>
+    <div class="kv"><span class="k">เขตทางกว้าง :</span><span class="v">{{ land_section.access_road_width | math.format "#,##0.##" }} เมตร</span></div>
     {{ end }}
     {{ if land_section.road_frontage }}
-    <div class="kv"><span class="k">ผิวจราจรกว้าง :</span><span class="v">{{ land_section.road_frontage | math.format "0.##" }} เมตร</span></div>
+    <div class="kv"><span class="k">ผิวจราจรกว้าง :</span><span class="v">{{ land_section.road_frontage | math.format "#,##0.##" }} เมตร</span></div>
     {{ end }}
   </div>
 </div>

--- a/Modules/Reporting/Reporting/Templates/partials/summary-standard-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-standard-body.html
@@ -83,7 +83,10 @@
         </tr>
         {{ end }}
         {{ if g.development_items.size > 0 }}
-        <tr class="cont"><td></td><td><strong>ส่วนพัฒนา</strong></td><td></td><td></td><td></td>{{ if uc }}<td></td>{{ end }}</tr>
+        <!-- A group whose building properties are ALL enhancement-only has no สิ่งปลูกสร้าง rows to
+             carry the ☑ marker, yet still totals its ส่วนพัฒนา into รวมมูลค่าสิ่งปลูกสร้าง — so the
+             marker moves onto this header row instead of leaving the block unlabelled. -->
+        <tr class="{{ if g.buildings.size == 0 && per_type_subtotals }}grp-first{{ else }}cont{{ end }}"><td>{{ if g.buildings.size == 0 }}<span class="chk on"></span> <strong>สิ่งปลูกสร้าง</strong>{{ end }}</td><td><strong>ส่วนพัฒนา</strong></td><td></td><td></td><td></td>{{ if uc }}<td></td>{{ end }}</tr>
         {{ for d in g.development_items }}
         <tr class="cont">
           <td></td>
@@ -113,7 +116,8 @@
         <!-- Market / combined: single value, no per-unit breakdown -->
         <tr>
           <td><span class="chk on"></span> <strong>{{ g.property_type }}</strong></td>
-          <td>{{ if multi }}<strong>กลุ่มที่ {{ g.group_number }}</strong>{{ end }}{{ if g.land_descriptions.size > 0 }}<ol class="land-titles{{ if g.land_descriptions.size == 1 }} no-num{{ end }}">{{ for d in g.land_descriptions }}<li>{{ d }}</li>{{ end }}</ol>{{ end }}{{ if g.building_description }}<div class="brk" style="margin-top:1px;">{{ g.building_description }}</div>{{ end }}</td>
+          <td>{{ if multi }}<strong>กลุ่มที่ {{ g.group_number }}</strong>{{ end }}{{ if g.land_descriptions.size > 0 }}<ol class="land-titles{{ if g.land_descriptions.size == 1 }} no-num{{ end }}">{{ for d in g.land_descriptions }}<li>{{ d }}</li>{{ end }}</ol>{{ end }}{{ if g.building_description }}<div class="brk" style="margin-top:1px;">{{ g.building_description }}</div>{{ end }}{{ if g.development_descriptions.size > 0 }}<div class="brk" style="margin-top:1px;"><strong>ส่วนพัฒนา</strong>{{ for d in g.development_descriptions }}
+- {{ d }}{{ end }}</div>{{ end }}</td>
           <td class="num">{{ if g.show_land_unit_columns }}{{ g.market_land_area | math.format "N2" }}{{ end }}</td>
           <td class="num">{{ if g.show_land_unit_columns }}{{ g.market_land_unit_price | math.format "N2" }}{{ end }}</td>
           <td class="num"{{ if uc }} colspan="2"{{ end }}>{{ if g.group_total; g.group_total | math.format "N2"; end }}</td>


### PR DESCRIPTION
Two fixes to the appraisal summary report, both found while reviewing a rendered ผลการประเมิน form.

## 1. Enhancement-only properties now print under ส่วนพัฒนา

Appraisers have changed how they enter data: an enhancement (fence, road/concrete apron, water tank, roofed open area) is now created as its **own property**, whose Building Detail table contains only Non-Building rows. The report still treated it as a สิ่งปลูกสร้าง in both layouts.

**Split cost breakdown** — it printed a numbered building line with a blank ราคาประเมิน (it has no `IsBuilding = 1` rows to value it), duplicating the ส่วนพัฒนา rows listed right below:

```
16. ถนนและลานคอนกรีต 1 ชั้น พื้นที่ใช้สอย 28728 ตารางเมตร อายุอาคาร 31 ปี      (no value)
17. รั้วตาข่ายเหล็ก 1 ชั้น พื้นที่ใช้สอย 2041.5 ตารางเมตร อายุอาคาร 31 ปี        (no value)
ส่วนพัฒนา
- พื้นที่ใช้สอย พื้นที่ 2041.5 ตารางเมตร อายุ 31 ปี                             930,924.00
- พื้นที่ใช้สอย พื้นที่ 28728 ตารางเมตร อายุ 31 ปี                            8,733,312.00
```

**Combined row** (a group holding an `LB` property alongside the enhancement renders as one blended ☑ ที่ดินพร้อมสิ่งปลูกสร้าง figure) — it printed a prose clause that reads as nonsense for a water tank:

```
- พร้อมถังน้ำ 3 ชั้น เลขที่ - พื้นที่ใช้สอย 100 ตารางเมตร อายุอาคาร 0 ปี
+ ส่วนพัฒนา
+ - ถังน้ำ พื้นที่ 3,333 ตารางเมตร อายุ 1 ปี
```

Both layouts now list such a property under ส่วนพัฒนา, named by its building type. The split layout keeps its valued rows; the combined row gets a descriptive sub-list, since that layout carries a single blended figure with no per-line money column.

**Classification is deliberately narrow.** A building is enhancement-only only when it has depreciation rows, *all* of them Non-Building, **and** no house number:

- No rows at all means nothing was entered yet, not "this is an enhancement" — it keeps its list line, unvalued.
- A house number is proof the appraiser meant a real building whose rows were merely flagged wrong; reclassifying it would erase the house, its เลขที่ and its พื้นที่ใช้สอย from the document. Note appraisers type `-` for "none" (35 of 232 rows on the dev database), so a dash-only value reads as absent.

**No figures change.** The dropped lines were valued `null`, and `BuildingSubtotal` already summed building lines *plus* ส่วนพัฒนา lines. `has_building` still counts enhancement-only properties on purpose — their ส่วนพัฒนา rows *are* the group's building block, and the template gates both per-type subtotals on it.

## 2. Thousand separators on report numbers

The `0.##` custom format emits no group separator — unlike `N0`/`N2`/`N4` — so areas printed as `3333 ตารางเมตร`. Swept every occurrence to `#,##0.##` across the Reporting module, and added a format to values that had none at all (`ThaiLandAreaFormatter`'s ไร่ component, the three รวมเนื้อที่ดิน totals in `section-land` — all `int`, so separator only, no rounding).

Below 1,000 the new format is byte-identical to the old, so existing reports change only where a number was genuinely large enough to need a separator. Identifiers are deliberately untouched.

## Verification

- Three appraisals with ส่วนพัฒนา blocks in the split layout render **byte-identical** to their pre-change output (`019D42F2…`, `019C7886…`, `019C813E…`).
- The combined-layout case (`019FA9F8…` — an `LB` property grouped with a `B` water-tank property, 0 Building / 1 Non-Building rows) differs in **exactly one cell**; รวมราคาประเมิน 5,000,000 / ทุนประกันภัย 8,910,000 / ราคาบังคับขาย 3,500,000 all unchanged.
- Separator sweep checked empirically rather than by inspection: land-building, condo, machine and book reports rendered, markup stripped, regexed for 4+ digit runs lacking a separator. Everything remaining is an identifier — report numbers, Buddhist years, DOPA geocodes, เลขที่ดิน/หน้าสำรวจ, dates.
- `dotnet build collateral-appraisal-system-api.sln --configuration Release` → 0 errors.

## Known follow-up (not in this PR)

`BuildingInsuranceCalculator` — and the in-sync `AppraisalValuationSummaryService` — filter `IsBuilding = 1`, so an enhancement-only property contributes **0** to ทุนประกันภัยสิ่งปลูกสร้าง. Pre-existing and untouched here, but if fences and tanks are meant to be insured it deserves its own ticket.
