### PR TITLE
feat(workflow): limit committee positions to four and stop the secretary voting

### DIFF
--- a/Database/Migration/Scripts/20260317002600_SeedData_GeneralParameter.sql
+++ b/Database/Migration/Scripts/20260317002600_SeedData_GeneralParameter.sql
@@ -3691,16 +3691,21 @@ VALUES
 GO
 
 -- ----------------------------------------
--- Group: MeetingPosition (EN=3, TH=3)
+-- Group: MeetingPosition (EN=4, TH=4)
+-- Codes are the CommitteeMemberPosition enum NAMES, not ordinals: the meeting/committee APIs bind
+-- the enum by name, so the dropdown posts this code straight through with no mapping layer.
+-- Keep in sync with CommitteeMemberPositions.Selectable (Modules/Workflow/.../CommitteeMember.cs).
 -- ----------------------------------------
 INSERT INTO parameter.Parameters ([group], [country], [language], [code], [description], [isactive], [seqno])
 VALUES
-    (N'MeetingPosition', N'TH', N'EN', N'01', N'Chairman', 1, 1),
-    (N'MeetingPosition', N'TH', N'TH', N'01', N'Chairman', 1, 1),
-    (N'MeetingPosition', N'TH', N'EN', N'02', N'Director', 1, 2),
-    (N'MeetingPosition', N'TH', N'TH', N'02', N'Director', 1, 2),
-    (N'MeetingPosition', N'TH', N'EN', N'03', N'Secretary', 1, 3),
-    (N'MeetingPosition', N'TH', N'TH', N'03', N'Secretary', 1, 3);
+    (N'MeetingPosition', N'TH', N'EN', N'Chairman', N'Chairman', 1, 1),
+    (N'MeetingPosition', N'TH', N'TH', N'Chairman', N'ประธาน', 1, 1),
+    (N'MeetingPosition', N'TH', N'EN', N'Director', N'Director', 1, 2),
+    (N'MeetingPosition', N'TH', N'TH', N'Director', N'กรรมการ', 1, 2),
+    (N'MeetingPosition', N'TH', N'EN', N'Secretary', N'Secretary', 1, 3),
+    (N'MeetingPosition', N'TH', N'TH', N'Secretary', N'เลขานุการฯ', 1, 3),
+    (N'MeetingPosition', N'TH', N'EN', N'UW', N'UW', 1, 4),
+    (N'MeetingPosition', N'TH', N'TH', N'UW', N'ผู้พิจารณาสินเชื่อ', 1, 4);
 GO
 
 -- ----------------------------------------

--- a/Database/Migration/Scripts/20260805120000_UpdateSeed_MeetingPositionParameter.sql
+++ b/Database/Migration/Scripts/20260805120000_UpdateSeed_MeetingPositionParameter.sql
@@ -1,0 +1,39 @@
+-- ============================================================
+-- CA: Re-seed parameter.Parameters group 'MeetingPosition' (EN=4, TH=4)
+--
+-- Feeds the POSITION dropdown on the meeting roster and the Committee Admin page.
+-- Three changes against the original seed in 20260317002600_SeedData_GeneralParameter.sql:
+--   1. Re-keyed from ordinals ('01'/'02'/'03') to the CommitteeMemberPosition enum NAMES. The
+--      meeting/committee APIs bind that enum by name, so a dropdown posting '01' would not bind.
+--   2. Added the missing 'UW' — it is required by the COMMITTEE_WITH_MEETING RoleRequired condition
+--      yet was absent from the group, so it could never be picked in the UI.
+--   3. Replaced the English placeholders in the TH rows with real Thai labels.
+--
+-- Retired positions (Risk / Appraisal / Credit / Member) are deliberately NOT seeded: they remain
+-- on the C# enum so existing rows and historical ApprovalVote.MemberRole values still materialize,
+-- but may no longer be assigned. See CommitteeMemberPositions.Selectable.
+--
+-- DELETE-then-INSERT rather than guarded per-row inserts: the group is being re-keyed, so the old
+-- '01'/'02'/'03' rows have to go. Nothing references parameter.Parameters by ParId, and the group
+-- had no consumers before this change, so removing the rows is safe.
+--
+-- Re-runnable: the DELETE makes the INSERT idempotent if this is ever replayed.
+--
+-- NOTE: CachedParameterRepository caches with no TTL and no eviction on write — restart the API
+-- after running this or the dropdown will keep serving the old rows.
+-- ============================================================
+SET NOCOUNT ON;
+
+DELETE FROM parameter.Parameters WHERE [group] = N'MeetingPosition';
+
+INSERT INTO parameter.Parameters ([group], [country], [language], [code], [description], [isactive], [seqno])
+VALUES
+    (N'MeetingPosition', N'TH', N'EN', N'Chairman', N'Chairman', 1, 1),
+    (N'MeetingPosition', N'TH', N'TH', N'Chairman', N'ประธาน', 1, 1),
+    (N'MeetingPosition', N'TH', N'EN', N'Director', N'Director', 1, 2),
+    (N'MeetingPosition', N'TH', N'TH', N'Director', N'กรรมการ', 1, 2),
+    (N'MeetingPosition', N'TH', N'EN', N'Secretary', N'Secretary', 1, 3),
+    (N'MeetingPosition', N'TH', N'TH', N'Secretary', N'เลขานุการฯ', 1, 3),
+    (N'MeetingPosition', N'TH', N'EN', N'UW', N'UW', 1, 4),
+    (N'MeetingPosition', N'TH', N'TH', N'UW', N'ผู้พิจารณาสินเชื่อ', 1, 4);
+GO

