### PR TITLE
fix(reporting): drop empty วาระ, keep the signature roster intact, order sign-off by committee rank

### DIFF
--- a/Modules/Reporting/Reporting/Application/Models/MeetingInvitationModel.cs
+++ b/Modules/Reporting/Reporting/Application/Models/MeetingInvitationModel.cs
@@ -32,12 +32,22 @@ public sealed class MeetingInvitationModel
 
 /// <summary>
 /// One วาระ (agenda item group) in the meeting invitation.
-/// Only agendas with at least one item are included.
+/// วาระ 1 and 2 are always present; the rest appear only when they carry items or body text.
 /// </summary>
 public sealed class MeetingAgendaGroup
 {
-    /// <summary>Agenda number (1–9).</summary>
+    /// <summary>
+    /// Printed sequence number, 1..N over the วาระ that survived the empty-วาระ filter — so the
+    /// document never shows a gap. Use <see cref="Wara"/>, not this, to identify a วาระ.
+    /// </summary>
     public int Number { get; init; }
+
+    /// <summary>
+    /// Fixed FSD identity of this วาระ (1–9), stable regardless of renumbering. Templates branch
+    /// on this (e.g. วาระ 5/6 carry no ราคาประเมิน column) because <see cref="Number"/> shifts
+    /// whenever an earlier วาระ is dropped.
+    /// </summary>
+    public int Wara { get; init; }
 
     /// <summary>Thai title for this agenda วาระ.</summary>
     public string Title { get; init; } = string.Empty;

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryCommonLoader.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryCommonLoader.cs
@@ -399,6 +399,7 @@ internal static class AppraisalSummaryCommonLoader
             SELECT
                 COALESCE(NULLIF(LTRIM(RTRIM(u.FirstName + ' ' + u.LastName)), ''), av.Member) AS MemberName,
                 COALESCE(NULLIF(u.Position, ''), av.MemberRole) AS Position,
+                av.MemberRole AS MemberRole,
                 av.Vote,
                 av.Comments   AS Comment,
                 av.Member     AS Member,
@@ -411,10 +412,15 @@ internal static class AppraisalSummaryCommonLoader
         var voteParams = new DynamicParameters();
         voteParams.Add("AppraisalId", appraisalId);
 
-        // One row per member (latest vote), in case of re-approval rounds.
+        // One row per member (latest vote), in case of re-approval rounds, then ordered by committee
+        // rank. The sort has to sit AFTER the GroupBy — GroupBy re-imposes first-appearance order,
+        // so an ORDER BY in the SQL would be silently discarded here.
         var votes = (await connection.QueryAsync<VoteRow>(votesSql, voteParams))
             .GroupBy(v => v.Member, StringComparer.OrdinalIgnoreCase)
             .Select(g => g.OrderByDescending(v => v.VotedAt).First())
+            .OrderBy(v => CommitteeRoleRank(v.MemberRole))
+            .ThenBy(v => v.VotedAt)
+            .ThenBy(v => v.MemberName, StringComparer.Ordinal)
             .ToList();
 
         List<ApproverRow> approvers = votes.Select(v => new ApproverRow
@@ -618,6 +624,20 @@ internal static class AppraisalSummaryCommonLoader
     internal static string? NormalizePosition(string? position) =>
         string.IsNullOrWhiteSpace(position) || position.Trim() == "-" ? null : position.Trim();
 
+    /// <summary>
+    /// Display rank for the committee sign-off block, matching the meeting reports:
+    /// Chairman → Director → everyone else → Secretary. Sorts on ApprovalVotes.MemberRole, which is
+    /// null on legacy-imported votes, and a Secretary normally cannot vote
+    /// (CommitteeMemberPositions.CanVote), so rank 9 is usually an empty slot.
+    /// </summary>
+    internal static int CommitteeRoleRank(string? role) => role?.Trim().ToLowerInvariant() switch
+    {
+        "chairman" => 1,
+        "director" => 2,
+        "secretary" => 9,
+        _ => 5
+    };
+
     // ── Private flat DTOs for Dapper mapping ─────────────────────────────────────
 
     internal sealed class HeaderRow
@@ -700,6 +720,12 @@ internal static class AppraisalSummaryCommonLoader
         public string? Comment { get; init; }
         public string? Member { get; init; }
         public DateTime VotedAt { get; init; }
+
+        /// <summary>
+        /// Committee role (CommitteeMemberPosition name) copied onto the vote from the meeting
+        /// roster. Drives display order only — <see cref="Position"/> is what actually prints.
+        /// </summary>
+        public string? MemberRole { get; init; }
     }
 
     internal sealed class RequestorRow

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryLandBuildingDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryLandBuildingDataProvider.cs
@@ -705,6 +705,7 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
             SELECT
                 COALESCE(NULLIF(LTRIM(RTRIM(u.FirstName + ' ' + u.LastName)), ''), av.Member) AS MemberName,
                 COALESCE(NULLIF(u.Position, ''), av.MemberRole) AS Position,
+                av.MemberRole AS MemberRole,
                 av.Vote,
                 av.Comments   AS Comment,
                 av.Member     AS Member,
@@ -717,10 +718,15 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
         var voteParams = new DynamicParameters();
         voteParams.Add("AppraisalId", appraisalId);
 
-        // One row per member (latest vote), in case of re-approval rounds.
+        // One row per member (latest vote), in case of re-approval rounds, then ordered by committee
+        // rank. The sort has to sit AFTER the GroupBy — GroupBy re-imposes first-appearance order,
+        // so an ORDER BY in the SQL would be silently discarded here.
         var votes = (await connection.QueryAsync<VoteRow>(votesSql, voteParams))
             .GroupBy(v => v.Member, StringComparer.OrdinalIgnoreCase)
             .Select(g => g.OrderByDescending(v => v.VotedAt).First())
+            .OrderBy(v => AppraisalSummaryCommonLoader.CommitteeRoleRank(v.MemberRole))
+            .ThenBy(v => v.VotedAt)
+            .ThenBy(v => v.MemberName, StringComparer.Ordinal)
             .ToList();
 
         List<ApproverRow> approvers = votes.Select(v => new ApproverRow
@@ -1749,6 +1755,12 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
         public string? Comment { get; init; }
         public string? Member { get; init; }
         public DateTime VotedAt { get; init; }
+
+        /// <summary>
+        /// Committee role (CommitteeMemberPosition name) copied onto the vote from the meeting
+        /// roster. Drives display order only — <see cref="Position"/> is what actually prints.
+        /// </summary>
+        public string? MemberRole { get; init; }
     }
 
     private sealed class RequestorRow

--- a/Modules/Reporting/Reporting/Application/Providers/MeetingAgendaBuilder.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/MeetingAgendaBuilder.cs
@@ -21,7 +21,10 @@ namespace Reporting.Application.Providers;
 ///   วาระ 2 = AgendaChairmanInformed
 ///   วาระ 9 = AgendaOthers
 ///
-/// All 9 วาระ are always emitted (fixed form), even when a วาระ carries no items/data.
+/// วาระ 1 and 2 are always emitted. Every other วาระ is dropped when it carries nothing — 3–8 with
+/// no items, 9 with a blank body — and the survivors are renumbered 1..N so the printed sequence
+/// has no gaps. The fixed 1–9 identity above survives renumbering on <c>MeetingAgendaGroup.Wara</c>,
+/// which is what the templates branch on; <c>Number</c> is the printed position only.
 /// </summary>
 internal static class MeetingAgendaBuilder
 {
@@ -44,9 +47,7 @@ internal static class MeetingAgendaBuilder
         List<MeetingAgendaItemRow> Rows(int wara) =>
             byWara.TryGetValue(wara, out var rows) ? rows : new List<MeetingAgendaItemRow>();
 
-        // FSD §2.1.8 — all 9 วาระ are a fixed form and always rendered, even when a วาระ carries
-        // no items/data. Decision วาระ (3–8) always show their "จำนวน N ราย" count (N may be 0).
-        return new List<MeetingAgendaGroup>
+        var all = new List<MeetingAgendaGroup>
         {
             TextGroup(1, BuildCertifyTitle(previousMeetingNo), agendaCertifyMinutes),
             TextGroup(2, "ประธานแจ้งเพื่อทราบ", agendaChairmanInformed),
@@ -57,16 +58,53 @@ internal static class MeetingAgendaBuilder
             DecisionGroup(7, "อนุมัติเร่งด่วน", Rows(7)),
             DecisionGroup(8, "แจ้งเพื่อทราบ", Rows(8)),
             TextGroup(9, "อื่นๆ", agendaOthers),
-        }.AsReadOnly();
+        };
+
+        return Renumber(all.Where(Keep).ToList());
     }
