### PR TITLE
fix(reporting): print construction progress, not a price, on the minute's วาระ การตรวจงวดงานก่อสร้าง

### DIFF
--- a/Modules/Reporting/Reporting/Application/Models/MeetingInvitationModel.cs
+++ b/Modules/Reporting/Reporting/Application/Models/MeetingInvitationModel.cs
@@ -72,6 +72,14 @@ public sealed class MeetingAgendaItemRow
     /// when IsPriceVerified is false/null.
     /// </summary>
     public string ValueText { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Cumulative construction progress (รวมผลการดำเนินงานปัจจุบัน), pre-formatted e.g. "16.61" —
+    /// the template adds the % sign. Set only for วาระ 5 (Progressive) rows, which carry a
+    /// construction milestone instead of an appraisal value; empty when the appraisal has no
+    /// construction-inspection data, which prints a blank cell.
+    /// </summary>
+    public string ProgressText { get; init; } = string.Empty;
 }
 
 /// <summary>One committee member row in the sign-off block.</summary>

--- a/Modules/Reporting/Reporting/Application/Providers/MeetingAgendaBuilder.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/MeetingAgendaBuilder.cs
@@ -204,6 +204,26 @@ internal static class MeetingAgendaBuilder
             };
         }
 
+        // Progressive items (วาระ 5, การตรวจงวดงานก่อสร้าง) approve a construction milestone, not a
+        // price — the minute prints รวมผลการดำเนินงานปัจจุบัน instead. ValueText stays empty so no
+        // template can fall back to a money figure; the invitation already suppresses วาระ 5 values.
+        if (IsProgressive(i))
+        {
+            var ciTotal = i.CiTotalValue ?? 0m;
+            var ciCurrent = i.CiCurrentValue ?? 0m;
+
+            return new MeetingAgendaItemRow
+            {
+                CustomerName = JoinThaiNames(i.CustomerName),
+                ValueText = string.Empty,
+                // No inspection data (or a zero 100%-value) leaves this empty → blank cell, rather
+                // than a misleading 0.00%.
+                ProgressText = ciTotal > 0m
+                    ? Math.Round(ciCurrent / ciTotal * 100m, 2).ToString("N2", CultureInfo.InvariantCulture)
+                    : string.Empty
+            };
+        }
+
         // When IsPriceVerified is explicitly false, show ไม่รับรองราคา instead of the value.
         var valueText = i.IsPriceVerified == false
             ? "ไม่รับรองราคา"
@@ -302,4 +322,17 @@ internal sealed class MeetingItemFlat
     /// Sourced from appraisal.AppraisalDecisions.IsPriceVerified.
     /// </summary>
     public bool? IsPriceVerified { get; init; }
+
+    /// <summary>
+    /// Building value at 100% complete, summed over the appraisal's construction inspections.
+    /// Null when the appraisal has none. Minute only — the invitation prints no value for วาระ 5.
+    /// </summary>
+    public decimal? CiTotalValue { get; init; }
+
+    /// <summary>
+    /// Building value as built so far, same summation. Divided by <see cref="CiTotalValue"/> this
+    /// gives รวมผลการดำเนินงานปัจจุบัน — the same value-ratio the construction summary report
+    /// prints as รวมผลการดำเนินงาน, deliberately NOT ConstructionInspection.OverallCurrentProgressPercent.
+    /// </summary>
+    public decimal? CiCurrentValue { get; init; }
 }