--- a/Modules/Workflow/Workflow/Data/Seed/CommitteeDataSeed.cs
+++ b/Modules/Workflow/Workflow/Data/Seed/CommitteeDataSeed.cs
@@ -124,24 +124,30 @@ public class CommitteeDataSeed(
 
         logger.LogInformation("Seeding workflow committee members...");
 
-        // Sub Committee: 3 members (tier 1: 0-10M)
+        // Positions are limited to CommitteeMemberPositions.Selectable — Risk/Credit/Appraisal are
+        // retired and would seed members the admin UI can no longer edit.
+
+        // Sub Committee: 3 members (tier 1: 0-10M) — quorum 2
         AddMemberIfUserExists(subCommittee, userMap, "john.doe", "John Doe", CommitteeMemberPosition.Chairman);
         AddMemberIfUserExists(subCommittee, userMap, "jane.smith", "Jane Smith", CommitteeMemberPosition.UW);
-        AddMemberIfUserExists(subCommittee, userMap, "m.wilson", "Mike Wilson", CommitteeMemberPosition.Risk);
+        AddMemberIfUserExists(subCommittee, userMap, "m.wilson", "Mike Wilson", CommitteeMemberPosition.Director);
 
-        // Committee: 5 members (tier 2: 10-30M)
+        // Committee: 5 members (tier 2: 10-30M) — quorum 3
         AddMemberIfUserExists(committee, userMap, "john.doe", "John Doe", CommitteeMemberPosition.Chairman);
         AddMemberIfUserExists(committee, userMap, "jane.smith", "Jane Smith", CommitteeMemberPosition.UW);
-        AddMemberIfUserExists(committee, userMap, "m.wilson", "Mike Wilson", CommitteeMemberPosition.Risk);
-        AddMemberIfUserExists(committee, userMap, "s.johnson", "Sarah Johnson", CommitteeMemberPosition.Credit);
-        AddMemberIfUserExists(committee, userMap, "thitipornw", "Thitiporn W", CommitteeMemberPosition.Appraisal);
+        AddMemberIfUserExists(committee, userMap, "m.wilson", "Mike Wilson", CommitteeMemberPosition.Director);
+        AddMemberIfUserExists(committee, userMap, "s.johnson", "Sarah Johnson", CommitteeMemberPosition.Director);
+        AddMemberIfUserExists(committee, userMap, "thitipornw", "Thitiporn W", CommitteeMemberPosition.Director);
 
-        // Committee With Meeting: 5 members (tier 3: >30M) — UW vote mandatory
+        // Committee With Meeting: 5 members (tier 3: >30M) — UW vote mandatory, quorum 3.
+        // One Secretary on purpose: they convene the meeting but are excluded from the approver
+        // roster at release, leaving 4 voters — so dev data exercises that path and still clears
+        // quorum.
         AddMemberIfUserExists(committeeWithMeeting, userMap, "john.doe", "John Doe", CommitteeMemberPosition.Chairman);
         AddMemberIfUserExists(committeeWithMeeting, userMap, "jane.smith", "Jane Smith", CommitteeMemberPosition.UW);
-        AddMemberIfUserExists(committeeWithMeeting, userMap, "m.wilson", "Mike Wilson", CommitteeMemberPosition.Risk);
-        AddMemberIfUserExists(committeeWithMeeting, userMap, "s.johnson", "Sarah Johnson", CommitteeMemberPosition.Credit);
-        AddMemberIfUserExists(committeeWithMeeting, userMap, "thitipornw", "Thitiporn W", CommitteeMemberPosition.Appraisal);
+        AddMemberIfUserExists(committeeWithMeeting, userMap, "m.wilson", "Mike Wilson", CommitteeMemberPosition.Director);
+        AddMemberIfUserExists(committeeWithMeeting, userMap, "s.johnson", "Sarah Johnson", CommitteeMemberPosition.Director);
+        AddMemberIfUserExists(committeeWithMeeting, userMap, "thitipornw", "Thitiporn W", CommitteeMemberPosition.Secretary);
 
         await context.SaveChangesAsync();
 

--- a/Modules/Workflow/Workflow/Domain/Committees/Committee.cs
+++ b/Modules/Workflow/Workflow/Domain/Committees/Committee.cs
@@ -77,10 +77,12 @@ public class Committee : Aggregate<Guid>
 
         // Members are known by now, so a threshold nobody could ever reach is rejected outright —
         // it would otherwise open a round that can never resolve and stalls with no error.
-        var activeMembers = GetActiveMembers().Count;
-        if (majorityType == MajorityType.FixedCount && activeMembers > 0 && majorityValue > activeMembers)
+        // Counts VOTING members, the same subset MeetingRosterEligibility checks the roster against
+        // at release; counting the Secretary here would accept a threshold that gate then refuses.
+        var votingMembers = CountActiveVoters();
+        if (majorityType == MajorityType.FixedCount && votingMembers > 0 && majorityValue > votingMembers)
             throw new ArgumentException(
-                $"MajorityValue {majorityValue} exceeds the committee's {activeMembers} active member(s); " +
+                $"MajorityValue {majorityValue} exceeds the committee's {votingMembers} voting member(s); " +
                 "the approval round could never reach it",
                 nameof(majorityValue));
 
@@ -211,14 +213,29 @@ public class Committee : Aggregate<Guid>
             // validation and then match no vote's role at runtime — CheckApprovalConditions
             // compares it as a plain case-insensitive string. That is the exact silent stall
             // this guard exists to prevent.
-            if (!Enum.GetNames<CommitteeMemberPosition>()
-                    .Contains(roleRequired, StringComparer.OrdinalIgnoreCase))
+            // Advertises the requirable set, not the selectable one: the latter includes the
+            // Secretary, whom the guard below refuses — so the error would name a value that a
+            // retry with it copied verbatim would reject again.
+            if (!CommitteeMemberPositions.TryParseName(roleRequired, out var position))
                 throw new ArgumentException(
                     $"Invalid role '{roleRequired}'. Allowed values: " +
-                    $"{string.Join(", ", Enum.GetNames<CommitteeMemberPosition>())}.",
+                    $"{CommitteeMemberPositions.RequirableNames}.",
                     nameof(roleRequired));
 
-            var position = Enum.Parse<CommitteeMemberPosition>(roleRequired, ignoreCase: true);
+            if (!CommitteeMemberPositions.Selectable.Contains(position))
+                throw new ArgumentException(
+                    $"Role '{position}' is retired and can no longer be required. Allowed values: " +
+                    $"{CommitteeMemberPositions.RequirableNames}.",
+                    nameof(roleRequired));
+
+            // The Secretary never casts an approval vote (Meeting.ReleaseItem excludes them from the
+            // approver roster), and this condition is evaluated against the role recorded on a vote.
+            // Requiring it would produce a round that can never satisfy the condition.
+            if (!CommitteeMemberPositions.CanVote(position))
+                throw new ArgumentException(
+                    $"Role '{position}' does not vote, so the approval round could never satisfy " +
+                    "this condition.",
+                    nameof(roleRequired));
 
             if (activeMembers.Count > 0 && activeMembers.All(m => m.Position != position))
                 throw new ArgumentException(
@@ -234,12 +251,22 @@ public class Committee : Aggregate<Guid>
                 $"ConditionType {nameof(ConditionType.MinVotes)} requires a MinVotesRequired greater than 0.",
                 nameof(minVotesRequired));
 
-        if (activeMembers.Count > 0 && minVotesRequired > activeMembers.Count)
+        // Voting members, for the same reason as the MajorityValue guard in Update: votes are what
+        // this threshold counts, and the Secretary casts none.
+        var votingMembers = CountActiveVoters();
+        if (votingMembers > 0 && minVotesRequired > votingMembers)
             throw new ArgumentException(
-                $"MinVotesRequired {minVotesRequired} exceeds the committee's {activeMembers.Count} " +
-                "active member(s); the approval round could never reach it.",
+                $"MinVotesRequired {minVotesRequired} exceeds the committee's {votingMembers} " +
+                "voting member(s); the approval round could never reach it.",
                 nameof(minVotesRequired));
     }
+
+    /// <summary>
+    /// Active members who actually cast a vote — the denominator every approval threshold is
+    /// judged against. See <see cref="CommitteeMemberPositions.CanVote"/>.
+    /// </summary>
+    private int CountActiveVoters() =>
+        _members.Count(m => m.IsActive && CommitteeMemberPositions.CanVote(m.Position));
 
     public List<CommitteeMember> GetActiveMembers() =>
         _members.Where(m => m.IsActive).ToList();

--- a/Modules/Workflow/Workflow/Domain/Committees/CommitteeMember.cs
+++ b/Modules/Workflow/Workflow/Domain/Committees/CommitteeMember.cs
@@ -72,12 +72,78 @@ public enum CommitteeMemberPosition
     Secretary,
     /// <summary>Underwriter representative.</summary>
     UW,
-    /// <summary>Risk representative.</summary>
+    /// <summary>Risk representative. Retired — see <see cref="CommitteeMemberPositions.Selectable"/>.</summary>
     Risk,
-    /// <summary>Appraisal representative.</summary>
+    /// <summary>Appraisal representative. Retired — see <see cref="CommitteeMemberPositions.Selectable"/>.</summary>
     Appraisal,
-    /// <summary>Credit representative.</summary>
+    /// <summary>Credit representative. Retired — see <see cref="CommitteeMemberPositions.Selectable"/>.</summary>
     Credit,
-    /// <summary>General committee member.</summary>
+    /// <summary>General committee member. Retired — see <see cref="CommitteeMemberPositions.Selectable"/>.</summary>
     Member
