### PR TITLE
fix(reporting): sort condo areas by sequence and print ตกสำรวจ on the condo summary

### DIFF
--- a/Modules/Reporting/Reporting/Application/Formatting/GovernmentPriceTextBuilder.cs
+++ b/Modules/Reporting/Reporting/Application/Formatting/GovernmentPriceTextBuilder.cs
@@ -1,0 +1,83 @@
+namespace Reporting.Application.Formatting;
+
+/// <summary>
+/// Builds the ราคาประเมินราชการ line printed on the appraisal summary forms.
+///
+/// The rule is the same whatever the collateral is — only the noun ("โฉนดที่ดินเลขที่" for land,
+/// "ห้องชุดเลขที่" for condo) and the rate wording ("ตารางวาละ" vs "ตารางเมตรละ") differ — so both
+/// providers share this builder rather than each keeping its own copy of the partitioning rules.
+/// </summary>
+public static class GovernmentPriceTextBuilder
+{
+    /// <summary>Printed instead of a rate for collateral the appraiser flagged as ตกสำรวจ.</summary>
+    public const string MissingFromSurveyText = "ตกสำรวจ";
+
+    /// <summary>
+    /// One piece of collateral carrying a government price.
+    /// </summary>
+    /// <param name="Number">Its title / room number, used only when several segments are printed.</param>
+    /// <param name="Price">The government rate, per the unit the caller formats with.</param>
+    /// <param name="IsMissingFromSurvey">The appraiser's ตกสำรวจ flag.</param>
+    /// <param name="DisplayOrder">
+    /// Where this item sits in the printed รายการทรัพย์สิน list, so the segments below read in the
+    /// same sequence as the list above them. Items outside every group pass <see cref="int.MaxValue"/>.
+    /// </param>
+    public readonly record struct Item(
+        string? Number,
+        decimal? Price,
+        bool IsMissingFromSurvey,
+        int DisplayOrder);
+
+    /// <summary>
+    /// Groups <paramref name="items"/> by identical price and renders one line. With more than one
+    /// segment each is prefixed with its numbers ("<paramref name="numberPrefix"/> … และ …") and the
+    /// segments are joined by " , "; a lone segment applies to the whole appraisal, so naming the
+    /// collateral would be noise. Returns null when there is nothing to print.
+    /// </summary>
+    /// <param name="numberPrefix">e.g. "โฉนดที่ดินเลขที่" or "ห้องชุดเลขที่".</param>
+    /// <param name="formatPrice">e.g. p => $"ตารางวาละ {p:N2} บาท".</param>
+    public static string? Build(
+        IEnumerable<Item> items,
+        string numberPrefix,
+        Func<decimal, string> formatPrice)
+    {
+        var rows = items.ToList();
+
+        // Missing-from-survey collateral has no government valuation, so it reads "ตกสำรวจ" rather
+        // than a price. Partition on the FLAG first and never infer it from the price: the frontend
+        // only started forcing the price to 0 for flagged rows recently, so older rows carry a real
+        // non-zero price alongside the flag. The flag wins.
+        var missingFromSurvey = rows
+            .Where(r => r.IsMissingFromSurvey)
+            .OrderBy(r => r.DisplayOrder)
+            .ToList();
+        var priceGroups = rows
+            .Where(r => !r.IsMissingFromSurvey && r.Price.HasValue)
+            .GroupBy(r => r.Price!.Value)
+            .ToList();
+
+        var segments = new List<(IReadOnlyList<Item> Rows, string Value)>();
+        if (missingFromSurvey.Count > 0)
+            segments.Add((missingFromSurvey, MissingFromSurveyText));
+        segments.AddRange(priceGroups
+            .Select(g => ((IReadOnlyList<Item>)[.. g.OrderBy(r => r.DisplayOrder)], formatPrice(g.Key))));
+
+        // Follow the collateral list, not price order: a segment sits where its first item does.
+        segments = segments
+            .OrderBy(s => s.Rows.Min(r => r.DisplayOrder))
+            .ToList();
+
+        return segments.Count == 0 ? null
+            : segments.Count == 1 ? segments[0].Value
+            : string.Join(" , ", segments.Select(s => Describe(s.Rows, s.Value, numberPrefix)));
+    }
+
+    /// <summary>Prefixes a segment with its numbers. Only used when there is more than one segment.</summary>
+    private static string Describe(IEnumerable<Item> rows, string value, string numberPrefix)
+    {
+        var numbers = string.Join(" และ ", rows
+            .Where(r => !string.IsNullOrWhiteSpace(r.Number))
+            .Select(r => r.Number));
+        return string.IsNullOrWhiteSpace(numbers) ? value : $"{numberPrefix} {numbers} {value}";
+    }
+}

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryCondoDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryCondoDataProvider.cs
@@ -20,6 +20,7 @@ namespace Reporting.Application.Providers;
 ///   RS03  QC3  appraisal.PropertyGroupItems + CondoAppraisalDetails — per-group detail
 ///   RS04       parameter.Parameters — LandEntranceExit code→Thai map (สิทธิทางเข้า-ออก)
 ///   RS05       parameter.Parameters — LandUse code→Thai map (สภาพการใช้ประโยชน์)