--- a/Modules/Reporting/Reporting/Application/Providers/MeetingMinuteDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/MeetingMinuteDataProvider.cs
@@ -77,7 +77,9 @@ public sealed class MeetingMinuteDataProvider(
                 u.FirstName + ' ' + u.LastName AS AppraisalStaff,
                 u.Position AS StaffPosition,
                 v.AppraisedValue,
-                ad.IsPriceVerified
+                ad.IsPriceVerified,
+                ciAgg.CiTotalValue,
+                ciAgg.CiCurrentValue
             FROM workflow.MeetingItems mi
             INNER JOIN appraisal.Appraisals a ON a.Id = mi.AppraisalId
             OUTER APPLY (
@@ -95,6 +97,28 @@ public sealed class MeetingMinuteDataProvider(
             LEFT JOIN appraisal.Projects pr ON pr.AppraisalId = a.Id
             LEFT JOIN appraisal.ValuationAnalyses v ON v.AppraisalId = a.Id
             LEFT JOIN appraisal.AppraisalDecisions ad ON ad.AppraisalId = a.Id
+            -- Construction-inspection values, summed over every property of the appraisal. วาระ 5
+            -- (การตรวจงวดงานก่อสร้าง) prints a progress percent instead of a value; the builder
+            -- derives it as CiCurrentValue / CiTotalValue. KEEP IN SYNC with RS01 of
+            -- AppraisalSummaryConstructionDataProvider, whose รวมผลการดำเนินงาน figure the minute
+            -- has to reconcile against ("ตามเอกสารแนบ"). OUTER APPLY over an aggregate always
+            -- yields exactly one row, so it cannot multiply agenda rows the way a join to the
+            -- one-row-per-property ConstructionInspections would.
+            OUTER APPLY (
+                SELECT
+                    SUM(ci.TotalValue) AS CiTotalValue,
+                    SUM(CASE WHEN ci.IsFullDetail = 0
+                             THEN ISNULL(ci.SummaryCurrentValue, 0)
+                             ELSE ISNULL(wd.CurrentPropertyValueSum, 0) END) AS CiCurrentValue
+                FROM appraisal.ConstructionInspections ci
+                INNER JOIN appraisal.AppraisalProperties ap ON ap.Id = ci.AppraisalPropertyId
+                OUTER APPLY (
+                    SELECT SUM(d.CurrentPropertyValue) AS CurrentPropertyValueSum
+                    FROM appraisal.ConstructionWorkDetails d
+                    WHERE d.ConstructionInspectionId = ci.Id
+                ) wd
+                WHERE ap.AppraisalId = a.Id
+            ) ciAgg
             WHERE mi.MeetingId = @MeetingId
             """;
 

--- a/Modules/Reporting/Reporting/Templates/meeting-minute.html
+++ b/Modules/Reporting/Reporting/Templates/meeting-minute.html
@@ -51,10 +51,18 @@
     .agenda-text .body-text { margin-left:1.5em; white-space:pre-wrap; }
 
     /* ── Agenda decision tables (วาระ 3–8) — monochrome bordered ─── */
-    .agenda-block { margin-bottom:14px; }
+    /* A วาระ heading must never be stranded at the foot of a page with its table overleaf, so the
+       heading + table are one unbreakable unit. "avoid" is a hint, not a guarantee: a วาระ with
+       more items than fit on a page still breaks — it just starts on a fresh page first, which
+       keeps the heading with the opening rows. <thead> repeats across the break by default. */
+    .agenda-block { margin-bottom:14px; break-inside:avoid; page-break-inside:avoid; }
     .agenda-block .wara-title { font-weight:700; margin-bottom:4px; }
     .agenda-block .count-text { font-weight:400; }
+    /* Backstop for the case above, and the only protection the text-only วาระ get — their body is
+       free text of any length, so binding the whole block would be worse than a break inside it. */
+    .agenda-block .wara-title, .agenda-text .wara-title { break-after:avoid; page-break-after:avoid; }
     table.agenda-table { width:100%; border-collapse:collapse; font-size:10.5pt; }
+    table.agenda-table tr { break-inside:avoid; page-break-inside:avoid; }
     table.agenda-table th, table.agenda-table td { border:1px solid #000; padding:4px 8px; }
     table.agenda-table th { background:#eee; text-align:center; font-weight:700; }
     table.agenda-table td.col-item { width:62%; }
@@ -62,8 +70,12 @@
     table.agenda-table .val-cell { display:flex; justify-content:space-between; gap:12px; }
 
     /* ── Sign-off 3-column table (FSD img43) ─────────────────────── */
+    /* Heading + roster are one unbreakable unit: a signature sheet split across pages, or its
+       "คณะกรรมการรับรองรายงานการประชุมครั้งที่ …" heading left behind, is not a signable document. */
+    .signoff-block { break-inside:avoid; page-break-inside:avoid; }
     .signoff-header { text-align:center; margin:18px 0 10px; }
     table.signoff-table { width:100%; border-collapse:collapse; font-size:10.5pt; }
+    table.signoff-table tr { break-inside:avoid; page-break-inside:avoid; }
     table.signoff-table th, table.signoff-table td { border:1px solid #000; padding:6px 8px; vertical-align:top; }
     table.signoff-table th { text-align:center; font-weight:700; }
     table.signoff-table td.col-sign { width:30%; }
@@ -147,6 +159,12 @@
             <td class="col-value">
               {{- if ag.wara == 6 -}}
               <div class="val-cell"><span>ราคาประเมิน</span><span>รายละเอียดดูตาม สรุปราคา</span></div>
+              {{- else if ag.wara == 5 -}}
+              <!-- การตรวจงวดงานก่อสร้าง approves a construction milestone, not a price. One
+                   continuous string (not .val-cell, which is flex space-between and would push the
+                   label and the figure to opposite edges). Empty progress_text = no inspection
+                   data → blank cell. -->
+              {{- if item.progress_text }}รวมผลการดำเนินงานปัจจุบัน = {{ item.progress_text }}%{{ end -}}
               {{- else if item.value_text -}}
               <div class="val-cell"><span>ราคาประเมิน</span><span>{{ item.value_text }}{{ if item.value_text != "ไม่รับรองราคา" }} บาท{{ end }}</span></div>
               {{- end -}}
@@ -165,7 +183,8 @@
     {{ end }}
   {{ end }}
 
-  <!-- ── Sign-off 3-column table ───────────────────────────────── -->
+  <!-- ── Sign-off 3-column table — one page-break unit with its heading ── -->
+  <div class="signoff-block">
   <div class="signoff-header">
     คณะกรรมการรับรองรายงานการประชุมครั้งที่ {{ model.meeting_no }} วันที่ {{ thai.date model.minute_date }}
   </div>
@@ -197,6 +216,7 @@
       {{ end }}
     </tbody>
   </table>
+  </div>
 
 </div>
 </body>


### PR DESCRIPTION
## Problem

On the meeting minute, the **การตรวจงวดงานก่อสร้าง** agenda (Progressive appraisals — fixed identity `Wara = 5`) printed the generic money row:

```
1. Wichian Thirakorn        ราคาประเมิน        53,000,000.00 บาท
```

That agenda approves a **construction milestone**, not a price. The sibling **meeting-invitation** template already treats วาระ 5 as value-less (`meeting-invitation.html:151`); the minute never got the same treatment, so it fell through to the default branch. This is open gap **#21** in `docs/reporting/FSD-template-fidelity-audit-2026-06-14.md:141`.

## Fix

The cell now reads `รวมผลการดำเนินงานปัจจุบัน = XX.XX%`.

**Which percent.** Two formulas coexist in the codebase and disagree. This uses the **value ratio** — `Σ CurrentValue / Σ TotalValue × 100` — because that is exactly what `AppraisalSummaryConstructionDataProvider` computes for the field it labels `รวมผลการดำเนินงาน` (RS01 + the C# derivation at `:302-312`). The minute's column header cites *ตามเอกสารแนบ*, and that attachment is the construction summary, so the two documents must agree. The alternative (`ConstructionInspection.OverallCurrentProgressPercent`) is what RCAS004 uses, but it rolls multiple properties up with `MIN` — not a "รวม".

Multi-building appraisals are therefore value-weighted, collapsing to the single property's own percent when there is only one.

**No inspection data → blank cell**, not a misleading `0.00%` and no fallback to `ราคาประเมิน`.

| File | Change |
|---|---|
| `Application/Providers/MeetingMinuteDataProvider.cs` | `OUTER APPLY … ciAgg` on `itemsSql` yielding `CiTotalValue` / `CiCurrentValue` per appraisal |
| `Application/Providers/MeetingAgendaBuilder.cs` | two fields on `MeetingItemFlat`; `IsProgressive` branch in `ToRow`, beside the existing `IsBlock` one |
| `Application/Models/MeetingInvitationModel.cs` | `MeetingAgendaItemRow.ProgressText` (pre-formatted, template adds `%`) |
| `Templates/meeting-minute.html` | `ag.wara == 5` case in the value cell |

`OUTER APPLY` over an aggregate always yields exactly one row, so it cannot multiply agenda rows the way a join to the one-row-per-property `ConstructionInspections` would. The `IsProgressive` branch leaves `ValueText` empty, so no template can fall back to a money figure.

The **invitation is unchanged** — it already prints nothing for this วาระ, and clearing `ValueText` is a no-op there.

## Also: page-break units

The minute template had no fragmentation rules at all, which surfaced while eyeballing the render:

- A วาระ heading stranded itself at the foot of a page with its table overleaf → `.agenda-block { break-inside: avoid }`.
- The sign-off heading and roster could split → wrapped in `.signoff-block { break-inside: avoid }`, mirroring `.roster-block` in `meeting-invitation.html:81`.
- Row-level `break-inside: avoid` on both tables, matching the existing roster rule.

`avoid` is a hint: an agenda with more items than fit a page still breaks — it just starts on a fresh page first, keeping the heading with the opening rows, and `<thead>` repeats. Text-only วาระ (1/2/9) get only `break-after: avoid` on the heading, since their body is free text of arbitrary length and binding the whole block would be worse than a break inside it.

## Scope

No migration, no schema change, no new view. Read-only query, fully parameterised — `@MeetingId` remains the only Dapper parameter.

## Verification

`dotnet build Modules/Reporting/Reporting/Reporting.csproj` — succeeds, 0 errors. Renders were eyeballed by the author, who confirmed both the percent (`15.00%`) and the two page-break fixes.

Worth a reviewer's eye on:
- the value-ratio choice over `OverallCurrentProgressPercent`;
- multi-property appraisals, where the two formulas visibly diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbJPZtaZiSj6gALFViAnTw