+}
+
+/// <summary>
+/// Business rules over <see cref="CommitteeMemberPosition"/>.
+/// </summary>
+public static class CommitteeMemberPositions
+{
+    /// <summary>
+    /// The positions a member may be assigned today.
+    /// <see cref="CommitteeMemberPosition.Risk"/>, <see cref="CommitteeMemberPosition.Appraisal"/>,
+    /// <see cref="CommitteeMemberPosition.Credit"/> and <see cref="CommitteeMemberPosition.Member"/>
+    /// stay on the enum because Position is persisted as the enum NAME — existing committee members,
+    /// meeting rosters and historical ApprovalVote.MemberRole rows still hold them and must keep
+    /// materializing. They simply may no longer be chosen for a new or edited member.
+    /// </summary>
+    public static readonly IReadOnlySet<CommitteeMemberPosition> Selectable =
+        new HashSet<CommitteeMemberPosition>
+        {
+            CommitteeMemberPosition.Chairman,
+            CommitteeMemberPosition.Director,
+            CommitteeMemberPosition.Secretary,
+            CommitteeMemberPosition.UW
+        };
+
+    /// <summary>
+    /// Whether a member holding this position casts an approval vote once a meeting item is released.
+    /// The Secretary convenes the meeting, releases its items and signs the minutes, but never votes —
+    /// so they are excluded from the approver roster handed to the approval round.
+    /// </summary>
+    public static bool CanVote(CommitteeMemberPosition position) =>
+        position != CommitteeMemberPosition.Secretary;
+
+    /// <summary>Comma-separated <see cref="Selectable"/> names, for member validation messages.</summary>
+    public static string SelectableNames => string.Join(", ", Selectable);
+
+    /// <summary>
+    /// Comma-separated positions valid for a RoleRequired condition: selectable AND able to vote.
+    /// Narrower than <see cref="SelectableNames"/>, which would advertise the Secretary as allowed
+    /// on a call that refuses them.
+    /// </summary>
+    public static string RequirableNames => string.Join(", ", Selectable.Where(CanVote));
+
+    /// <summary>
+    /// Parses a role string by NAME, without judging whether the position is still assignable.
+    /// Name comparison rather than a bare <see cref="Enum.TryParse{T}(string, bool, out T)"/>:
+    /// TryParse also accepts the numeric form ("3" -> UW), which would pass validation and then
+    /// match no vote's role at runtime, since roles are compared as plain strings.
+    /// </summary>
+    public static bool TryParseName(string? role, out CommitteeMemberPosition position)
+    {
+        position = default;
+
+        if (!Enum.GetNames<CommitteeMemberPosition>().Contains(role, StringComparer.OrdinalIgnoreCase))
+            return false;
+
+        position = Enum.Parse<CommitteeMemberPosition>(role!, ignoreCase: true);
+        return true;
+    }
+
+    /// <summary>
+    /// Parses a role string to a currently-assignable position, rejecting unknown names and retired
+    /// ones alike. Use <see cref="TryParseName"/> instead where an existing retired value must be
+    /// allowed to survive unchanged.
+    /// </summary>
+    public static bool TryParseSelectable(string? role, out CommitteeMemberPosition position) =>
+        TryParseName(role, out position) && Selectable.Contains(position);
 }

--- a/Modules/Workflow/Workflow/Meetings/Domain/Meeting.cs
+++ b/Modules/Workflow/Workflow/Meetings/Domain/Meeting.cs
@@ -469,7 +469,12 @@ public class Meeting : Aggregate<Guid>
 
         // Carries the position as well as the user id: the approval activity uses this roster
         // as its member list, and the position becomes each voter's approval role.
+        // The Secretary is filtered out — they run the meeting and released this very item, so they
+        // are not one of its approvers. They stay on _members, and therefore on the invitation and
+        // the minutes; only the voting roster drops them. MeetingRosterEligibility validates against
+        // this same subset, so the gate and the round it opens can never disagree.
         var approvers = _members
+            .Where(m => CommitteeMemberPositions.CanVote(m.Position))
             .Select(m => new MeetingApprover(m.UserId, m.Position.ToString()))
             .ToList()
             .AsReadOnly();

--- a/Modules/Workflow/Workflow/Meetings/Domain/MeetingRosterEligibility.cs
+++ b/Modules/Workflow/Workflow/Meetings/Domain/MeetingRosterEligibility.cs
@@ -10,6 +10,10 @@ namespace Workflow.Meetings.Domain;
 /// come from the committee. A roster that cannot satisfy them produces a round that can never
 /// resolve, with the appraisal stuck in Committee Approval and no error anywhere. The release
 /// endpoint runs this first and refuses instead.
+///
+/// Counts are taken of the roster's VOTING members, since that is the subset
+/// <see cref="Meeting.ReleaseItem"/> actually hands to the round — the Secretary is excluded. The
+/// full roster is used only where membership itself is what matters (the username check).
 /// </summary>
 public static class MeetingRosterEligibility
 {
@@ -42,9 +46,26 @@ public static class MeetingRosterEligibility
             return failures;
         }
 
-        // Members who do not resolve to a real user. They still count toward the round's member
-        // total — and therefore raise the majority denominator (MajorityRule evaluates against ALL
-        // members, not votes cast) — while never being able to vote.
+        // Everything below counts VOTERS, not roster members. Release hands the approval round only
+        // the members who can vote (the Secretary is excluded — see Meeting.ReleaseItem), so the
+        // roster total would overstate the set the round actually runs with: a roster of
+        // Chairman + Secretary + UW clears a quorum of 3 but opens a round with 2 voters that can
+        // never reach it. Counting the same subset the round receives keeps the two in step.
+        var voters = roster.Where(m => CommitteeMemberPositions.CanVote(m.Position)).ToList();
+
+        // No voting members. Checked before quorum for the same reason the empty-roster guard is:
+        // ApprovalActivity switches on `overrideMembers.Count > 0`, so an empty voting roster
+        // silently falls back to the committee's own members — the substitution this path prevents.
+        if (voters.Count == 0)
+        {
+            failures.Add("the meeting has no voting members (the secretary does not vote)");
+            return failures;
+        }
+
+        // Members who do not resolve to a real user. Checked against the FULL roster: a bad username
+        // is worth reporting whether or not that member votes. Voting ones still count toward the
+        // round's member total — and therefore raise the majority denominator (MajorityRule
+        // evaluates against ALL members, not votes cast) — while never being able to vote.
         if (knownUsernames is not null)
         {
             var unresolved = roster
@@ -57,17 +78,17 @@ public static class MeetingRosterEligibility
         }
 
         // Quorum. The same rule the approval round applies, against the same member count it will
-        // run with (the roster), so this check and that round can never disagree. Only a Fixed
-        // quorum can fail here — a Percentage of the roster is satisfiable by construction.
-        var requiredQuorum = QuorumRule.Required(committee.QuorumType, committee.QuorumValue, roster.Count);
-        if (roster.Count < requiredQuorum)
-            failures.Add($"{roster.Count} member(s) but quorum requires {requiredQuorum}");
+        // run with (the voters), so this check and that round can never disagree. Only a Fixed
+        // quorum can fail here — a Percentage of the voters is satisfiable by construction.
+        var requiredQuorum = QuorumRule.Required(committee.QuorumType, committee.QuorumValue, voters.Count);
+        if (voters.Count < requiredQuorum)
+            failures.Add($"{voters.Count} voting member(s) but quorum requires {requiredQuorum}");
 
         // Majority. Only FixedCount can be unreachable — the proportional types are taken of the
-        // roster itself and so are satisfiable by construction, exactly like a Percentage quorum.
-        if (committee.MajorityType == MajorityType.FixedCount && committee.MajorityValue > roster.Count)
+        // voters themselves and so are satisfiable by construction, exactly like a Percentage quorum.
+        if (committee.MajorityType == MajorityType.FixedCount && committee.MajorityValue > voters.Count)
             failures.Add(
-                $"{committee.MajorityValue} approve vote(s) required but the roster has only {roster.Count} member(s)");
+                $"{committee.MajorityValue} approve vote(s) required but the roster has only {voters.Count} voting member(s)");
 
         foreach (var condition in committee.Conditions.Where(c => c.IsActive).OrderBy(c => c.Priority))
         {
@@ -78,15 +99,15 @@ public static class MeetingRosterEligibility
                 // no vote can ever carry that role.
                 case ConditionType.RoleRequired
                     when !string.IsNullOrWhiteSpace(condition.RoleRequired)
-                         && !roster.Any(m => string.Equals(
+                         && !voters.Any(m => string.Equals(
                              m.Position.ToString(), condition.RoleRequired, StringComparison.OrdinalIgnoreCase)):
-                    failures.Add($"no member holds the required role {condition.RoleRequired}");
+                    failures.Add($"no voting member holds the required role {condition.RoleRequired}");
                     break;
 
                 case ConditionType.MinVotes
-                    when condition.MinVotesRequired > roster.Count:
+                    when condition.MinVotesRequired > voters.Count:
                     failures.Add(
-                        $"{condition.MinVotesRequired} approve vote(s) required but the roster has only {roster.Count} member(s)");
+                        $"{condition.MinVotesRequired} approve vote(s) required but the roster has only {voters.Count} voting member(s)");
                     break;
             }
         }

