### PR TITLE
fix(workflow): report unresolved usernames with the no-voters failure and order allowed-values

### DIFF
--- a/Modules/Workflow/Workflow/Domain/Committees/CommitteeMember.cs
+++ b/Modules/Workflow/Workflow/Domain/Committees/CommitteeMember.cs
@@ -88,21 +88,30 @@ public enum CommitteeMemberPosition
 public static class CommitteeMemberPositions
 {
     /// <summary>
-    /// The positions a member may be assigned today.
+    /// The positions a member may be assigned today, in display order.
     /// <see cref="CommitteeMemberPosition.Risk"/>, <see cref="CommitteeMemberPosition.Appraisal"/>,
     /// <see cref="CommitteeMemberPosition.Credit"/> and <see cref="CommitteeMemberPosition.Member"/>
     /// stay on the enum because Position is persisted as the enum NAME — existing committee members,
     /// meeting rosters and historical ApprovalVote.MemberRole rows still hold them and must keep
     /// materializing. They simply may no longer be chosen for a new or edited member.
+    ///
+    /// Declared before <see cref="Selectable"/>: static initializers run in textual order, so the
+    /// set would be built from a null array if this came second.
     /// </summary>
-    public static readonly IReadOnlySet<CommitteeMemberPosition> Selectable =
-        new HashSet<CommitteeMemberPosition>
-        {
-            CommitteeMemberPosition.Chairman,
-            CommitteeMemberPosition.Director,
-            CommitteeMemberPosition.Secretary,
-            CommitteeMemberPosition.UW
-        };
+    private static readonly CommitteeMemberPosition[] SelectableOrder =
+    [
+        CommitteeMemberPosition.Chairman,
+        CommitteeMemberPosition.Director,
+        CommitteeMemberPosition.Secretary,
+        CommitteeMemberPosition.UW
+    ];
+
+    /// <summary>
+    /// <see cref="SelectableOrder"/> as a set, for O(1) membership tests. A HashSet's iteration
+    /// order is not contractually guaranteed, so anything user-facing is built from the array —
+    /// never from this.
+    /// </summary>
+    public static readonly IReadOnlySet<CommitteeMemberPosition> Selectable = SelectableOrder.ToHashSet();
 
     /// <summary>
     /// Whether a member holding this position casts an approval vote once a meeting item is released.
@@ -113,14 +122,14 @@ public static class CommitteeMemberPositions
         position != CommitteeMemberPosition.Secretary;
 
     /// <summary>Comma-separated <see cref="Selectable"/> names, for member validation messages.</summary>
-    public static string SelectableNames => string.Join(", ", Selectable);
+    public static string SelectableNames => string.Join(", ", SelectableOrder);
 
     /// <summary>
     /// Comma-separated positions valid for a RoleRequired condition: selectable AND able to vote.
     /// Narrower than <see cref="SelectableNames"/>, which would advertise the Secretary as allowed
     /// on a call that refuses them.
     /// </summary>
-    public static string RequirableNames => string.Join(", ", Selectable.Where(CanVote));
+    public static string RequirableNames => string.Join(", ", SelectableOrder.Where(CanVote));
 
     /// <summary>
     /// Parses a role string by NAME, without judging whether the position is still assignable.

--- a/Modules/Workflow/Workflow/Meetings/Domain/MeetingRosterEligibility.cs
+++ b/Modules/Workflow/Workflow/Meetings/Domain/MeetingRosterEligibility.cs
@@ -53,19 +53,14 @@ public static class MeetingRosterEligibility
         // never reach it. Counting the same subset the round receives keeps the two in step.
         var voters = roster.Where(m => CommitteeMemberPositions.CanVote(m.Position)).ToList();
 
-        // No voting members. Checked before quorum for the same reason the empty-roster guard is:
-        // ApprovalActivity switches on `overrideMembers.Count > 0`, so an empty voting roster
-        // silently falls back to the committee's own members — the substitution this path prevents.
-        if (voters.Count == 0)
-        {
-            failures.Add("the meeting has no voting members (the secretary does not vote)");
-            return failures;
-        }
-
         // Members who do not resolve to a real user. Checked against the FULL roster: a bad username
         // is worth reporting whether or not that member votes. Voting ones still count toward the
         // round's member total — and therefore raise the majority denominator (MajorityRule
         // evaluates against ALL members, not votes cast) — while never being able to vote.
+        //
+        // Runs BEFORE the no-voters return so both problems surface in one message. An all-secretary
+        // roster that also carries a typo'd username would otherwise report only "no voting members",
+        // and the secretary would discover the bad username on the next attempt instead of this one.
         if (knownUsernames is not null)
         {
             var unresolved = roster
@@ -75,6 +70,16 @@ public static class MeetingRosterEligibility
 
             if (unresolved.Count > 0)
                 failures.Add($"no such user: {string.Join(", ", unresolved)}");
+        }
+
+        // No voting members. Returns early for the same reason the empty-roster guard does:
+        // ApprovalActivity switches on `overrideMembers.Count > 0`, so an empty voting roster
+        // silently falls back to the committee's own members — the substitution this path prevents.
+        // Everything past here divides by the voter count, which would be meaningless at zero.
+        if (voters.Count == 0)
+        {
+            failures.Add("the meeting has no voting members (the secretary does not vote)");
+            return failures;
         }
 
         // Quorum. The same rule the approval round applies, against the same member count it will

--- a/Tests/Unit/Workflow.Tests/Domain/CommitteeAddConditionTests.cs
+++ b/Tests/Unit/Workflow.Tests/Domain/CommitteeAddConditionTests.cs
@@ -48,6 +48,18 @@ public class CommitteeAddConditionTests
     }
 
     [Fact]