+
+    /// <summary>
+    /// วาระ 1 and 2 are mandatory headings and print even when their text box is blank. Every other
+    /// วาระ is dropped when it carries nothing: decision วาระ 3–8 with no items (the old
+    /// "จำนวน 0 ราย" heading and its empty table), and วาระ 9 (อื่นๆ) with no body text.
+    /// </summary>
+    private static bool Keep(MeetingAgendaGroup g) =>
+        g.Wara is 1 or 2
+        || g.Items.Count > 0
+        || !string.IsNullOrWhiteSpace(g.BodyText);
+
+    /// <summary>
+    /// Assigns the printed 1..N sequence to the surviving วาระ, preserving each one's fixed
+    /// <see cref="MeetingAgendaGroup.Wara"/> identity so the templates' วาระ 5/6 special-casing
+    /// keeps pointing at the right topic.
+    /// </summary>
+    private static IReadOnlyList<MeetingAgendaGroup> Renumber(List<MeetingAgendaGroup> groups) =>
+        groups
+            .Select((g, idx) => new MeetingAgendaGroup
+            {
+                Number = idx + 1,
+                Wara = g.Wara,
+                Title = g.Title,
+                CountText = g.CountText,
+                BodyText = g.BodyText,
+                Items = g.Items
+            })
+            .ToList()
+            .AsReadOnly();
 
     /// <summary>
     /// FSD §2.1.9 fields 4.1–4.3: distinct appraisal staff (presenters) across all decision/ack
     /// agenda items, each with their position and the "{วาระ}.{seq}" references of the items they