--- a/Modules/Workflow/Workflow/Meetings/Features/UpdateMeetingMembers/UpdateMeetingMembersEndpoint.cs
+++ b/Modules/Workflow/Workflow/Meetings/Features/UpdateMeetingMembers/UpdateMeetingMembersEndpoint.cs
@@ -71,6 +71,13 @@ public class AddMeetingMemberCommandHandler(
         var meeting = await meetingRepository.GetByIdForDecisionAsync(command.MeetingId, ct)
             ?? throw new NotFoundException($"Meeting {command.MeetingId} not found");
 
+        // The request binds the enum directly, so a retired position (Risk/Appraisal/Credit/Member)
+        // would still deserialize. Existing rows keep theirs; new assignments may not use them.
+        if (!CommitteeMemberPositions.Selectable.Contains(command.Request.Position))
+            throw new BadRequestException(
+                $"Position '{command.Request.Position}' is retired and can no longer be assigned. " +
+                $"Allowed values: {CommitteeMemberPositions.SelectableNames}");
+
         // The roster is the approval round's voting group once the item is released, so a member
         // who is not a real user would inflate the majority denominator while never being able to
         // vote. Reject at the point of entry rather than at release.
@@ -126,6 +133,12 @@ public class ChangeMemberPositionCommandHandler(
 {
     public async Task<Unit> Handle(ChangeMemberPositionCommand command, CancellationToken ct)
     {
+        // Retired positions stay readable on existing rows but may not be assigned by an edit.
+        if (!CommitteeMemberPositions.Selectable.Contains(command.Position))
+            throw new BadRequestException(
+                $"Position '{command.Position}' is retired and can no longer be assigned. " +
+                $"Allowed values: {CommitteeMemberPositions.SelectableNames}");
+
         var meeting = await meetingRepository.GetByIdForDecisionAsync(command.MeetingId, ct)
             ?? throw new NotFoundException($"Meeting {command.MeetingId} not found");
 

--- a/Modules/Workflow/Workflow/Workflow/Features/Committees/AddCommitteeMember/AddCommitteeMemberEndpoint.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/Committees/AddCommitteeMember/AddCommitteeMemberEndpoint.cs
@@ -54,9 +54,9 @@ public class AddCommitteeMemberCommandHandler(
 
         var req = command.Request;
 
-        if (!Enum.TryParse<CommitteeMemberPosition>(req.Role, ignoreCase: true, out var position))
-            throw new ArgumentException(
-                $"Invalid Role '{req.Role}'. Allowed values: {string.Join(", ", Enum.GetNames<CommitteeMemberPosition>())}");
+        if (!CommitteeMemberPositions.TryParseSelectable(req.Role, out var position))
+            throw new BadRequestException(
+                $"Invalid Role '{req.Role}'. Allowed values: {CommitteeMemberPositions.SelectableNames}");
 
         // UserId is a username and becomes an approval voter — counted into the round's member
         // total whether or not anyone can actually sign in as it. Validated alongside Role.

--- a/Modules/Workflow/Workflow/Workflow/Features/Committees/CreateCommittee/CreateCommitteeEndpoint.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/Committees/CreateCommittee/CreateCommitteeEndpoint.cs
@@ -80,10 +80,17 @@ public class CreateCommitteeCommandHandler(
 
             foreach (var m in req.Members)
             {
-                var position = Enum.Parse<CommitteeMemberPosition>(m.Role, ignoreCase: true);
-                var attendance = string.IsNullOrWhiteSpace(m.Attendance)
-                    ? CommitteeAttendance.Always
-                    : Enum.Parse<CommitteeAttendance>(m.Attendance, ignoreCase: true);
+                if (!CommitteeMemberPositions.TryParseSelectable(m.Role, out var position))
+                    throw new BadRequestException(
+                        $"Invalid Role '{m.Role}'. Allowed values: {CommitteeMemberPositions.SelectableNames}");
+
+                var attendance = CommitteeAttendance.Always;
+                if (!string.IsNullOrWhiteSpace(m.Attendance)
+                    && !Enum.TryParse(m.Attendance, ignoreCase: true, out attendance))
+                    throw new BadRequestException(
+                        $"Invalid Attendance '{m.Attendance}'. Allowed values: " +
+                        $"{string.Join(", ", Enum.GetNames<CommitteeAttendance>())}");
+
                 committee.AddMember(m.UserId, m.MemberName, position, attendance);
             }
         }
@@ -98,8 +105,23 @@ public class CreateCommitteeCommandHandler(
         {
             foreach (var c in req.Conditions)
             {
-                var conditionType = Enum.Parse<ConditionType>(c.ConditionType, ignoreCase: true);
-                committee.AddCondition(conditionType, c.RoleRequired, c.MinVotesRequired, c.Priority, c.Description);
+                if (!Enum.TryParse<ConditionType>(c.ConditionType, ignoreCase: true, out var conditionType))
+                    throw new BadRequestException(
+                        $"Invalid ConditionType '{c.ConditionType}'. Allowed values: " +
+                        $"{string.Join(", ", Enum.GetNames<ConditionType>())}");
+
+                // The domain signals an unsatisfiable condition with ArgumentException, which the
+                // global CustomExceptionHandler does not map — translate it so the caller gets 400,
+                // not a 500 with a stack-traced ProblemDetails. Same as AddCommitteeCondition.
+                try
+                {
+                    committee.AddCondition(
+                        conditionType, c.RoleRequired, c.MinVotesRequired, c.Priority, c.Description);
+                }
+                catch (ArgumentException ex)
+                {
+                    throw new BadRequestException(ex.Message);
+                }
             }
         }
 

--- a/Modules/Workflow/Workflow/Workflow/Features/Committees/UpdateCommitteeMember/UpdateCommitteeMemberEndpoint.cs
+++ b/Modules/Workflow/Workflow/Workflow/Features/Committees/UpdateCommitteeMember/UpdateCommitteeMemberEndpoint.cs
@@ -40,12 +40,24 @@ public class UpdateCommitteeMemberCommandHandler(
 
         var req = command.Request;
 
-        if (!Enum.TryParse<CommitteeMemberPosition>(req.Role, ignoreCase: true, out var position))
-            throw new ArgumentException(
-                $"Invalid Role '{req.Role}'. Allowed values: {string.Join(", ", Enum.GetNames<CommitteeMemberPosition>())}");
+        // Includes inactive members — reactivating one is exactly the case that must keep working.
+        var member = committee.Members.FirstOrDefault(m => m.Id == command.MemberId)
+            ?? throw new NotFoundException($"CommitteeMember {command.MemberId} not found");
+
+        if (!CommitteeMemberPositions.TryParseName(req.Role, out var position))
+            throw new BadRequestException(
+                $"Invalid Role '{req.Role}'. Allowed values: {CommitteeMemberPositions.SelectableNames}");
+
+        // This is a whole-record update, so deactivating or re-scheduling a member added before
+        // Risk/Appraisal/Credit/Member were retired still sends their existing role back. Only a
+        // CHANGE has to land on a currently-assignable position; an unchanged one may stand.
+        if (position != member.Position && !CommitteeMemberPositions.Selectable.Contains(position))
+            throw new BadRequestException(
+                $"Role '{position}' is retired and can no longer be assigned. " +
+                $"Allowed values: {CommitteeMemberPositions.SelectableNames}");
 
         if (!Enum.TryParse<CommitteeAttendance>(req.Attendance, ignoreCase: true, out var attendance))
-            throw new ArgumentException(
+            throw new BadRequestException(
                 $"Invalid Attendance '{req.Attendance}'. Allowed values: {string.Join(", ", Enum.GetNames<CommitteeAttendance>())}");
 
         committee.UpdateMember(command.MemberId, position, attendance, req.IsActive);

--- a/Tests/Unit/Workflow.Tests/Domain/CommitteeAddConditionTests.cs
+++ b/Tests/Unit/Workflow.Tests/Domain/CommitteeAddConditionTests.cs
@@ -17,7 +17,7 @@ public class CommitteeAddConditionTests
     [InlineData("UW")]
     [InlineData("uw")]
     [InlineData("Chairman")]
-    [InlineData("Member")]
+    [InlineData("Director")]
     public void AddCondition_RoleRequired_AcceptsAPositionName(string role)
     {
         var committee = BuildCommittee();
@@ -48,6 +48,27 @@ public class CommitteeAddConditionTests
     }
 
     [Fact]
+    public void AddCondition_RoleRequired_InvalidNameMessageOnlyListsRolesItWouldAccept()
+    {
+        // The message used to advertise the selectable set, which includes the Secretary — so an
+        // admin could copy a value straight out of the error and be refused again by the next guard.
+        var committee = BuildCommittee();
+
+        var act = () => committee.AddCondition(
+            ConditionType.RoleRequired, "Cheirman", minVotesRequired: null, priority: 1, description: null);
+
+        var message = act.Should().Throw<ArgumentException>().Which.Message;
+
+        message.Should().NotContain(nameof(CommitteeMemberPosition.Secretary));
+        foreach (var retired in Enum.GetValues<CommitteeMemberPosition>()
+                     .Where(p => !CommitteeMemberPositions.Selectable.Contains(p)))
+            message.Should().NotContain(retired.ToString());
+
+        message.Should().Contain(nameof(CommitteeMemberPosition.Chairman));
+        message.Should().Contain(nameof(CommitteeMemberPosition.UW));
+    }
+
+    [Fact]
     public void AddCondition_RoleRequired_RejectsTheNumericFormOfAPosition()
     {
         // Enum.TryParse would accept "3" and map it to UW, but RoleRequired is persisted as the raw
@@ -72,17 +93,52 @@ public class CommitteeAddConditionTests
     }
 
     [Fact]
-    public void AddCondition_RoleRequired_AcceptsEveryDefinedPosition()
+    public void AddCondition_RoleRequired_AcceptsEverySelectableVotingPosition()
     {
-        // The guard must not drift from the enum the vote role is produced from.
-        foreach (var name in Enum.GetNames<CommitteeMemberPosition>())
+        // The guard must not drift from the positions a vote role can actually be produced from:
+        // currently selectable, and able to vote. The Secretary is selectable but never votes.
+        var expected = CommitteeMemberPositions.Selectable
+            .Where(CommitteeMemberPositions.CanVote)
+            .ToList();
+
+        foreach (var position in expected)
         {
             var committee = BuildCommittee();
             var act = () => committee.AddCondition(
-                ConditionType.RoleRequired, name, null, 1, null);
+                ConditionType.RoleRequired, position.ToString(), null, 1, null);
 
-            act.Should().NotThrow($"{name} is a valid CommitteeMemberPosition");
+            act.Should().NotThrow($"{position} is selectable and votes");
         }
+    }
+
+    [Fact]
+    public void AddCondition_RoleRequired_RejectsSecretary_BecauseTheyNeverVote()
+    {
+        // Meeting.ReleaseItem drops the Secretary from the approver roster, so no vote can ever
+        // carry that role — requiring it would open a round that can never satisfy the condition.
+        var committee = BuildCommittee();
+
+        var act = () => committee.AddCondition(
+            ConditionType.RoleRequired, nameof(CommitteeMemberPosition.Secretary), null, 1, null);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*does not vote*");
+    }
+
+    [Theory]
+    [InlineData("Risk")]
+    [InlineData("Appraisal")]
+    [InlineData("Credit")]
+    [InlineData("Member")]
+    public void AddCondition_RoleRequired_RejectsRetiredPositions(string role)
+    {
+        // Still on the enum so existing rows materialize, but no longer assignable — a condition
+        // requiring one could only be satisfied by a member nobody can create any more.
+        var committee = BuildCommittee();
+
+        var act = () => committee.AddCondition(
+            ConditionType.RoleRequired, role, null, 1, null);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*retired*");
     }
 
     private static Committee BuildCommittee()

--- a/Tests/Unit/Workflow.Tests/Domain/CommitteeMajorityTests.cs
+++ b/Tests/Unit/Workflow.Tests/Domain/CommitteeMajorityTests.cs
@@ -76,7 +76,7 @@ public class CommitteeMajorityTests
         var act = () => committee.Update("C", null, QuorumType.Fixed, 1,
             MajorityType.FixedCount, isActive: true, VotingMode.WaitForAll, majorityValue: 3);
 
-        act.Should().Throw<ArgumentException>().WithMessage("*exceeds*2 active member(s)*");
+        act.Should().Throw<ArgumentException>().WithMessage("*exceeds*2 voting member(s)*");
     }
 
     [Fact]

--- a/Tests/Unit/Workflow.Tests/Domain/CommitteeVotingThresholdTests.cs
+++ b/Tests/Unit/Workflow.Tests/Domain/CommitteeVotingThresholdTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using Workflow.Domain.Committees;
+using Xunit;
+
+namespace Workflow.Tests.Domain;
+
+/// <summary>
+/// The committee's own satisfiability guards must count the members who actually VOTE, which is the
+/// same subset <see cref="Workflow.Meetings.Domain.MeetingRosterEligibility"/> checks a meeting
+/// roster against at release. Counting the Secretary here would let the admin screen accept a
+/// threshold that the release gate then refuses — the two guards must not drift apart.
+/// </summary>
+public class CommitteeVotingThresholdTests
+{
+    [Fact]
+    public void Update_FixedCountMajority_DoesNotCountTheSecretary()
+    {
+        // Four active members, one of them the Secretary => three voters. A FixedCount of 4 can
+        // never be reached, even though the committee "has" four members.
+        var committee = BuildCommitteeWithSecretary();
+
+        var act = () => committee.Update("C", null, QuorumType.Fixed, 1,
+            MajorityType.FixedCount, isActive: true, majorityValue: 4);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*3 voting member(s)*");
+    }
+
+    [Fact]
+    public void Update_FixedCountMajority_AcceptsAThresholdTheVotersCanReach()
+    {
+        var committee = BuildCommitteeWithSecretary();
+
+        var act = () => committee.Update("C", null, QuorumType.Fixed, 1,
+            MajorityType.FixedCount, isActive: true, majorityValue: 3);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void AddCondition_MinVotes_DoesNotCountTheSecretary()
+    {
+        var committee = BuildCommitteeWithSecretary();
+
+        var act = () => committee.AddCondition(
+            ConditionType.MinVotes, roleRequired: null, minVotesRequired: 4,
+            priority: 1, description: null);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*3 voting member(s)*");
+    }
+
+    [Fact]
+    public void AddCondition_MinVotes_AcceptsWhatTheVotersCanReach()
+    {
+        var committee = BuildCommitteeWithSecretary();
+
+        var act = () => committee.AddCondition(
+            ConditionType.MinVotes, roleRequired: null, minVotesRequired: 3,
+            priority: 1, description: null);
+
+        act.Should().NotThrow();
+    }
+
+    private static Committee BuildCommitteeWithSecretary()
+    {
+        var committee = Committee.Create("C", "C", null,
+            QuorumType.Fixed, 1, MajorityType.Simple, VotingMode.WaitForAll);
+
+        committee.AddMember("a", "Alice", CommitteeMemberPosition.Chairman);
+        committee.AddMember("b", "Bob", CommitteeMemberPosition.Director);
+        committee.AddMember("c", "Carol", CommitteeMemberPosition.UW);
+        committee.AddMember("d", "Dan", CommitteeMemberPosition.Secretary);
+
+        return committee;
+    }
+}

--- a/Tests/Unit/Workflow.Tests/Domain/UpdateCommitteeMemberRoleTests.cs
+++ b/Tests/Unit/Workflow.Tests/Domain/UpdateCommitteeMemberRoleTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using NSubstitute;
+using Shared.Exceptions;
+using Workflow.Domain.Committees;
+using Workflow.Workflow.Features.Committees.UpdateCommitteeMember;
+using Xunit;
+
+namespace Workflow.Tests.Domain;
+
+/// <summary>
+/// Updating a committee member is a WHOLE-RECORD write (Role + Attendance + IsActive), so an admin
+/// deactivating or re-scheduling a member added before Risk/Appraisal/Credit/Member were retired
+/// sends that retired role straight back. Rejecting it outright would strand those members — the
+/// rule is that only a CHANGE has to land on a currently-assignable position.
+/// </summary>
+public class UpdateCommitteeMemberRoleTests
+{
+    [Fact]
+    public async Task Deactivating_AMemberHoldingARetiredRole_IsAllowed()
+    {
+        var (handler, committee, memberId) = Build(CommitteeMemberPosition.Risk);
+
+        await handler.Handle(
+            Command(committee.Id, memberId, nameof(CommitteeMemberPosition.Risk), isActive: false),
+            CancellationToken.None);
+
+        var member = committee.Members.Single(m => m.Id == memberId);
+        member.IsActive.Should().BeFalse();
+        member.Position.Should().Be(CommitteeMemberPosition.Risk, "an untouched role must survive");
+    }
+
+    [Fact]
+    public async Task MovingARetiredRoleOntoASelectableOne_IsAllowed()
+    {
+        // The cleanup path: Committee Admin must always be able to migrate a legacy member.
+        var (handler, committee, memberId) = Build(CommitteeMemberPosition.Risk);
+
+        await handler.Handle(
+            Command(committee.Id, memberId, nameof(CommitteeMemberPosition.Director)),
+            CancellationToken.None);
+
+        committee.Members.Single(m => m.Id == memberId)
+            .Position.Should().Be(CommitteeMemberPosition.Director);
+    }
+
+    [Fact]
+    public async Task AssigningARetiredRoleToAMemberWhoDidNotHoldIt_IsRejected()
+    {
+        var (handler, committee, memberId) = Build(CommitteeMemberPosition.Chairman);
+
+        var act = () => handler.Handle(
+            Command(committee.Id, memberId, nameof(CommitteeMemberPosition.Risk)),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<BadRequestException>().WithMessage("*retired*");
+    }
+
+    [Fact]
+    public async Task AnUnknownRoleName_IsRejected()
+    {
+        var (handler, committee, memberId) = Build(CommitteeMemberPosition.Chairman);
+
+        var act = () => handler.Handle(
+            Command(committee.Id, memberId, "Underwriter"),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<BadRequestException>().WithMessage("*Invalid Role*");
+    }
+
+    [Fact]
+    public async Task TheNumericFormOfAPosition_IsRejected()
+    {
+        // Enum.TryParse would map "3" to UW; roles are compared as raw strings downstream.
+        var (handler, committee, memberId) = Build(CommitteeMemberPosition.Chairman);
+
+        var act = () => handler.Handle(
+            Command(committee.Id, memberId, "3"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<BadRequestException>().WithMessage("*Invalid Role*");
+    }
+
+    // -- Helpers --
+
+    private static UpdateCommitteeMemberCommand Command(
+        Guid committeeId, Guid memberId, string role, bool isActive = true) =>
+        new(committeeId, memberId,
+            new UpdateCommitteeMemberRequest(role, nameof(CommitteeAttendance.Always), isActive));
+
+    private static (UpdateCommitteeMemberCommandHandler Handler, Committee Committee, Guid MemberId)
+        Build(CommitteeMemberPosition position)
+    {
+        var committee = Committee.Create("C", "C", null,
+            QuorumType.Fixed, 1, MajorityType.Simple, VotingMode.WaitForAll);
+
+        var member = committee.AddMember("legacy", "Legacy Member", position);
+
+        var repository = Substitute.For<ICommitteeRepository>();
+        repository.GetByIdWithMembersAsync(committee.Id, Arg.Any<CancellationToken>())
+            .Returns(committee);
+
+        return (new UpdateCommitteeMemberCommandHandler(repository), committee, member.Id);
+    }
+}

--- a/Tests/Unit/Workflow.Tests/Meetings/MeetingRosterEligibilityTests.cs
+++ b/Tests/Unit/Workflow.Tests/Meetings/MeetingRosterEligibilityTests.cs
@@ -19,8 +19,8 @@ public class MeetingRosterEligibilityTests
 
         var failures = MeetingRosterEligibility.Check(
             Roster(("a", CommitteeMemberPosition.Chairman),
-                   ("b", CommitteeMemberPosition.Member),
-                   ("c", CommitteeMemberPosition.Member)),
+                   ("b", CommitteeMemberPosition.Director),
+                   ("c", CommitteeMemberPosition.Director)),
             committee);
 
         failures.Should().BeEmpty();
@@ -33,11 +33,11 @@ public class MeetingRosterEligibilityTests
 
         var failures = MeetingRosterEligibility.Check(
             Roster(("a", CommitteeMemberPosition.Chairman),
-                   ("b", CommitteeMemberPosition.Member)),
+                   ("b", CommitteeMemberPosition.Director)),
             committee);
 
         failures.Should().ContainSingle()
-            .Which.Should().Be("2 member(s) but quorum requires 3");
+            .Which.Should().Be("2 voting member(s) but quorum requires 3");
     }
 
     [Fact]
@@ -62,11 +62,11 @@ public class MeetingRosterEligibilityTests
 
         var failures = MeetingRosterEligibility.Check(
             Roster(("a", CommitteeMemberPosition.Chairman),
-                   ("b", CommitteeMemberPosition.Member)),
+                   ("b", CommitteeMemberPosition.Director)),
             committee);
 
         failures.Should().ContainSingle()
-            .Which.Should().Be("no member holds the required role UW");
+            .Which.Should().Be("no voting member holds the required role UW");
     }
 
     [Fact]
@@ -107,11 +107,11 @@ public class MeetingRosterEligibilityTests
 
         var failures = MeetingRosterEligibility.Check(
             Roster(("a", CommitteeMemberPosition.Chairman),
-                   ("b", CommitteeMemberPosition.Member)),
+                   ("b", CommitteeMemberPosition.Director)),
             committee);
 
         failures.Should().ContainSingle()
-            .Which.Should().Be("3 approve vote(s) required but the roster has only 2 member(s)");
+            .Which.Should().Be("3 approve vote(s) required but the roster has only 2 voting member(s)");
     }
 
     [Fact]
@@ -126,8 +126,8 @@ public class MeetingRosterEligibilityTests
 
         failures.Should().BeEquivalentTo(
         [
-            "1 member(s) but quorum requires 3",
-            "no member holds the required role UW"
+            "1 voting member(s) but quorum requires 3",
+            "no voting member holds the required role UW"
         ]);
     }
 
@@ -180,7 +180,7 @@ public class MeetingRosterEligibilityTests
         var failures = MeetingRosterEligibility.Check(
             Roster(("alice", CommitteeMemberPosition.Chairman),
                    ("ghost", CommitteeMemberPosition.UW),
-                   ("phantom", CommitteeMemberPosition.Member)),
+                   ("phantom", CommitteeMemberPosition.Director)),
             committee,
             knownUsernames: Known("alice"));
 
@@ -229,7 +229,7 @@ public class MeetingRosterEligibilityTests
             committee);
 
         failures.Should().ContainSingle()
-            .Which.Should().Be("3 approve vote(s) required but the roster has only 2 member(s)");
+            .Which.Should().Be("3 approve vote(s) required but the roster has only 2 voting member(s)");
     }
 
     [Fact]
