### PR TITLE
fix(reporting): print เงื่อนไข in red on every appraisal summary report

### DIFF
--- a/Modules/Reporting/Reporting/Templates/appraisal-summary-condo.html
+++ b/Modules/Reporting/Reporting/Templates/appraisal-summary-condo.html
@@ -60,7 +60,7 @@
       {{ if model.groups.size == 0 }}
       <tr><td colspan="5" style="height:34px;">&nbsp;</td></tr>
       {{ end }}
-      {{ if model.condition }}<tr><td><strong>เงื่อนไข</strong></td><td colspan="4" class="brk">{{ model.condition }}</td></tr>{{ end }}
+      {{ if model.condition }}<tr class="cond"><td><strong>เงื่อนไข</strong></td><td colspan="4" class="brk">{{ model.condition }}</td></tr>{{ end }}
       {{ if model.remark }}<tr><td><strong>หมายเหตุ</strong></td><td colspan="4" class="brk">{{ model.remark }}</td></tr>{{ end }}
     </tbody>
   </table>

--- a/Modules/Reporting/Reporting/Templates/appraisal-summary-machine.html
+++ b/Modules/Reporting/Reporting/Templates/appraisal-summary-machine.html
@@ -59,7 +59,7 @@
         <td colspan="3"><strong>รวมมูลค่าเครื่องจักร</strong></td>
         <td class="num"><strong>{{ if model.total_appraisal_value; model.total_appraisal_value | math.format "N2"; end }}</strong></td>
       </tr>
-      {{ if model.condition }}<tr><td><strong>เงื่อนไข</strong></td><td colspan="4" class="brk">{{ model.condition }}</td></tr>{{ end }}
+      {{ if model.condition }}<tr class="cond"><td><strong>เงื่อนไข</strong></td><td colspan="4" class="brk">{{ model.condition }}</td></tr>{{ end }}
       {{ if model.remark }}<tr><td><strong>หมายเหตุ</strong></td><td colspan="4" class="brk">{{ model.remark }}</td></tr>{{ end }}
     </tbody>
   </table>

--- a/Modules/Reporting/Reporting/Templates/partials/summary-block-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-block-body.html
@@ -67,7 +67,11 @@
       <tr><td class="k">สาธารณูปโภค</td><td class="v">{{ model.utilities }}</td></tr>
       <tr><td class="k">สิ่งอำนวยความสะดวก</td><td class="v">{{ model.facilities }}</td></tr>
       <tr><td class="k">ราคาประเมิน</td><td class="v">{{ model.appraisal_value_wording }}</td></tr>
-      <tr><td class="k">เงื่อนไข</td><td class="v brk">{{ model.condition }}</td></tr>
+      <!-- .cond is gated: this table renders every row unconditionally to keep the form's fixed
+           shape, so an absent condition still emits the row and falls through to the "-" from
+           td.v:empty::before. An ungated class would print that dash — and the label — in red on
+           every block report with no condition, reading as a defect rather than a highlight. -->
+      <tr{{ if model.condition }} class="cond"{{ end }}><td class="k">เงื่อนไข</td><td class="v brk">{{ model.condition }}</td></tr>
       <tr><td class="k">หมายเหตุ</td><td class="v brk">{{ model.remark }}</td></tr>
       <tr class="last"><td class="k">ค่าพิกัด</td><td class="v">{{ model.gps }}</td></tr>
       <tr class="methods-row">

--- a/Modules/Reporting/Reporting/Templates/partials/summary-standard-body.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-standard-body.html
@@ -134,7 +134,7 @@
       {{ if model.groups.size == 0 }}
       <tr><td colspan="{{ if uc }}6{{ else }}5{{ end }}" style="height:34px;">&nbsp;</td></tr>
       {{ end }}
-      {{ if model.condition }}<tr><td><strong>เงื่อนไข</strong></td><td colspan="{{ if uc }}5{{ else }}4{{ end }}" class="brk">{{ model.condition }}</td></tr>{{ end }}
+      {{ if model.condition }}<tr class="cond"><td><strong>เงื่อนไข</strong></td><td colspan="{{ if uc }}5{{ else }}4{{ end }}" class="brk">{{ model.condition }}</td></tr>{{ end }}
       {{ if model.remark }}<tr><td><strong>หมายเหตุ</strong></td><td colspan="{{ if uc }}5{{ else }}4{{ end }}" class="brk">{{ model.remark }}</td></tr>{{ end }}
     </tbody>
   </table>