+    public void AllowedValueMessages_AreDeterministicAndInDisplayOrder()
+    {
+        // Built from an ordered array, not from the HashSet: a set's iteration order is not
+        // guaranteed, so the text a client sees could otherwise vary between runs.
+        CommitteeMemberPositions.SelectableNames
+            .Should().Be("Chairman, Director, Secretary, UW");
+
+        CommitteeMemberPositions.RequirableNames
+            .Should().Be("Chairman, Director, UW", "the secretary never votes");
+    }
+
+    [Fact]
     public void AddCondition_RoleRequired_InvalidNameMessageOnlyListsRolesItWouldAccept()
     {
         // The message used to advertise the selectable set, which includes the Secretary — so an

--- a/Tests/Unit/Workflow.Tests/Meetings/MeetingRosterEligibilityTests.cs
+++ b/Tests/Unit/Workflow.Tests/Meetings/MeetingRosterEligibilityTests.cs
@@ -329,6 +329,26 @@ public class MeetingRosterEligibilityTests
     }
 
     [Fact]
+    public void Check_RosterOfOnlySecretaries_StillReportsAnUnresolvedUsername()
+    {
+        // Both problems have to surface together. The no-voters check returns early, so if it ran
+        // before the username check the secretary would fix the roster, release again, and only then
+        // be told the username was wrong.
+        var committee = BuildCommittee(QuorumType.Fixed, 1);
+
+        var failures = MeetingRosterEligibility.Check(
+            Roster(("ghost", CommitteeMemberPosition.Secretary)),
+            committee,
+            knownUsernames: Known("alice"));
+
+        failures.Should().BeEquivalentTo(
+        [
+            "no such user: ghost",
+            "the meeting has no voting members (the secretary does not vote)"
+        ]);
+    }
+
+    [Fact]
     public void Check_UnresolvedSecretary_IsStillReported()
     {
         // The username check covers the whole roster, not just voters: a secretary who resolves to


### PR DESCRIPTION
Follow-up to #368, answering both Copilot review comments on it. Each was checked against the merged code rather than taken at face value — **both are real**, neither is severe.

## 1. `Check` hid the "no such user" detail

`MeetingRosterEligibility.Check` ran its guards in the order empty-roster → **no-voters (returns)** → unresolved-username. So a roster of only secretaries that *also* carried a typo'd username reported just `the meeting has no voting members`. The secretary would fix the roster, release again, and only then be told the username was wrong — two round trips for one broken roster. Release always supplies `knownUsernames`, so this was reachable.

The username check now runs first and both failures surface together. The no-voters early return stays where it is: every count past it divides by the voter total, which is meaningless at zero.

## 2. Allowed-values messages were built from a `HashSet`

`SelectableNames` and `RequirableNames` were `string.Join` over `Selectable`, an `IReadOnlySet`. `HashSet` iteration order is not contractually guaranteed, so the `Allowed values: …` text in a 400 could in principle vary between runs or framework versions.

Both now build from an ordered array, which also pins the intended display order (`Chairman, Director, Secretary, UW`). The set stays for O(1) membership tests, so **no call site changed** — every use of `Selectable` is `.Contains(...)` or `.Where(...)`.

One trap worth flagging for reviewers: the array must be declared **before** the set. Static field initializers run in textual order, so the reverse order would build the set from a null array and throw at type init. There is a comment on it.

## Verification

- `dotnet build collateral-appraisal-system-api.sln --configuration Release` → **0 errors**.
- `dotnet test Tests/Unit/Workflow.Tests` → **985 passed, 10 failed** — the same 10 pre-existing failures as `main`. 996 total, +2 from this PR.
- Both new tests pass across repeated runs. `ExpressionEvaluatorTests.EvaluateExpression_CachingPerformance` is a timing flake that appeared in one of two runs and not the other; it is unrelated and pre-existing.

New coverage:
- an all-secretary roster with an unknown username reports **both** failures;
- `SelectableNames` / `RequirableNames` are asserted as exact strings, so the ordering guarantee is pinned rather than incidental.

## Note for reviewers

The two remaining Copilot comments from the original pair were on the frontend and are fixed separately in immortalgky/collateral-appraisal-system-app#308. Nothing here is cross-repo coupled — the two can merge and deploy in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnGqs6hMcgZCc6LvGeFBr9