+///   RS06  QC6  appraisal.CondoAppraisalDetails — ราคาประเมินราชการ per unit (incl. ตกสำรวจ flag)
 /// </summary>
 public sealed class AppraisalSummaryCondoDataProvider(
     ISqlConnectionFactory connectionFactory,
@@ -121,10 +122,12 @@ public sealed class AppraisalSummaryCondoDataProvider(
             JOIN appraisal.CondoAppraisalAreaDetails cada ON cada.CondoAppraisalDetailsId = cad.Id
             JOIN appraisal.AppraisalProperties ap ON ap.Id = cad.AppraisalPropertyId
             WHERE ap.AppraisalId = @AppraisalId
-            -- Order by creation sequence: CondoAppraisalAreaDetails has no Seq/CreatedOn
-            -- column, but its Id is a Guid v7 whose canonical text form sorts by creation
-            -- time (native uniqueidentifier sort does not).
-            ORDER BY cad.Id, CONVERT(char(36), cada.Id);
+            -- Sequence is the order the appraiser arranged the rows in on the property screen, so
+            -- the printed areas must follow it. Rows saved before that column existed carry NULL
+            -- and sort first — matching the screen, which reads a missing sequence as 0. The Guid
+            -- v7 Id's canonical text form breaks ties by creation time (native uniqueidentifier
+            -- sort does not).
+            ORDER BY cad.Id, cada.Sequence, CONVERT(char(36), cada.Id);
 
             -- RS03: QC3 — Per-group condo detail rows
             SELECT
@@ -171,6 +174,21 @@ public sealed class AppraisalSummaryCondoDataProvider(
             SELECT [code] AS Code, [description] AS Description
             FROM parameter.Parameters
             WHERE [group] = 'LandUse' AND [language] = 'TH' AND [isactive] = 1;
+
+            -- RS06: QC6 — ราคาประเมินราชการ per unit. RS01 is TOP 1, but the field lists every
+            -- distinct rate across the appraisal's units, so it needs them all. Missing-from-survey
+            -- units are NOT filtered out — they render as "ตกสำรวจ" instead of a rate, so the flag
+            -- has to reach C#. A surveyed unit still needs a rate to be worth showing.
+            SELECT
+                cad.RoomNumber,
+                cad.GovernmentPricePerSqm,
+                cad.IsMissingFromSurvey
+            FROM appraisal.CondoAppraisalDetails cad
+            JOIN appraisal.AppraisalProperties ap ON ap.Id = cad.AppraisalPropertyId
+            WHERE ap.AppraisalId = @AppraisalId
+              AND (cad.GovernmentPricePerSqm IS NOT NULL
+                   OR ISNULL(cad.IsMissingFromSurvey, 0) = 1)
+            ORDER BY ap.SequenceNumber, cad.Id;
             """;
 
         var p = new DynamicParameters();
@@ -181,6 +199,7 @@ public sealed class AppraisalSummaryCondoDataProvider(
         List<GroupCondoDetailRow> groupCondoRows;
         List<ParamRow> entranceExitParams;
         List<ParamRow> landUseParams;
+        List<CondoGovPriceRow> govPriceRows;
 
         using (var multi = await connection.QueryMultipleAsync(batchSql, p))
         {
@@ -198,6 +217,9 @@ public sealed class AppraisalSummaryCondoDataProvider(
 
             // RS05
             landUseParams = (await multi.ReadAsync<ParamRow>()).ToList();
+
+            // RS06
+            govPriceRows = (await multi.ReadAsync<CondoGovPriceRow>()).ToList();
         }
 
         var entranceExitMap = ToParamMap(entranceExitParams);
@@ -210,10 +232,17 @@ public sealed class AppraisalSummaryCondoDataProvider(
         string? utilization = ParameterCodeFormatter.DecodeJsonArray(
             firstCondo?.LandUseType, firstCondo?.LandUseTypeOther, landUseMap);
 
-        // ราคาประเมินราชการ — condo is priced per SQUARE METRE (not per sq-wa, unlike land).
-        string? governmentPriceText = firstCondo?.GovernmentPricePerSqm is { } gpps
-            ? $"ตารางเมตรละ {gpps:N2} บาท"
-            : null;
+        // ราคาประเมินราชการ — condo is priced per SQUARE METRE (not per sq-wa, unlike land), and a
+        // unit the appraiser ticked ตกสำรวจ reads that instead of a rate. Same builder as the
+        // land/building summary; display order is the order RS06 came back in (ap.SequenceNumber).
+        string? governmentPriceText = GovernmentPriceTextBuilder.Build(
+            govPriceRows.Select((r, i) => new GovernmentPriceTextBuilder.Item(
+                r.RoomNumber,
+                r.GovernmentPricePerSqm,
+                r.IsMissingFromSurvey == true,
+                i)),
+            "ห้องชุดเลขที่",
+            gpps => $"ตารางเมตรละ {gpps:N2} บาท");
 
         var gps = ThaiAddressFormatter.FormatGps(firstCondo?.Latitude, firstCondo?.Longitude);
 
@@ -441,6 +470,13 @@ public sealed class AppraisalSummaryCondoDataProvider(
         public Guid CondoDetailId { get; init; }
         public string? AreaDescription { get; init; }
         public decimal? AreaSize { get; init; }
+    }
+
+    private sealed class CondoGovPriceRow
+    {
+        public string? RoomNumber { get; init; }
+        public decimal? GovernmentPricePerSqm { get; init; }
+        public bool? IsMissingFromSurvey { get; init; }
     }
 
     private sealed class GroupCondoDetailRow

--- a/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryLandBuildingDataProvider.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/AppraisalSummaryLandBuildingDataProvider.cs
@@ -1260,51 +1260,19 @@ public sealed class AppraisalSummaryLandBuildingDataProvider(
 
         // ราคาประเมินราชการ — government price per sq.wa, grouped by same price. With >1 distinct
         // price, list the title numbers per price ("โฉนด… และ … ตารางวาละ X บาท") joined by " , ".
+        // Partitioning (ตกสำรวจ beats price) and segment ordering live in the shared
+        // GovernmentPriceTextBuilder, which the condo summary uses too.
         //
-        // Missing-from-survey land has no government valuation, so it reads "ตกสำรวจ" rather than a
-        // price. Partition on the FLAG first and never infer it from the price: the frontend only
-        // started forcing the price to 0 for flagged titles recently, so older rows carry a real
-        // non-zero price alongside the flag. The flag wins.
-        // Where a title sits in the printed list; titles outside every group sort last, keeping
-        // their existing relative order.
-        int TitleOrder(GovPriceRow r) =>
-            titleDisplayOrder.TryGetValue(r.TitleId, out var i) ? i : int.MaxValue;
-
-        var missingFromSurvey = govPriceRows
-            .Where(r => r.IsMissingFromSurvey == true)
-            .OrderBy(TitleOrder)
-            .ToList();
-        var govPriceGroups = govPriceRows
-            .Where(r => r.IsMissingFromSurvey != true && r.GovernmentPricePerSqWa.HasValue)
-            .GroupBy(r => r.GovernmentPricePerSqWa!.Value)
-            .ToList();
-
-        // Prefixes a segment with its title numbers. Only used when there is more than one segment —
-        // a lone segment applies to the whole appraisal, so naming the titles would be noise.
-        static string DescribeTitles(IEnumerable<GovPriceRow> rows, string value)
-        {
-            var titles = string.Join(" และ ", rows
-                .Where(r => !string.IsNullOrWhiteSpace(r.TitleNumber))
-                .Select(r => r.TitleNumber));
-            return string.IsNullOrWhiteSpace(titles) ? value : $"โฉนดที่ดินเลขที่ {titles} {value}";
-        }
-
-        const string missingFromSurveyText = "ตกสำรวจ";
-        var govPriceSegments = new List<(IReadOnlyList<GovPriceRow> Rows, string Value)>();
-        if (missingFromSurvey.Count > 0)
-            govPriceSegments.Add((missingFromSurvey, missingFromSurveyText));
-        govPriceSegments.AddRange(govPriceGroups
-            .Select(g => ((IReadOnlyList<GovPriceRow>)[.. g.OrderBy(TitleOrder)], $"ตารางวาละ {g.Key:N2} บาท")));
-
-        // Follow the land-title list, not price order: a segment sits where its first title does.
-        govPriceSegments = govPriceSegments
-            .OrderBy(s => s.Rows.Min(TitleOrder))
-            .ToList();
-
-        string? governmentPriceText =
-            govPriceSegments.Count == 0 ? null
-            : govPriceSegments.Count == 1 ? govPriceSegments[0].Value
-            : string.Join(" , ", govPriceSegments.Select(s => DescribeTitles(s.Rows, s.Value)));
+        // titleDisplayOrder places each title in the printed list; titles outside every group sort
+        // last, keeping their existing relative order.
+        string? governmentPriceText = GovernmentPriceTextBuilder.Build(
+            govPriceRows.Select(r => new GovernmentPriceTextBuilder.Item(
+                r.TitleNumber,
+                r.GovernmentPricePerSqWa,
+                r.IsMissingFromSurvey == true,
+                titleDisplayOrder.TryGetValue(r.TitleId, out var order) ? order : int.MaxValue)),
+            "โฉนดที่ดินเลขที่",
+            p => $"ตารางวาละ {p:N2} บาท");
 
         // Show the committee block only when this appraisal actually falls into a meeting.
         bool showMeeting = review?.MeetingId is not null;

--- a/Modules/Reporting/Reporting/Application/Providers/Sections/CondoSectionLoader.cs
+++ b/Modules/Reporting/Reporting/Application/Providers/Sections/CondoSectionLoader.cs
@@ -153,9 +153,12 @@ internal static class CondoSectionLoader
             JOIN appraisal.CondoAppraisalDetails cad ON cad.Id = cada.CondoAppraisalDetailsId
             JOIN appraisal.AppraisalProperties ap ON ap.Id = cad.AppraisalPropertyId
             WHERE ap.AppraisalId = @AppraisalId
-            -- Creation order: no Seq/CreatedOn column exists; the Guid v7 Id's text form
-            -- sorts by creation time (native uniqueidentifier sort does not).
-            ORDER BY cad.Id, CONVERT(char(36), cada.Id);
+            -- Sequence is the order the appraiser arranged the rows in on the property screen.
+            -- Rows saved before that column existed carry NULL and sort first, matching the screen.
+            -- The Guid v7 Id's text form breaks ties by creation time (native uniqueidentifier sort
+            -- does not). The rows below are pivoted by keyword, so this only keeps the two condo
+            -- readers consistent — it does not move anything in this section's output.
+            ORDER BY cad.Id, cada.Sequence, CONVERT(char(36), cada.Id);
 
             -- RS04: QPrice — selected pricing for the property GROUP(S) the condo belongs to.
             --   The condo appraisal price comes from its group's value, NOT the application total.


### PR DESCRIPTION
Two condo-side fields on the appraisal summary had fallen behind the screens that feed them.

## 1. Area rows ignored the sequence the appraiser set

CA-598 (#373) added `appraisal.CondoAppraisalAreaDetails.Sequence` so the appraiser can arrange the area rows on the property screen. No read path ever ordered by it — the summary still printed them in row-creation order (`CONVERT(char(36), cada.Id)`, the Guid v7 text form).

The areas are concatenated into the `รายละเอียดหลักประกัน` cell, so **SQL order is print order**. Ordering by `Sequence` is enough; rows saved before the column existed carry `NULL` and sort first, matching the screen, which reads a missing sequence as `0`.

`CondoSectionLoader` (appraisal book) gets the same `ORDER BY` for consistency — its rows are keyword-pivoted into Interior/Balcony/AirCon/Other, so the book's output does not move. The stale `-- no Seq/CreatedOn column exists` comments are removed from both.

## 2. ตกสำรวจ never reached the condo summary

CA-595 (#376) added `appraisal.CondoAppraisalDetails.IsMissingFromSurvey` and the frontend has ticked it since, but `AppraisalSummaryCondoDataProvider` never read the column. On top of that its `RS01` is `SELECT TOP 1`, so a multi-unit appraisal printed only the first unit's rate regardless.

`RS06` now pulls the rate per unit along with the flag, mirroring the land side's `RS22` including its `WHERE` (a flagged unit must reach C# rather than being filtered out in SQL).

## Shared builder instead of a second copy

The land/building summary already handled all of this. Rather than duplicate it, the logic moves to `Application/Formatting/GovernmentPriceTextBuilder.cs` and **both** summaries call it — they differ only in the noun (`โฉนดที่ดินเลขที่` / `ห้องชุดเลขที่`) and the rate wording (`ตารางวาละ` / `ตารางเมตรละ`).

One copy matters because of the rule living inside it: **partition on the flag first and never infer it from the price** — the frontend only started forcing the price to 0 for flagged rows recently, so older rows carry a real non-zero price alongside the flag, and the flag wins.

## Verification — by rendering, not by reading

Rendered on a second API instance (port 7112) so the running dev instance on 7111 was untouched. HTML compared after normalizing whitespace and stripping comments.

**No regression on the land/building summary** — the refactor's only risk:

| appraisal | contains ตกสำรวจ | result |
|---|---|---|
| `019C6758…` (5 titles, 4 distinct prices, 2 flagged) | yes | identical |
| `019E9824-9228…` (3 titles, 2 prices, 1 flagged) | yes | identical |
| `019E00B7…` | yes | identical |
| `019C813E…` | no | identical |

Two appraisal books rendered before/after: identical.

**Condo summary** — 5 units staged as 101/102 = 50,000 · 103 ตกสำรวจ · 104/105 = 60,000:

```
before:  ตารางเมตรละ 50,000.00 บาท
after :  ห้องชุดเลขที่ 101 และ 102 ตารางเมตรละ 50,000.00 บาท ,
         ห้องชุดเลขที่ 103 ตกสำรวจ ,
         ห้องชุดเลขที่ 104 และ 105 ตารางเมตรละ 60,000.00 บาท
```

Segments sit where their **first unit** sits, not in price order, so ตกสำรวจ lands in the middle. A single-unit condo still prints the bare `ตารางเมตรละ 200,000.00 บาท` with no prefix.

**Area order** — with `Sequence` set to ระเบียง=1, ภายในห้องชุด=2:

```
before:  พื้นที่ภายในห้องชุด 33 ตารางเมตร  พื้นที่ระเบียง 2 ตารางเมตร  รวมพื้นที่ 35 ตารางเมตร
after :  พื้นที่ระเบียง 2 ตารางเมตร  พื้นที่ภายในห้องชุด 33 ตารางเมตร  รวมพื้นที่ 35 ตารางเมตร
```

Test data was staged on dormant appraisals and **restored to its original values** afterwards; the 7112 instance was stopped. `dotnet build` clean, 0 errors 0 warnings.

## Not included

- No migration, no seed script, no frontend change — both columns already exist and the frontend already writes them.
- `GetDecisionSummaryQueryHandler` still averages the condo government price **including** missing-from-survey units (the land side excludes them), and `CondoGovernmentPriceTable.tsx` likewise. Those are Decision Summary screen bugs, out of scope here.
- Rendering ตกสำรวจ inside the appraisal book's `section-condo.html` was deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Grn5tNj4RRyzBS19bmdjXF
