### PR TITLE
fix(reporting): drop the Secretary from the meeting invitation's signature roster

### DIFF
--- a/Modules/Reporting/Reporting/Application/Providers/MeetingInvitationDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/MeetingInvitationDataProvider.cs
@@ -98,13 +98,16 @@ public sealed class MeetingInvitationDataProvider(
             PreviousMeetingNoQuery.Sql("MeetingId"), p);
 
         // ── Build model ───────────────────────────────────────────────────────
-        // The roster lists every member including the Secretary, who membersSql ranks last. They
-        // also get their own signature block above it, so their name appears twice by design.
-        var members = memberRows.Select(m => new MeetingMemberRow
-        {
-            MemberName = m.MemberName,
-            PositionThai = MapPositionThai(m.Position)
-        }).ToList();
+        // The Secretary signs their own เลขานุการคณะกรรมการ ฯ block above the roster, so listing them
+        // again here would print the same name twice. Filtered in the projection rather than in
+        // membersSql — the SecretaryName lookup below still needs their row.
+        var members = memberRows
+            .Where(m => !IsSecretary(m.Position))
+            .Select(m => new MeetingMemberRow
+            {
+                MemberName = m.MemberName,
+                PositionThai = MapPositionThai(m.Position)
+            }).ToList();
 
         var secretary = memberRows.FirstOrDefault(m => IsSecretary(m.Position));
 
@@ -146,9 +149,11 @@ public sealed class MeetingInvitationDataProvider(
     };
 
     /// <summary>
-    /// Identifies the member whose name fills the เลขานุการคณะกรรมการ ฯ signature block. The
-    /// Secretary is NOT filtered out of any roster — every committee list includes them, ranked
-    /// last by the ORDER BY in membersSql.
+    /// Serves two purposes on the invitation: it picks the member whose name fills the
+    /// เลขานุการคณะกรรมการ ฯ signature block, and it keeps that same member out of the
+    /// รายนาม/ลายเซ็น roster below it, which would otherwise print the name a second time.
+    /// The minute's รายชื่อคณะกรรมการ and ลงนาม lists are unaffected — both still include the
+    /// Secretary, ranked last by the ORDER BY in their own queries.
     /// </summary>
     internal static bool IsSecretary(string? position) =>
         string.Equals(position, "Secretary", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
## What

End user reported that the meeting invitation prints the Secretary's name **twice**: once in their own `( ชื่อ ) / เลขานุการคณะกรรมการ ฯ` signature block, and again as an ordinary row in the รายนาม/ลายเซ็น table directly below it. This removes the duplicate row.

Follow-up to #370.

## Scope

| List | Secretary |
|---|---|
| Invitation รายนาม/ลายเซ็น table | **removed** ← this change |
| Invitation เลขานุการคณะกรรมการ ฯ signature block | kept |
| Minute รายชื่อคณะกรรมการ attendance list | kept |
| Minute ลงนาม / รายชื่อคณะกรรมการ / ความเห็นเพิ่มเติม table | kept |

## Implementation note

The filter goes on the `Members` projection, **not** on `membersSql`. That query also feeds the `secretary` lookup that fills `SecretaryName` — filtering in SQL would blank the very signature block this change exists to preserve.

No ordering change was needed: `membersSql`'s `WHEN 'Secretary' THEN 9` stays and simply has nothing left to rank on the invitation. `MeetingMinuteDataProvider` is untouched.

No model change, no template change, no migration, no seed script, no frontend change.

## Verification

Rendered meeting 55/2569 (its roster has a Secretary, Mongkol Nakornprasit) on a spare port:

1. Invitation รายนาม/ลายเซ็น table → **5** names, Secretary gone.
2. Invitation still prints `( Mongkol Nakornprasit )` above `เลขานุการคณะกรรมการ ฯ` — the regression the projection-level filter avoids.
3. Minute รายชื่อคณะกรรมการ → unchanged, 6 entries with `Mongkol Nakornprasit / เลขานุการฯ` last.
4. Minute ลงนาม sign-off table → unchanged, 6 rows with the Secretary last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Svrb5ZmHdep1rMfa7o2DHN