@@ -257,6 +257,92 @@ public class MeetingRosterEligibilityTests
             Roster(("a", CommitteeMemberPosition.Chairman)), committee);
 
         failures.Should().BeEmpty();
+    }
+
+    // -- The secretary attends but does not vote --
+
+    [Fact]
+    public void Check_SecretaryDoesNotCountTowardQuorum()
+    {
+        // The exact stall this guard exists for: three people on the roster clears a quorum of 3,
+        // but release hands the round only the two who vote, so it could never reach quorum.
+        var committee = BuildCommittee(QuorumType.Fixed, 3);
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Chairman),
+                   ("b", CommitteeMemberPosition.Secretary),
+                   ("c", CommitteeMemberPosition.UW)),
+            committee);
+
+        failures.Should().ContainSingle()
+            .Which.Should().Be("2 voting member(s) but quorum requires 3");
+    }
+
+    [Fact]
+    public void Check_RosterOfOnlySecretaries_Fails()
+    {
+        // Non-empty, so the empty-roster guard does not catch it, yet it yields no approvers at all.
+        // Released, ApprovalActivity's `overrideMembers.Count > 0` switch would read the empty list
+        // as "no override" and silently run the round with the COMMITTEE's members.
+        var committee = BuildCommittee(QuorumType.Percentage, 100);
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Secretary)), committee);
+
+        failures.Should().ContainSingle()
+            .Which.Should().Be("the meeting has no voting members (the secretary does not vote)");
+    }
+
+    [Fact]
+    public void Check_SecretaryCannotSatisfyARequiredRole()
+    {
+        // No vote can ever carry the Secretary role, so a roster that leans on them for a
+        // RoleRequired condition is unsatisfiable even though someone "holds" the position.
+        var committee = BuildCommittee(QuorumType.Fixed, 1);
+        committee.AddCondition(ConditionType.RoleRequired, nameof(CommitteeMemberPosition.UW),
+            null, 1, "UW must approve");
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Chairman),
+                   ("b", CommitteeMemberPosition.Secretary)),
+            committee);
+
+        failures.Should().ContainSingle()
+            .Which.Should().Be("no voting member holds the required role UW");
+    }
+
+    [Fact]
+    public void Check_SecretaryAlongsideEnoughVoters_NoFailures()
+    {
+        // The Secretary is not a problem in itself — only when the voters left behind fall short.
+        var committee = BuildCommittee(QuorumType.Fixed, 2);
+        committee.AddCondition(ConditionType.RoleRequired, nameof(CommitteeMemberPosition.UW),
+            null, 1, "UW must approve");
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("a", CommitteeMemberPosition.Chairman),
+                   ("b", CommitteeMemberPosition.Secretary),
+                   ("c", CommitteeMemberPosition.UW)),
+            committee);
+
+        failures.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Check_UnresolvedSecretary_IsStillReported()
+    {
+        // The username check covers the whole roster, not just voters: a secretary who resolves to
+        // nobody is a roster error worth surfacing before release.
+        var committee = BuildCommittee(QuorumType.Fixed, 1);
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("alice", CommitteeMemberPosition.Chairman),
+                   ("ghost", CommitteeMemberPosition.Secretary)),
+            committee,
+            knownUsernames: Known("alice"));
+
+        failures.Should().ContainSingle()
+            .Which.Should().Be("no such user: ghost");
     }
 
     // -- Helpers --