-    /// presented (e.g. a staff on วาระ 8 item 1 → "8.1"; multiple → "8.1, 8.2"). Minute only.
+    /// presented (e.g. a staff on the วาระ printed as 8, item 1 → "8.1"; multiple → "8.1, 8.2").
+    /// Minute only. Takes the built <paramref name="agendas"/> so the references use the PRINTED
+    /// วาระ numbers — after empty วาระ are dropped these no longer match the fixed 1–9 identities.
     /// </summary>
-    public static IReadOnlyList<MeetingPresenterRow> BuildPresenters(IReadOnlyList<MeetingItemFlat> items)
+    public static IReadOnlyList<MeetingPresenterRow> BuildPresenters(
+        IReadOnlyList<MeetingItemFlat> items,
+        IReadOnlyList<MeetingAgendaGroup> agendas)
     {
+        var printedNumberByWara = agendas.ToDictionary(g => g.Wara, g => g.Number);
+
         var byStaff = new Dictionary<string, (string Position, List<string> Refs)>();
         var order = new List<string>();
 
@@ -76,13 +114,18 @@ internal static class MeetingAgendaBuilder
             if (string.IsNullOrWhiteSpace(name))
                 continue;
 
+            // A วาระ that produced this item necessarily has items, so it was never dropped and the
+            // lookup always hits. Skip rather than mis-reference if that ever stops holding.
+            if (!printedNumberByWara.TryGetValue(wara, out var printedNumber))
+                continue;
+
             if (!byStaff.TryGetValue(name, out var entry))
             {
                 entry = (item.StaffPosition?.Trim() ?? string.Empty, new List<string>());
                 byStaff[name] = entry;
                 order.Add(name);
             }
-            entry.Refs.Add($"{wara}.{seq}");
+            entry.Refs.Add($"{printedNumber}.{seq}");
         }
 
         return order
@@ -196,21 +239,27 @@ internal static class MeetingAgendaBuilder
         };
     }
 
-    /// <summary>A decision วาระ (3–8): always carries a "จำนวน N ราย" count, items may be empty.</summary>
-    private static MeetingAgendaGroup DecisionGroup(int number, string title, List<MeetingAgendaItemRow> rows) =>
+    /// <summary>
+    /// A decision วาระ (3–8), carrying its "จำนวน N ราย" count. An empty one is dropped by
+    /// <see cref="Keep"/> before it reaches a template. <c>Number</c> is provisional — Renumber
+    /// overwrites it with the printed position.
+    /// </summary>
+    private static MeetingAgendaGroup DecisionGroup(int wara, string title, List<MeetingAgendaItemRow> rows) =>
         new()
         {
-            Number = number,
+            Number = wara,
+            Wara = wara,
             Title = title,
             CountText = $"จำนวน {rows.Count} ราย",
             Items = rows.AsReadOnly()
         };
 