--- a/Modules/Reporting/Reporting/Templates/partials/summary-styles.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-styles.html
@@ -223,10 +223,16 @@ table.grid.comparison th:first-child, table.grid.comparison td:first-child { wid
    to the next line whole, and Thai still breaks on ICU word boundaries. */
 .brk { white-space:pre-line; overflow-wrap:anywhere; }
 /* Business rule: a report carrying a เงื่อนไข prints it in red, so a condition attached to the
-   appraisal cannot be missed when scanning the document. Set on the row so the label and the
-   appraiser's text both turn red; the selector names td directly because body sets color:#000
-   and inheritance alone would not reach a cell. เงื่อนไข only — the หมายเหตุ row that sits
-   directly beneath it in every one of these tables deliberately stays black. */
+   appraisal cannot be missed when scanning the document. The class goes on the row so the label
+   and the appraiser's text both turn red.
+
+   `tr.cond` alone would suffice today — color inherits, and nothing sets a color on these cells.
+   Naming td is deliberate insurance: an inherited value loses to ANY direct rule on the cell, so
+   a future `table.grid td { color: … }` would silently undo this, whereas this rule matches such
+   a selector's specificity and wins on source order (it is declared after table.grid's).
+
+   เงื่อนไข only — the หมายเหตุ row that sits directly beneath it in every one of these tables
+   deliberately stays black, per the requirement. */
 tr.cond td { color:#C00000; }
 /* Sections wrapped in .landscape-page start on a new A4 landscape page. */
 @page landscape { size: A4 landscape; margin: 10mm; }

--- a/Modules/Reporting/Reporting/Templates/partials/summary-styles.html
+++ b/Modules/Reporting/Reporting/Templates/partials/summary-styles.html
@@ -222,6 +222,12 @@ table.grid.comparison th:first-child, table.grid.comparison td:first-child { wid
    than the page. It never pre-empts a real break opportunity: a word that fits still moves
    to the next line whole, and Thai still breaks on ICU word boundaries. */
 .brk { white-space:pre-line; overflow-wrap:anywhere; }
+/* Business rule: a report carrying a เงื่อนไข prints it in red, so a condition attached to the
+   appraisal cannot be missed when scanning the document. Set on the row so the label and the
+   appraiser's text both turn red; the selector names td directly because body sets color:#000
+   and inheritance alone would not reach a cell. เงื่อนไข only — the หมายเหตุ row that sits
+   directly beneath it in every one of these tables deliberately stays black. */
+tr.cond td { color:#C00000; }
 /* Sections wrapped in .landscape-page start on a new A4 landscape page. */
 @page landscape { size: A4 landscape; margin: 10mm; }
 .landscape-page { page: landscape; break-before: page; }


### PR DESCRIPTION
## What

Business rule: *ทุก Report ที่มีเงื่อนไข ต้องขึ้นตัวหนังสือเป็นสีแดง* — a condition attached to an appraisal must stand out so it cannot be missed when scanning the document. It previously rendered in the same black as every other row.

## Where เงื่อนไข actually appears

The reported screenshot was the land-building summary, but the field is emitted from **four** places reaching **five** reports:

| Site | Reports |
|---|---|
| `partials/summary-standard-body.html:137` | land-building summary, `appraisal-book` (standard body) |
| `partials/summary-block-body.html:70` | block summary, `appraisal-book` (block body) |
| `appraisal-summary-condo.html:63` | condo summary |
| `appraisal-summary-machine.html:62` | machine summary |

`appraisal-summary-construction.html` has no เงื่อนไข row (only หมายเหตุ, bound to `model.construction_remark`) and is unaffected. The `section-*.html` detail partials in the appraisal book carry หมายเหตุ but never เงื่อนไข.

## How

All four sites tag the row `class="cond"`, and `partials/summary-styles.html` — included by every summary template (line 13) and by `appraisal-book.html:10` — carries one rule:

```css
tr.cond td { color:#C00000; }
```

The selector names `td` directly because `body` sets `color:#000`, so inheritance alone would not reach a cell.

**Scoped to เงื่อนไข.** The หมายเหตุ row sitting directly beneath it in all four tables stays black, per the written requirement (the reference image showed both red, but the spec text names เงื่อนไข alone).

### One gated case

`summary-block-body.html` renders every row unconditionally to keep the form's fixed shape, so an absent condition still emits the row and falls through to the `"-"` placeholder from `.prop-table td.v:empty::before`. The class is gated there:

```html
<tr{{ if model.condition }} class="cond"{{ end }}>
```

Ungated, every block report with no condition would print that dash **and its label** in red — reading as a defect rather than a highlight. The other three sites are already inside `{{ if model.condition }}`, so their class is unconditional.

## Verification

Rendered on a spare port against the dev DB:

- land-building, condo and machine all emit `<tr class="cond">` on เงื่อนไข and a plain `<tr>` on หมายเหตุ — this is the check that proves the rule doesn't leak to the sibling row.
- A block report with an empty condition correctly **omits** the class.
- A land-building **PDF** confirms the colour survives the Puppeteer print path: เงื่อนไข label and value both red, หมายเหตุ beneath it black.

**Not rendered with real data:** no block/PreAppraisal in the dev database has a condition populated (none even has an `AppraisalDecisions` row), so the block template's *red* state was not exercised — only its empty/black state. The gated-attribute construct itself is verified: an inline `{{ if }}` body emits its literal leading space verbatim elsewhere in these templates.

Templates only — no C#, no model, no migration, no seed script, no frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Svrb5ZmHdep1rMfa7o2DHN