--- a/Tests/Unit/Workflow.Tests/Meetings/MeetingTests.cs
+++ b/Tests/Unit/Workflow.Tests/Meetings/MeetingTests.cs
@@ -54,7 +54,7 @@ public class MeetingTests
         var meeting = BuildNewMeeting();
         var committee = BuildCommittee();
         committee.AddMember("active-1", "Alice", CommitteeMemberPosition.Chairman);
-        committee.AddMember("active-2", "Bob", CommitteeMemberPosition.Member);
+        committee.AddMember("active-2", "Bob", CommitteeMemberPosition.Director);
         var inactiveMember = committee.AddMember("inactive-1", "Charlie", CommitteeMemberPosition.Secretary);
         inactiveMember.Deactivate();
 
@@ -315,7 +315,7 @@ public class MeetingTests
     {
         var committee = BuildCommittee();
         committee.AddMember("m1", "Alice", CommitteeMemberPosition.Chairman);
-        committee.AddMember("m2", "Bob", CommitteeMemberPosition.Member);
+        committee.AddMember("m2", "Bob", CommitteeMemberPosition.Director);
 
         var meeting = BuildInvitationSentMeetingWithOneItem(committee);
         var appraisalId = meeting.Items.Single(i => i.Kind == MeetingItemKind.Decision).AppraisalId;
@@ -327,8 +327,33 @@ public class MeetingTests
         ReleasedMembers(meeting).Should().BeEquivalentTo(
         [
             new MeetingApprover("m1", nameof(CommitteeMemberPosition.Chairman)),
-            new MeetingApprover("m2", nameof(CommitteeMemberPosition.Member))
+            new MeetingApprover("m2", nameof(CommitteeMemberPosition.Director))
         ]);
+    }
+
+    [Fact]
+    public void ReleaseItem_ExcludesTheSecretary_FromTheApproverRoster()
+    {
+        // The secretary convenes the meeting and releases the item; they are not one of its
+        // approvers. They stay on the roster (invitation and minutes still list them) — only the
+        // voting set handed to the approval round drops them.
+        var committee = BuildCommittee();
+        committee.AddMember("m1", "Alice", CommitteeMemberPosition.Chairman);
+        committee.AddMember("m2", "Bob", CommitteeMemberPosition.Secretary);
+        committee.AddMember("m3", "Carol", CommitteeMemberPosition.UW);
+
+        var meeting = BuildInvitationSentMeetingWithOneItem(committee);
+        var appraisalId = meeting.Items.Single(i => i.Kind == MeetingItemKind.Decision).AppraisalId;
+
+        meeting.ReleaseItem(appraisalId, "secretary", DateTime.UtcNow);
+
+        ReleasedMembers(meeting).Should().BeEquivalentTo(
+        [
+            new MeetingApprover("m1", nameof(CommitteeMemberPosition.Chairman)),
+            new MeetingApprover("m3", nameof(CommitteeMemberPosition.UW))
+        ]);
+
+        meeting.Members.Select(m => m.UserId).Should().Contain("m2");
     }
 
     [Fact]