-    /// <summary>A text วาระ (1/2/9): heading always shown; body text optional.</summary>
-    private static MeetingAgendaGroup TextGroup(int number, string title, string? bodyText) =>
+    /// <summary>A text วาระ (1/2/9): body text optional. See DecisionGroup on <c>Number</c>.</summary>
+    private static MeetingAgendaGroup TextGroup(int wara, string title, string? bodyText) =>
         new()
         {
-            Number = number,
+            Number = wara,
+            Wara = wara,
             Title = title,
             BodyText = string.IsNullOrWhiteSpace(bodyText) ? null : bodyText.Trim()
         };

--- a/Modules/Reporting/Reporting/Application/Providers/MeetingInvitationDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/MeetingInvitationDataProvider.cs
@@ -98,14 +98,15 @@ public sealed class MeetingInvitationDataProvider(
             PreviousMeetingNoQuery.Sql("MeetingId"), p);
 
         // ── Build model ───────────────────────────────────────────────────────
+        // The roster lists every member including the Secretary, who membersSql ranks last. They
+        // also get their own signature block above it, so their name appears twice by design.
         var members = memberRows.Select(m => new MeetingMemberRow
         {
             MemberName = m.MemberName,
             PositionThai = MapPositionThai(m.Position)
         }).ToList();
 
-        var secretary = memberRows.FirstOrDefault(m =>
-            string.Equals(m.Position, "Secretary", StringComparison.OrdinalIgnoreCase));
+        var secretary = memberRows.FirstOrDefault(m => IsSecretary(m.Position));
 
         var agendas = MeetingAgendaBuilder.Build(
             items,
@@ -143,6 +144,14 @@ public sealed class MeetingInvitationDataProvider(
         "Secretary" => "เลขานุการฯ",
         _           => "กรรมการ"
     };
+
+    /// <summary>
+    /// Identifies the member whose name fills the เลขานุการคณะกรรมการ ฯ signature block. The
+    /// Secretary is NOT filtered out of any roster — every committee list includes them, ranked
+    /// last by the ORDER BY in membersSql.
+    /// </summary>
+    internal static bool IsSecretary(string? position) =>
+        string.Equals(position, "Secretary", StringComparison.OrdinalIgnoreCase);
 
     // ── Private Dapper flat DTOs ──────────────────────────────────────────────
 

--- a/Modules/Reporting/Reporting/Application/Providers/MeetingMinuteDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/MeetingMinuteDataProvider.cs
@@ -157,7 +157,7 @@ public sealed class MeetingMinuteDataProvider(
             header.AgendaChairmanInformed,
             header.AgendaOthers);
 
-        var presenters = MeetingAgendaBuilder.BuildPresenters(items);
+        var presenters = MeetingAgendaBuilder.BuildPresenters(items, agendas);
 
         var committeeOpinions = voteRows.Select(v => new CommitteeOpinionRow
         {

--- a/Modules/Reporting/Reporting/Templates/meeting-invitation.html
+++ b/Modules/Reporting/Reporting/Templates/meeting-invitation.html
@@ -60,7 +60,10 @@
     .agenda-items .item-value-unit { width:34px; text-align:left; padding-left:6px; }
 
     /* ── Closing + secretary block (centered, FSD img39) ─────────── */
-    .closing { text-align:center; margin:20px 0 24px; }
+    /* Wide top margin separates the closing sentence — and the whole signature half of the
+       page below it — from the agenda list. It collapses with the last .agenda-group's 10px
+       bottom margin (the larger wins), so the gap is 64px, not 74px. */
+    .closing { text-align:center; margin:64px 0 24px; }
     .secretary-block { text-align:center; margin-bottom:28px; }
     /* Top margin reserves a wet-signature area above the dotted line (~16mm). */
     .secretary-block .sig-line {
@@ -71,12 +74,12 @@
     /* ── Signature roster (FSD รายนาม / ลายเซ็น) ─────────────────── */
     .roster-header { text-align:center; margin-bottom:16px; }
     .roster-header div { line-height:1.6; }
-    /* Keep the whole signature table on one page: if it does not fit in the remaining
-       space it moves to the next page intact, instead of splitting and repeating the
-       รายนาม/ลายเซ็น header over a stray row or two. The 3-line roster heading above is
-       deliberately NOT included — it may stay behind on the previous page. */
-    table.roster-table { width:100%; border-collapse:collapse;
-      break-inside:avoid; page-break-inside:avoid; }
+    /* The 3-line heading and the signature table are one unit: if the pair does not fit in
+       the remaining space the whole block moves to the next page, instead of stranding the
+       heading alone at the bottom of a page with the table overleaf. A roster taller than a
+       full page still splits — Chromium drops the constraint rather than lose content. */
+    .roster-block { break-inside:avoid; page-break-inside:avoid; }
+    table.roster-table { width:100%; border-collapse:collapse; }
     table.roster-table th {
       text-decoration:underline; font-weight:400; padding:4px 8px; text-align:center;
     }
@@ -142,8 +145,10 @@
       <div class="item-row">
         <span class="item-seq">{{ for.index + 1 }}.</span>
         <span class="item-customer">{{ item.customer_name }}</span>
-        <!-- FSD: การตรวจงวดงานก่อสร้าง (วาระ 5) and MF/block (วาระ 6) carry no appraisal value -->
-        {{- if item.value_text && ag.number != 5 && ag.number != 6 }}
+        <!-- FSD: การตรวจงวดงานก่อสร้าง (วาระ 5) and MF/block (วาระ 6) carry no appraisal value.
+             Tested on ag.wara, the fixed identity — ag.number is the printed position and shifts
+             whenever an earlier วาระ is dropped as empty. -->
+        {{- if item.value_text && ag.wara != 5 && ag.wara != 6 }}
         <span class="item-value"><span class="item-value-label">ราคาประเมิน</span><span
           class="item-value-amount">{{ item.value_text }}</span><span
           class="item-value-unit">{{ if item.value_text != "ไม่รับรองราคา" }}บาท{{ end }}</span></span>
@@ -166,6 +171,7 @@
   </div>
 
   <!-- ── Signature roster (รายนาม / ลายเซ็น) ───────────────────── -->
+  <div class="roster-block">
   <div class="roster-header">
     <div>คณะกรรมการกำหนดราคาประเมินหลักประกันและทรัพย์สิน</div>
     <div>การประชุมคณะกรรมการกำหนดราคาประเมินหลักประกัน และทรัพย์สิน ครั้งที่ {{ model.meeting_no }}</div>
@@ -184,6 +190,7 @@
       {{ end }}
     </tbody>
   </table>
+  </div><!-- .roster-block -->
 
 </div>
 </body>

--- a/Modules/Reporting/Reporting/Templates/meeting-minute.html
+++ b/Modules/Reporting/Reporting/Templates/meeting-minute.html
@@ -124,8 +124,10 @@
 
   <!-- ── Agenda groups ─────────────────────────────────────────── -->
   {{ for ag in model.agendas }}
-    {{ if ag.number >= 3 && ag.number <= 8 }}
-    <!-- Decision agenda → bordered table (always shown, even with no items) -->
+    <!-- Branch on ag.wara, the fixed 1–9 identity: ag.number is the printed position and shifts
+         whenever an earlier วาระ is dropped as empty. -->
+    {{ if ag.wara >= 3 && ag.wara <= 8 }}
+    <!-- Decision agenda → bordered table (empty ones never reach here — see MeetingAgendaBuilder) -->
     <div class="agenda-block">
       <div class="wara-title">
         วาระที่ {{ ag.number }} {{ ag.title }}
@@ -135,7 +137,7 @@
         <thead>
           <tr>
             <th>รายการ</th>
-            <th>{{ if ag.number == 6 }}อนุมัติ/ไม่อนุมัติ{{ else }}อนุมัติราคาประเมิน (ตามเอกสารแนบ){{ end }}</th>
+            <th>{{ if ag.wara == 6 }}อนุมัติ/ไม่อนุมัติ{{ else }}อนุมัติราคาประเมิน (ตามเอกสารแนบ){{ end }}</th>
           </tr>
         </thead>
         <tbody>
@@ -143,16 +145,13 @@
           <tr>
             <td class="col-item">{{ for.index + 1 }}. {{ item.customer_name }}</td>
             <td class="col-value">
-              {{- if ag.number == 6 -}}
+              {{- if ag.wara == 6 -}}
               <div class="val-cell"><span>ราคาประเมิน</span><span>รายละเอียดดูตาม สรุปราคา</span></div>
               {{- else if item.value_text -}}
               <div class="val-cell"><span>ราคาประเมิน</span><span>{{ item.value_text }}{{ if item.value_text != "ไม่รับรองราคา" }} บาท{{ end }}</span></div>
               {{- end -}}
             </td>
           </tr>
-          {{ end }}
-          {{ if ag.items.size == 0 }}
-          <tr><td class="col-item">&nbsp;</td><td class="col-value">&nbsp;</td></tr>
           {{ end }}
         </tbody>
       </table>


### PR DESCRIPTION
## What

Three fixes to the committee meeting reports (`meeting-invitation`, `meeting-minute`) and the appraisal summary's committee sign-off block.

### 1. The signature roster heading was orphaning

`break-inside:avoid` sat on `table.roster-table` only, and a comment explicitly excluded the 3-line heading above it ("it may stay behind on the previous page"). Result: the heading printed at the bottom of one page with the รายนาม/ลายเซ็น table overleaf, leaving a large blank gap. Both are now wrapped in a single `.roster-block`.

`.closing` also gets a wider top margin (20px → 64px) so the agenda list is visually separated from the signature half of the page.

### 2. Empty วาระ are dropped and the sequence renumbered

`MeetingAgendaBuilder` emitted all 9 วาระ as a fixed form — decision วาระ printing "จำนวน 0 ราย" and, in the minutes, an empty bordered table. Now วาระ 1 and 2 always print; the rest are dropped when they carry nothing (3–8 with no items, 9 with a blank body), and the survivors are renumbered 1..N so there are no gaps.

**The subtle part:** วาระ numbers were load-bearing. The invitation suppresses the ราคาประเมิน column for วาระ 5/6, the minutes switch between bordered table and plain text on `3 <= n <= 8` and special-case 6, and presenter references read `"วาระที่ 8.1"`. Renumbering naively would have moved all of that onto the wrong topic.

So `MeetingAgendaGroup` now carries two numbers:
- `Wara` — the fixed FSD identity 1–9, stable across renumbering. **This is what templates branch on.**
- `Number` — the printed position only.

`BuildPresenters` takes the built agenda list so its `{วาระ}.{seq}` references use the printed numbers.

### 3. Sign-off block ordered by committee rank

The appraisal summary's มติคณะกรรมการ table ordered by `ORDER BY av.VotedAt` — whoever clicked approve first was listed first, so the Chairman landed anywhere. It now follows the same Chairman → Director → other → Secretary rank as the meeting reports, using `workflow.ApprovalVotes.MemberRole`, which was already on that table (no new joins).

The sort **must** sit after the `.GroupBy` that picks each member's latest vote — `GroupBy` re-imposes first-appearance order, so a SQL-side `ORDER BY` would be silently discarded. Applied to both copies of that duplicated query (`AppraisalSummaryCommonLoader` and `AppraisalSummaryLandBuildingDataProvider`); leaving one behind would have made land/building summaries disagree with every other type.

The printed position text is deliberately unchanged — still the HR job title from `auth.AspNetUsers.Position`, not the Thai committee role.

## Verification

Rendered meetings 50/2569, 53/2569, 54/2569 and 55/2569 through the real PDF pipeline on a spare port:

- Renumbering is gapless: 55/2569 → วาระ 1, 2 only; 54/2569 → orig 6 printed as 3; 53/2569 → orig 5 as 3 and orig 9 as 4; 50/2569 → orig 7, 8 as 3, 4.
- **Discriminating check:** 54/2569's orig-วาระ-6 renders at printed number 3 and still gets the `อนุมัติ/ไม่อนุมัติ` header and `รายละเอียดดูตาม สรุปราคา` cell; both it and 53/2569's orig-วาระ-5 still suppress the ราคาประเมิน column. Had the templates kept branching on `ag.number`, printed-3 would have failed every one of those.
- Presenter refs on 50/2569 read `3.1, 4.4` / `4.1, 4.2` / `4.3` — renumbered, not `7.x` / `8.x`.
- Sign-off order changed from vote-time to rank, with each row's checkbox and comment staying attached to its member (checked against an appraisal with a distinctive per-member comment).
- At a content length that pushes the roster to a page boundary, heading and table stay together.

**Not covered:** only the land/building summary type was re-rendered, so the `AppraisalSummaryCommonLoader` copy of the votes query (condo / block / machine / construction) was exercised only indirectly.

No DB migration, no seed script, no frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNaiZ8DFaanZ6zb6HF7rDJ