@@ -357,7 +382,7 @@ public class MeetingTests
     {
         var committee = BuildCommittee();
         committee.AddMember("m1", "Alice", CommitteeMemberPosition.Chairman);
-        committee.AddMember("m2", "Bob", CommitteeMemberPosition.Member);
+        committee.AddMember("m2", "Bob", CommitteeMemberPosition.Director);
 
         var meeting = BuildInvitationSentMeetingWithOneItem(committee);
         var bob = meeting.Members.Single(m => m.UserId == "m2");
@@ -374,7 +399,7 @@ public class MeetingTests
     public void ReleaseItem_AfterPositionChangedOnThisMeeting_CarriesTheNewPosition()
     {
         var committee = BuildCommittee();
-        committee.AddMember("m1", "Alice", CommitteeMemberPosition.Member);
+        committee.AddMember("m1", "Alice", CommitteeMemberPosition.Director);
 
         var meeting = BuildInvitationSentMeetingWithOneItem(committee);
         var alice = meeting.Members.Single(m => m.UserId == "m1");
@@ -718,7 +743,7 @@ public class MeetingTests
     public void AddMember_DuplicateUser_Throws()
     {
         var meeting = BuildNewMeeting();
-        var member1 = MeetingMember.CreateManual(meeting.Id, "user-dup", "Duper", CommitteeMemberPosition.Member);
+        var member1 = MeetingMember.CreateManual(meeting.Id, "user-dup", "Duper", CommitteeMemberPosition.Director);
         meeting.AddMember(member1, DateTime.UtcNow);
         var member2 = MeetingMember.CreateManual(meeting.Id, "user-dup", "Duper Clone", CommitteeMemberPosition.Credit);
 
@@ -731,7 +756,7 @@ public class MeetingTests
     public void ChangeMemberPosition_InNew_UpdatesPosition()
     {
         var meeting = BuildNewMeeting();
-        var member = MeetingMember.CreateManual(meeting.Id, "user-pos", "Posie", CommitteeMemberPosition.Member);
+        var member = MeetingMember.CreateManual(meeting.Id, "user-pos", "Posie", CommitteeMemberPosition.Director);
         meeting.AddMember(member, DateTime.UtcNow);
 
         meeting.ChangeMemberPosition(member.Id, CommitteeMemberPosition.Director, DateTime.UtcNow);
@@ -749,9 +774,9 @@ public class MeetingTests
         var committee = BuildCommittee();
         var always = committee.AddMember("u1", "Always", CommitteeMemberPosition.Chairman);
         // always.Attendance is Always by default
-        var odd = committee.AddMember("u2", "Odd", CommitteeMemberPosition.Member);
+        var odd = committee.AddMember("u2", "Odd", CommitteeMemberPosition.Director);
         odd.UpdateAttendance(CommitteeAttendance.Odd);
-        var even = committee.AddMember("u3", "Even", CommitteeMemberPosition.Member);
+        var even = committee.AddMember("u3", "Even", CommitteeMemberPosition.Director);
         even.UpdateAttendance(CommitteeAttendance.Even);
 
         var result = committee.GetActiveMembers(meetingSeq: 1);
@@ -764,9 +789,9 @@ public class MeetingTests
     {
         var committee = BuildCommittee();
         var always = committee.AddMember("u1", "Always", CommitteeMemberPosition.Chairman);
-        var odd = committee.AddMember("u2", "Odd", CommitteeMemberPosition.Member);
+        var odd = committee.AddMember("u2", "Odd", CommitteeMemberPosition.Director);
         odd.UpdateAttendance(CommitteeAttendance.Odd);
-        var even = committee.AddMember("u3", "Even", CommitteeMemberPosition.Member);
+        var even = committee.AddMember("u3", "Even", CommitteeMemberPosition.Director);
         even.UpdateAttendance(CommitteeAttendance.Even);
 
         var result = committee.GetActiveMembers(meetingSeq: 2);
@@ -779,7 +804,7 @@ public class MeetingTests
     {
         var committee = BuildCommittee();
         var active = committee.AddMember("u1", "Active", CommitteeMemberPosition.Chairman);
-        var inactive = committee.AddMember("u2", "Inactive", CommitteeMemberPosition.Member);
+        var inactive = committee.AddMember("u2", "Inactive", CommitteeMemberPosition.Director);
         inactive.Deactivate();
 
         var result = committee.GetActiveMembers(meetingSeq: 1);
@@ -792,7 +817,7 @@ public class MeetingTests
     {
         var committee = BuildCommittee();
         var always = committee.AddMember("u1", "Always", CommitteeMemberPosition.Chairman);
-        var odd = committee.AddMember("u2", "Odd", CommitteeMemberPosition.Member);
+        var odd = committee.AddMember("u2", "Odd", CommitteeMemberPosition.Director);
         odd.UpdateAttendance(CommitteeAttendance.Odd);
 
         // No-arg overload must still return all active members regardless of Attendance


### PR DESCRIPTION
## Problem

The meeting/committee **POSITION** dropdown offered 8 options. The business uses four: Chairman, Director, Secretary, UW.

Separately, when the secretary released a meeting item, the **entire roster — secretary included — was handed to the approval round as voting members**. The secretary convenes the meeting, releases its items and signs the minutes; they should not also cast an approval vote.

There was already a `MeetingPosition` general-parameter group, but it was **orphaned**:

| Problem | Detail |
|---|---|
| Nothing read it | No backend or frontend code referenced the group |
| Missing a value | 3 codes; `UW` absent — yet `COMMITTEE_WITH_MEETING` has a `RoleRequired = UW` condition |
| Unbindable keys | Keyed `01`/`02`/`03`, while the API binds `CommitteeMemberPosition` **by name** |
| Fake Thai | The `TH` rows contained English text |

The frontend hardcoded the 8 positions in five separate places.

## What changed

**1. Four selectable positions, eight readable ones.** `CommitteeMemberPosition` keeps all 8 values. Position is persisted as the enum **name**, and live data holds the retired ones:

| Table | Risk | Appraisal | Credit | Member |
|---|---|---|---|---|
| `workflow.CommitteeMembers` | 3 | 2 | 2 | 0 |
| `workflow.MeetingMembers` | 9 | 8 | 7 | 4 |
| `workflow.ApprovalVotes.MemberRole` | 28 | 6 | 6 | 0 |

Deleting enum values would break EF materialization and rewrite approval history. A new `CommitteeMemberPositions` companion (`Selectable`, `CanVote`, `TryParseName`, `TryParseSelectable`, `SelectableNames`, `RequirableNames`) gates **assignment** only. Validation lives at the write endpoints, not in `CommitteeMember.Create` / `MeetingMember.CreateSnapshot`, so snapshots and repository materialization keep accepting legacy values.

**2. The secretary is excluded from the approver roster.** `Meeting.ReleaseItem` filters on `CanVote`. They stay on `_members`, so the invitation and minutes reports still list them as เลขานุการฯ.

**3. `MeetingRosterEligibility` counts VOTERS, not roster members** — quorum, `FixedCount` majority, `MinVotes` and `RoleRequired`. This is the load-bearing part:

> `COMMITTEE_WITH_MEETING` has `Quorum = Fixed 3`. A roster of `Chairman + Secretary + UW` **passes** a full-roster check (3 ≥ 3) but opens a round with **2** voters that can never reach quorum. The appraisal then sits in Committee Approval forever with no error anywhere — the exact failure this gate exists to prevent (#350).

The unresolved-username check deliberately still spans the full roster: a bad username is worth reporting whether or not that member votes. `Committee.Update`'s `FixedCount` guard and the `MinVotes` guard now count voters too, so the admin screen can no longer accept a threshold release will refuse.

**4. `MeetingPosition` re-keyed** to enum names with real Thai labels, plus `UW`. Shipped twice on purpose: the master seed is edited for **fresh** databases, and `20260805120000_UpdateSeed_MeetingPositionParameter.sql` updates **existing** ones — DbUp journals one-time scripts by filename, so editing the master alone is a no-op where it already ran.

**5. Three 500s became 400s.** `ArgumentException` has no arm in `CustomExceptionHandler`, so it falls through to a stack-traced 500. `CreateCommittee`'s conditions loop, its `ConditionType`/`Attendance` parses, and `UpdateCommitteeMember`'s `Attendance` parse all returned 500 on plain bad input.

## Review round

A high-effort review raised 10 findings: **7 fixed, 2 need no change, 1 deliberately skipped.** The three not fixed were each checked against live data rather than argued:

- **"The secretary still votes on non-meeting committees."** True of the code — `SUB_COMMITTEE`/`COMMITTEE` approve without a meeting and resolve members straight off the roster. Not applicable: **zero Secretary rows exist in `workflow.CommitteeMembers`** (`SUB_COMMITTEE`: Chairman 8, Risk 1, UW 1). Per the team rule those committees never have one, so `ApprovalMemberResolver` is untouched and "everyone on the roster votes" stays correct where there is no meeting.
- **"Voting-subset quorum will block existing meetings."** The smallest voting roster across all 9 meetings is **4**, against a quorum of 3. Nothing existing is blocked; no `QuorumValue` backfill needed.
- **"Rejecting retired roles makes existing conditions uneditable."** Skipped deliberately: **no condition anywhere uses a retired role** — the only two that exist are `RoleRequired = UW`. Nothing to strand.

**Why members and conditions differ.** Members get the softer *enforce-only-on-change* rule so a legacy `Risk` member can still be deactivated or re-scheduled without rewriting their position — 7 such rows exist. Conditions get a hard rejection, because 0 such rows exist and never should. The asymmetry is data-driven, not an oversight.

## Verification

- `dotnet build collateral-appraisal-system-api.sln --configuration Release` → **0 errors** (the step CI gates on).
- `dotnet test Tests/Unit/Workflow.Tests` → **983 passed, 10 failed**, byte-identical to the pre-change baseline on `main` (InboxGuard/relational-provider and friends, all unrelated). **994 total, up from 973/984** — 21 new tests.
- The migration was applied to the dev database and the rows queried back: 8 rows, codes `Chairman`/`Director`/`Secretary`/`UW`, real Thai labels.

⚠ `ExpressionEvaluatorTests.EvaluateExpression_CachingPerformance` is a **timing flake**. A run showing 11 failures is not a regression — re-run before believing it.

## Deliberately out of scope

- `ApprovalMemberResolver` (the non-meeting approval path) — see the review round above.
- The `Appraisal` module's parallel `CommitteeMember.Role`, which is free text with no enum validation at all.

## Deploy notes

- **Ship with the frontend half: immortalgky/collateral-appraisal-system-app#307.** Deployed apart, backend-first means the old UI still offers retired positions and users get a 400 toast.
- Run the migration so the re-keyed parameter group lands. Until it does, the new UI falls back to its built-in list of four — correct, just not parameter-driven.
- **Restart the API afterwards.** `CachedParameterRepository` caches with no TTL and no eviction on write, so new rows are invisible until the process restarts.
- Tell admins that members holding `Risk`/`Appraisal`/`Credit`/`Member` keep working and stay editable, but can only be moved onto one of the four — so they retire them deliberately rather than discovering them one edit at a time.

## Note for reviewers

The highest-value diff to read is `MeetingRosterEligibility.Check`. The rule is that it must count the **same set** `Meeting.ReleaseItem` hands the round; if those two ever drift, the symptom is a silently stalled appraisal, not an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnGqs6hMcgZCc6LvGeFBr9
